### PR TITLE
Remove clustering by era

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,3 @@ When first launched, the server populates `tech-tree.json` with the contents of 
 
 Edit `app.js`, `style.css`, and `index.html` to adjust the interface. The server itself is implemented in `server.js`. Restart the server after making changes to server-side code.
 
-### Large graphs
-
-When the tech tree grows beyond a hundred nodes the browser may struggle to render every node individually. The application now automatically clusters technologies by era once this threshold is reached and disables physics after the initial stabilisation. Double‑click a cluster to expand it and reveal the underlying technologies.
-

--- a/app.js
+++ b/app.js
@@ -192,30 +192,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const network = new vis.Network(container, data, options);
 
-    // Cluster nodes by era when dataset is large for better performance
-    function clusterByEra() {
-        const eras = [...new Set(dynamicData.map(t => t.era))];
-        eras.forEach(era => {
-            network.cluster({
-                joinCondition: nodeOptions => nodeOptions.era === era,
-                clusterNodeProperties: { id: `cluster_${era}`, label: `${era} Era` }
-            });
-        });
-    }
-
-    if (nodes.length > 100) {
-        clusterByEra();
-    }
 
     // Fit once after initial draw so the layout sizes correctly
     network.once('afterDrawing', () => {
         network.fit();
     });
 
-    // Disable physics after stabilization for large graphs
-    network.once('stabilized', () => {
-        network.setOptions({ physics: { enabled: false } });
-    });
 
     // Refit on window resize
     window.addEventListener('resize', () => {
@@ -248,11 +230,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 
-    network.on('doubleClick', params => {
-        if (params.nodes.length === 1 && network.isCluster(params.nodes[0])) {
-            network.openCluster(params.nodes[0]);
-        }
-    });
 
     async function saveData() {
         try {


### PR DESCRIPTION
## Summary
- remove clustering logic from app.js
- remove README notes on large graphs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841b6818d6083279fd35da1d767e277