### PR TITLE
Fix layout loop and dataset cycle

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,13 +84,21 @@ document.addEventListener('DOMContentLoaded', async () => {
         dynamicData.forEach(t => {
             if (t.prerequisites && t.prerequisites.includes(current)) {
                 const nextLevel = currentLevel + 1;
-                if (levelMap[t.id] === undefined || levelMap[t.id] < nextLevel) {
+                if (levelMap[t.id] === undefined || nextLevel < levelMap[t.id]) {
                     levelMap[t.id] = nextLevel;
                     queue.push(t.id);
                 }
             }
         });
     }
+
+    // Any nodes involved in cycles may not have been assigned a level.
+    // Default them to 0 so the layout still renders.
+    dynamicData.forEach(t => {
+        if (levelMap[t.id] === undefined) {
+            levelMap[t.id] = 0;
+        }
+    });
 
     const ERA_OFFSETS = {
         Ancient: 0,

--- a/tech-tree.json
+++ b/tech-tree.json
@@ -108,7 +108,6 @@
     "prerequisites": [
       "basic_tools",
       "trapping",
-      "fishing_nets_hooks",
       "oral_tradition_storytelling"
     ]
   },


### PR DESCRIPTION
## Summary
- avoid infinite loops in tech tree layout
- default level to 0 for nodes in cycles
- fix data cycle by removing `fishing_nets_hooks` from `hunting_gathering` prerequisites

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841b51ea2d8832782380c9fc9418969