### PR TITLE
fix tree rendering without CDN

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,8 +70,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const network = new vis.Network(container, data, options);
 
-    // 1a. Fit the network to the view
-    network.fit();
+    // Fit once after initial draw so the layout sizes correctly
+    network.once('afterDrawing', () => {
+        network.fit();
+    });
 
     // Refit on window resize
     window.addEventListener('resize', () => {

--- a/style.css
+++ b/style.css
@@ -30,6 +30,7 @@ main {
     position: relative; /* For positioning nodes absolutely if doing manually */
 /* min-height: 0 allows the container to shrink correctly if its own content tries to overflow. */
     min-height: 0;
+    height: 80vh; /* Ensure the canvas has some initial height */
 }
 
 #tech-info-panel {


### PR DESCRIPTION
## Summary
- restore Vis.js-based rendering
- fit network after initial draw
- ensure the tree container has some height

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_684144ca3ce88327bdc66ee9ee384dac