### PR TITLE
Add dropdown to filter technologies by era

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ PORT=8080 npm start
 
 Once running, open `http://localhost:3000` in your browser to view and modify the tech tree.
 
-The info panel includes a search box to quickly highlight technologies by name or ID. A color legend explains the era assigned to each technology.
+The info panel includes a search box to quickly highlight technologies by name or ID. A color legend explains the era assigned to each technology. You can also filter the tree by era using the dropdown next to the search box.
 
 ### Data persistence
 

--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const updateBtn = document.getElementById('update-tech-btn');
     const addBtn = document.getElementById('add-tech-btn');
     const searchInput = document.getElementById('search-tech');
+    const eraFilter = document.getElementById('era-filter');
 
     let dynamicData = [];
     try {
@@ -65,7 +66,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
+    function populateEraFilter() {
+        if (!eraFilter) return;
+        eraFilter.innerHTML = '<option value="all">All Eras</option>';
+        for (const era of Object.keys(eraColors)) {
+            const opt = document.createElement('option');
+            opt.value = era;
+            opt.textContent = era;
+            eraFilter.appendChild(opt);
+        }
+    }
+
     renderLegend();
+    populateEraFilter();
 
     // Compute radial layout levels using an adjacency list for efficiency
     const levelMap = {};
@@ -316,6 +329,27 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
+    function applyEraFilter(era) {
+        const visible = new Set();
+        if (!era || era === 'all') {
+            nodes.forEach(n => {
+                nodes.update({ id: n.id, hidden: false });
+                visible.add(n.id);
+            });
+        } else {
+            nodes.forEach(n => {
+                const isVisible = n.era === era;
+                nodes.update({ id: n.id, hidden: !isVisible });
+                if (isVisible) visible.add(n.id);
+            });
+        }
+        edges.forEach(e => {
+            const isVisible = visible.has(e.from) && visible.has(e.to);
+            edges.update({ id: e.id, hidden: !isVisible });
+        });
+        network.fit({ animation: true });
+    }
+
 
     let selectedNodeId = null;
     network.on("selectNode", function (params) {
@@ -355,6 +389,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     if (searchInput) {
         searchInput.addEventListener('input', () => applySearch(searchInput.value));
+    }
+
+    if (eraFilter) {
+        eraFilter.addEventListener('change', () => applyEraFilter(eraFilter.value));
     }
 
 

--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
             <div id="tech-info-panel">
                 <h2>Select a Technology</h2>
                 <input type="text" id="search-tech" placeholder="Search by name or ID">
+                <select id="era-filter">
+                    <option value="all">All Eras</option>
+                </select>
                 <p id="tech-name"></p>
                 <p id="tech-era"></p>
                 <p id="tech-description"></p>

--- a/style.css
+++ b/style.css
@@ -66,6 +66,14 @@ main {
     border-radius: 4px;
 }
 
+#era-filter {
+    width: 100%;
+    margin-bottom: 10px;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
 #tech-add-panel {
     border: 1px solid #ddd;
     border-radius: 8px;


### PR DESCRIPTION
## Summary
- add era filter dropdown in the info panel
- style the dropdown
- populate era options dynamically and filter nodes/edges
- document era filter usage in README

## Testing
- `npm test` *(fails: no test specified)*
- `npm start` and `curl http://localhost:3000/api/tech-tree`

------
https://chatgpt.com/codex/tasks/task_e_6852df8fbef08327adcdada1656adca2