### PR TITLE
Improve tech tree visualization

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,6 +36,16 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 
+    const eraColors = {
+        Ancient: '#e67e22',
+        Classical: '#3498db',
+        Medieval: '#2ecc71',
+        Renaissance: '#9b59b6',
+        Industrial: '#f1c40f',
+        Modern: '#e74c3c',
+        Future: '#95a5a6'
+    };
+
     // 1. Transform dynamicData into Vis.js nodes and edges
     const nodes = new vis.DataSet(
         dynamicData.map(tech => ({
@@ -45,7 +55,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             era: tech.era, // Store custom data
             description: tech.description,
             value: (dependentsCount[tech.id] || 0) + 1, // Larger for more important techs
-            color: (!tech.prerequisites || tech.prerequisites.length === 0) ? '#f0ad4e' : undefined
+            color: eraColors[tech.era] || '#cccccc'
         }))
     );
 
@@ -105,7 +115,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         layout: {
             improvedLayout: false
         },
-        physics: false,
+        physics: {
+            enabled: true,
+            barnesHut: { springLength: 120 }
+        },
         interaction: {
             dragNodes: true,
             dragView: true,

--- a/tech-data.js
+++ b/tech-data.js
@@ -57,6 +57,13 @@ const techTreeData = [
         description: "Extraction of valuable minerals and other geological materials from the Earth.",
         prerequisites: ["basic_tools"]
     },
+    {
+        id: "sailing",
+        name: "Sailing",
+        era: "Ancient",
+        description: "Use of wind-powered vessels for navigation across water.",
+        prerequisites: ["basic_tools"]
+    },
 
     // --- CLASSICAL ERA ---
     {
@@ -101,6 +108,13 @@ const techTreeData = [
         description: "Standardized medium of exchange.",
         prerequisites: ["writing", "mining"]
     },
+    {
+        id: "navigation",
+        name: "Navigation",
+        era: "Classical",
+        description: "Techniques for determining position and course during travel.",
+        prerequisites: ["sailing", "mathematics"]
+    },
 
     // --- MEDIEVAL ERA ---
     {
@@ -137,6 +151,13 @@ const techTreeData = [
         era: "Medieval",
         description: "Early form of investigation of nature and philosophical and spiritual discipline.",
         prerequisites: ["philosophy", "mining"]
+    },
+    {
+        id: "medicine",
+        name: "Medicine",
+        era: "Medieval",
+        description: "Study and practice of diagnosing and treating illness.",
+        prerequisites: ["universities"]
     },
 
     // --- RENAISSANCE ERA ---
@@ -242,6 +263,13 @@ const techTreeData = [
         description: "Transmission of information over significant distances by electronic means.",
         prerequisites: ["electricity", "scientific_method"]
     },
+    {
+        id: "radio",
+        name: "Radio",
+        era: "Modern",
+        description: "Wireless transmission of signals using electromagnetic waves.",
+        prerequisites: ["electricity", "telecommunications"]
+    },
 
     // --- FUTURE ERA (Speculative) ---
     {
@@ -264,6 +292,13 @@ const techTreeData = [
         era: "Modern", // Could be late modern, leading to future
         description: "Deep understanding of molecular interactions and material science.",
         prerequisites: ["scientific_method", "alchemy"] // Evolution from early chemistry
+    },
+    {
+        id: "genetic_engineering",
+        name: "Genetic Engineering",
+        era: "Future",
+        description: "Direct manipulation of genetic material to modify organisms.",
+        prerequisites: ["nanotechnology", "chemistry_advanced", "scientific_method"]
     },
     {
         id: "space_colonization",

--- a/tech-tree.json
+++ b/tech-tree.json
@@ -71,6 +71,15 @@
     ]
   },
   {
+    "id": "sailing",
+    "name": "Sailing",
+    "era": "Ancient",
+    "description": "Use of wind-powered vessels for navigation across water.",
+    "prerequisites": [
+      "basic_tools"
+    ]
+  },
+  {
     "id": "bronze_working",
     "name": "Bronze Working",
     "era": "Classical",
@@ -129,6 +138,16 @@
     ]
   },
   {
+    "id": "navigation",
+    "name": "Navigation",
+    "era": "Classical",
+    "description": "Techniques for determining position and course during travel.",
+    "prerequisites": [
+      "sailing",
+      "mathematics"
+    ]
+  },
+  {
     "id": "feudalism",
     "name": "Feudalism",
     "era": "Medieval",
@@ -176,6 +195,15 @@
     "prerequisites": [
       "philosophy",
       "mining"
+    ]
+  },
+  {
+    "id": "medicine",
+    "name": "Medicine",
+    "era": "Medieval",
+    "description": "Study and practice of diagnosing and treating illness.",
+    "prerequisites": [
+      "universities"
     ]
   },
   {
@@ -331,6 +359,16 @@
     ]
   },
   {
+    "id": "radio",
+    "name": "Radio",
+    "era": "Modern",
+    "description": "Wireless transmission of signals using electromagnetic waves.",
+    "prerequisites": [
+      "electricity",
+      "telecommunications"
+    ]
+  },
+  {
     "id": "artificial_general_intelligence",
     "name": "Artificial General Intelligence",
     "era": "Future",
@@ -360,6 +398,17 @@
     "prerequisites": [
       "scientific_method",
       "alchemy"
+    ]
+  },
+  {
+    "id": "genetic_engineering",
+    "name": "Genetic Engineering",
+    "era": "Future",
+    "description": "Direct manipulation of genetic material to modify organisms.",
+    "prerequisites": [
+      "nanotechnology",
+      "chemistry_advanced",
+      "scientific_method"
     ]
   },
   {


### PR DESCRIPTION
## Summary
- enable physics in the network options
- colour nodes by era for easier reading
- expand default dataset with sailing, navigation, medicine, radio and genetic engineering

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68419c5ab0688327a88e0ad49894ce7c