### PR TITLE
Fix endless jiggling in network layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -198,6 +198,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const network = new vis.Network(container, data, options);
 
+    // Disable physics once the network stabilizes to prevent endless jiggle
+    network.once('stabilizationIterationsDone', function () {
+        network.setOptions({ physics: false });
+    });
+
 
     // Fit once after initial draw so the layout sizes correctly
     network.once('afterDrawing', () => {


### PR DESCRIPTION
## Summary
- stop Vis.js physics once the graph stabilizes to prevent endless jiggling

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841b9f0aa048327973cbbb80c192c91