### PR TITLE
Add shared server persistence for tech tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,7 @@
             <button id="update-tech-btn" style="display:none">Update Technology</button>
         </div>
     </main>
-    <script src="tech-data.js"></script> <!-- Your tech data -->
-    <script src="app.js"></script>   <!-- Your application logic -->
+    <script src="app.js"></script>   <!-- Application logic -->
 </body>
 </html>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "techtree",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,78 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const DATA_FILE = path.join(__dirname, 'tech-tree.json');
+
+function loadData() {
+    if (fs.existsSync(DATA_FILE)) {
+        return JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+    }
+    let initial = [];
+    try {
+        initial = require('./tech-data.js');
+    } catch (e) {
+        console.error('Failed to load initial tech data:', e);
+    }
+    fs.writeFileSync(DATA_FILE, JSON.stringify(initial, null, 2));
+    return initial;
+}
+
+let techData = loadData();
+
+function saveData() {
+    fs.writeFileSync(DATA_FILE, JSON.stringify(techData, null, 2));
+}
+
+function serveStatic(req, res) {
+    const filePath = path.join(__dirname, req.url === '/' ? 'index.html' : req.url);
+    fs.readFile(filePath, (err, content) => {
+        if (err) {
+            res.statusCode = 404;
+            res.end('Not found');
+            return;
+        }
+        const ext = path.extname(filePath);
+        const mime = {
+            '.html': 'text/html',
+            '.js': 'application/javascript',
+            '.css': 'text/css',
+            '.json': 'application/json'
+        }[ext] || 'text/plain';
+        res.setHeader('Content-Type', mime);
+        res.end(content);
+    });
+}
+
+const server = http.createServer((req, res) => {
+    if (req.url === '/api/tech-tree') {
+        if (req.method === 'GET') {
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify(techData));
+            return;
+        } else if (req.method === 'PUT') {
+            let body = '';
+            req.on('data', chunk => body += chunk);
+            req.on('end', () => {
+                try {
+                    const data = JSON.parse(body);
+                    if (!Array.isArray(data)) throw new Error('Invalid data');
+                    techData = data;
+                    saveData();
+                    res.end('ok');
+                } catch (e) {
+                    res.statusCode = 400;
+                    res.end('Invalid JSON');
+                }
+            });
+            return;
+        }
+    }
+
+    serveStatic(req, res);
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+    console.log(`Server running at http://localhost:${PORT}`);
+});

--- a/tech-data.js
+++ b/tech-data.js
@@ -273,3 +273,5 @@ const techTreeData = [
         prerequisites: ["flight", "nuclear_power", "computers", "nanotechnology"]
     }
 ];
+
+if (typeof module !== "undefined") { module.exports = techTreeData; }

