### PR TITLE
Add Wi-Fi and Bluetooth tech

### DIFF
--- a/data/modern.json
+++ b/data/modern.json
@@ -1419,6 +1419,28 @@
     ]
   },
   {
+    "id": "wifi_wireless_networking",
+    "name": "Wi-Fi Wireless Networking",
+    "era": "Modern",
+    "description": "Short-range wireless technology enabling devices to connect to local networks and the Internet without cables.",
+    "prerequisites": [
+      "computer_networking",
+      "radio",
+      "integrated_circuits"
+    ]
+  },
+  {
+    "id": "bluetooth_short_range",
+    "name": "Bluetooth",
+    "era": "Modern",
+    "description": "Standard for short-range wireless data exchange between devices, often used for peripherals and accessories.",
+    "prerequisites": [
+      "integrated_circuits",
+      "radio",
+      "digital_signal_processing"
+    ]
+  },
+  {
     "id": "internet_of_things_iot_ubiquitous_connectivity",
     "name": "Internet of Things (IoT) & Ubiquitous Connectivity",
     "era": "Modern",

--- a/tech-data.js
+++ b/tech-data.js
@@ -503,6 +503,20 @@ const techTreeData = [
         prerequisites: ["telecommunications", "computers"]
     },
     {
+        id: "wifi",
+        name: "Wi-Fi",
+        era: "Modern",
+        description: "Wireless local area networking technology for connecting devices to the Internet.",
+        prerequisites: ["computer_networking", "radio", "integrated_circuits"]
+    },
+    {
+        id: "bluetooth",
+        name: "Bluetooth",
+        era: "Modern",
+        description: "Short-range wireless communication standard for exchanging data between devices.",
+        prerequisites: ["integrated_circuits", "radio", "digital_signal_processing"]
+    },
+    {
         id: "robotics",
         name: "Robotics",
         era: "Modern",


### PR DESCRIPTION
## Summary
- add Wi-Fi and Bluetooth entries to tech-data.js
- insert matching Wi-Fi and Bluetooth entries in Modern era dataset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843100593e083278cca83346117f925