--- a/tech-tree.json
+++ b/tech-tree.json
@@ -1,0 +1,377 @@
+[
+  {
+    "id": "fire_control",
+    "name": "Fire Control",
+    "era": "Ancient",
+    "description": "Mastery of fire for warmth, cooking, and protection.",
+    "prerequisites": []
+  },
+  {
+    "id": "basic_tools",
+    "name": "Basic Tools",
+    "era": "Ancient",
+    "description": "Rudimentary tools made from stone, wood, and bone.",
+    "prerequisites": [
+      "fire_control"
+    ]
+  },
+  {
+    "id": "hunting_gathering",
+    "name": "Hunting & Gathering",
+    "era": "Ancient",
+    "description": "Societies primarily sustained by foraging and hunting.",
+    "prerequisites": [
+      "basic_tools"
+    ]
+  },
+  {
+    "id": "agriculture",
+    "name": "Agriculture",
+    "era": "Ancient",
+    "description": "The cultivation of crops and domestication of animals, leading to settled societies.",
+    "prerequisites": [
+      "hunting_gathering"
+    ]
+  },
+  {
+    "id": "pottery",
+    "name": "Pottery",
+    "era": "Ancient",
+    "description": "Crafting vessels from clay for storage and cooking.",
+    "prerequisites": [
+      "fire_control",
+      "agriculture"
+    ]
+  },
+  {
+    "id": "writing",
+    "name": "Writing",
+    "era": "Ancient",
+    "description": "Development of systems to record language and information.",
+    "prerequisites": [
+      "agriculture"
+    ]
+  },
+  {
+    "id": "animal_husbandry",
+    "name": "Animal Husbandry",
+    "era": "Ancient",
+    "description": "Systematic breeding and raising of livestock.",
+    "prerequisites": [
+      "agriculture"
+    ]
+  },
+  {
+    "id": "mining",
+    "name": "Mining",
+    "era": "Ancient",
+    "description": "Extraction of valuable minerals and other geological materials from the Earth.",
+    "prerequisites": [
+      "basic_tools"
+    ]
+  },
+  {
+    "id": "bronze_working",
+    "name": "Bronze Working",
+    "era": "Classical",
+    "description": "Alloying copper and tin to create bronze for tools and weapons.",
+    "prerequisites": [
+      "mining",
+      "pottery"
+    ]
+  },
+  {
+    "id": "iron_working",
+    "name": "Iron Working",
+    "era": "Classical",
+    "description": "Smelting iron ore to produce iron and steel, stronger than bronze.",
+    "prerequisites": [
+      "bronze_working"
+    ]
+  },
+  {
+    "id": "philosophy",
+    "name": "Philosophy",
+    "era": "Classical",
+    "description": "Systematic study of general and fundamental questions.",
+    "prerequisites": [
+      "writing"
+    ]
+  },
+  {
+    "id": "mathematics",
+    "name": "Mathematics",
+    "era": "Classical",
+    "description": "The study of numbers, quantity, space, structure, and change.",
+    "prerequisites": [
+      "writing",
+      "agriculture"
+    ]
+  },
+  {
+    "id": "construction",
+    "name": "Construction",
+    "era": "Classical",
+    "description": "Advanced building techniques for temples, roads, and aqueducts.",
+    "prerequisites": [
+      "mathematics",
+      "iron_working"
+    ]
+  },
+  {
+    "id": "currency",
+    "name": "Currency",
+    "era": "Classical",
+    "description": "Standardized medium of exchange.",
+    "prerequisites": [
+      "writing",
+      "mining"
+    ]
+  },
+  {
+    "id": "feudalism",
+    "name": "Feudalism",
+    "era": "Medieval",
+    "description": "Social, economic, and political system based on land tenure and loyalty.",
+    "prerequisites": [
+      "iron_working",
+      "animal_husbandry"
+    ]
+  },
+  {
+    "id": "engineering",
+    "name": "Engineering",
+    "era": "Medieval",
+    "description": "Practical application of scientific and mathematical principles for design and construction (e.g., castles, cathedrals).",
+    "prerequisites": [
+      "construction",
+      "mathematics"
+    ]
+  },
+  {
+    "id": "universities",
+    "name": "Universities",
+    "era": "Medieval",
+    "description": "Institutions of higher learning.",
+    "prerequisites": [
+      "philosophy",
+      "writing"
+    ]
+  },
+  {
+    "id": "gunpowder",
+    "name": "Gunpowder",
+    "era": "Medieval",
+    "description": "Explosive mixture used in early firearms and cannons.",
+    "prerequisites": [
+      "mining",
+      "alchemy"
+    ]
+  },
+  {
+    "id": "alchemy",
+    "name": "Alchemy",
+    "era": "Medieval",
+    "description": "Early form of investigation of nature and philosophical and spiritual discipline.",
+    "prerequisites": [
+      "philosophy",
+      "mining"
+    ]
+  },
+  {
+    "id": "printing_press",
+    "name": "Printing Press",
+    "era": "Renaissance",
+    "description": "Mechanical device for applying pressure to an inked surface, transferring ink to paper.",
+    "prerequisites": [
+      "writing",
+      "iron_working",
+      "universities"
+    ]
+  },
+  {
+    "id": "scientific_method",
+    "name": "Scientific Method",
+    "era": "Renaissance",
+    "description": "Systematic observation, measurement, experiment, and the formulation, testing, and modification of hypotheses.",
+    "prerequisites": [
+      "philosophy",
+      "mathematics",
+      "universities"
+    ]
+  },
+  {
+    "id": "banking",
+    "name": "Banking",
+    "era": "Renaissance",
+    "description": "Sophisticated financial institutions and practices.",
+    "prerequisites": [
+      "currency",
+      "mathematics",
+      "writing"
+    ]
+  },
+  {
+    "id": "astronomy",
+    "name": "Astronomy",
+    "era": "Renaissance",
+    "description": "Study of celestial objects and phenomena, revolutionized by new tools and methods.",
+    "prerequisites": [
+      "mathematics",
+      "scientific_method",
+      "philosophy"
+    ]
+  },
+  {
+    "id": "steam_engine",
+    "name": "Steam Engine",
+    "era": "Industrial",
+    "description": "Heat engine that performs mechanical work using steam as its working fluid.",
+    "prerequisites": [
+      "iron_working",
+      "scientific_method",
+      "mining"
+    ]
+  },
+  {
+    "id": "electricity",
+    "name": "Electricity",
+    "era": "Industrial",
+    "description": "Understanding and harnessing electrical phenomena.",
+    "prerequisites": [
+      "scientific_method",
+      "steam_engine"
+    ]
+  },
+  {
+    "id": "mass_production",
+    "name": "Mass Production",
+    "era": "Industrial",
+    "description": "Manufacture of large quantities of standardized products, often using assembly lines.",
+    "prerequisites": [
+      "steam_engine",
+      "iron_working",
+      "banking"
+    ]
+  },
+  {
+    "id": "railroads",
+    "name": "Railroads",
+    "era": "Industrial",
+    "description": "Mode of transport using trains running on tracks.",
+    "prerequisites": [
+      "steam_engine",
+      "mass_production",
+      "engineering"
+    ]
+  },
+  {
+    "id": "internal_combustion_engine",
+    "name": "Internal Combustion Engine",
+    "era": "Modern",
+    "description": "Engine that generates motive power by burning fuel within the engine itself.",
+    "prerequisites": [
+      "steam_engine",
+      "scientific_method",
+      "mass_production"
+    ]
+  },
+  {
+    "id": "flight",
+    "name": "Flight",
+    "era": "Modern",
+    "description": "Achieving sustained travel through the air.",
+    "prerequisites": [
+      "internal_combustion_engine",
+      "scientific_method",
+      "engineering"
+    ]
+  },
+  {
+    "id": "computers",
+    "name": "Computers",
+    "era": "Modern",
+    "description": "Electronic devices for storing and processing data.",
+    "prerequisites": [
+      "electricity",
+      "mathematics",
+      "scientific_method"
+    ]
+  },
+  {
+    "id": "nuclear_power",
+    "name": "Nuclear Power",
+    "era": "Modern",
+    "description": "Using nuclear reactions to produce electricity.",
+    "prerequisites": [
+      "electricity",
+      "scientific_method",
+      "astronomy"
+    ]
+  },
+  {
+    "id": "internet",
+    "name": "Internet",
+    "era": "Modern",
+    "description": "Global system of interconnected computer networks.",
+    "prerequisites": [
+      "computers",
+      "electricity",
+      "telecommunications"
+    ]
+  },
+  {
+    "id": "telecommunications",
+    "name": "Telecommunications",
+    "era": "Modern",
+    "description": "Transmission of information over significant distances by electronic means.",
+    "prerequisites": [
+      "electricity",
+      "scientific_method"
+    ]
+  },
+  {
+    "id": "artificial_general_intelligence",
+    "name": "Artificial General Intelligence",
+    "era": "Future",
+    "description": "AI with human-like cognitive abilities.",
+    "prerequisites": [
+      "computers",
+      "internet",
+      "scientific_method"
+    ]
+  },
+  {
+    "id": "nanotechnology",
+    "name": "Nanotechnology",
+    "era": "Future",
+    "description": "Engineering of functional systems at the molecular scale.",
+    "prerequisites": [
+      "computers",
+      "scientific_method",
+      "chemistry_advanced"
+    ]
+  },
+  {
+    "id": "chemistry_advanced",
+    "name": "Advanced Chemistry",
+    "era": "Modern",
+    "description": "Deep understanding of molecular interactions and material science.",
+    "prerequisites": [
+      "scientific_method",
+      "alchemy"
+    ]
+  },
+  {
+    "id": "space_colonization",
+    "name": "Space Colonization",
+    "era": "Future",
+    "description": "Permanent human settlement off Earth.",
+    "prerequisites": [
+      "flight",
+      "nuclear_power",
+      "computers",
+      "nanotechnology"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add a simple Node.js server to store the tech tree in `tech-tree.json`
- fetch tech tree from the server and save updates via API
- export tech data for Node usage
- remove unused tech-data script from HTML
- add package.json and startup script

## Testing
- `node server.js` *(fails:  Server could not run due to environment restrictions)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418a8a081c8327b76fd71bc37388d0