### PR TITLE
Add sorted technology list view

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
 <body>
     <header>
         <h1>World Tech Tree (MVP)</h1>
+        <nav>
+            <a href="sorted.html">Sorted View</a>
+        </nav>
     </header>
     <main>
         <div id="tech-tree-container">

--- a/sorted.html
+++ b/sorted.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sorted Technologies</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Sorted Technologies</h1>
+        <nav>
+            <a href="index.html">Graph View</a>
+        </nav>
+    </header>
+    <main>
+        <div id="sorted-tech-container">
+            <table id="tech-table">
+                <thead>
+                    <tr><th>#</th><th>Name</th><th>Era</th><th>Prerequisites</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </main>
+    <script src="sorted.js"></script>
+</body>
+</html>

--- a/sorted.js
+++ b/sorted.js
@@ -1,0 +1,73 @@
+document.addEventListener('DOMContentLoaded', async () => {
+    let data = [];
+    try {
+        const resp = await fetch('/api/tech-tree');
+        if (resp.ok) {
+            data = await resp.json();
+        } else {
+            throw new Error('Failed to load tech tree');
+        }
+    } catch (err) {
+        console.error('Error loading tech tree:', err);
+        return;
+    }
+
+    // Build adjacency and compute levels for topological order
+    const dependentsMap = {};
+    const levelMap = {};
+    data.forEach(t => {
+        (t.prerequisites || []).forEach(pr => {
+            if (!dependentsMap[pr]) dependentsMap[pr] = [];
+            dependentsMap[pr].push(t.id);
+        });
+    });
+    const queue = [];
+    data.forEach(t => {
+        if (!t.prerequisites || t.prerequisites.length === 0) {
+            levelMap[t.id] = 0;
+            queue.push(t.id);
+        }
+    });
+    while (queue.length) {
+        const current = queue.shift();
+        const currentLevel = levelMap[current];
+        (dependentsMap[current] || []).forEach(dep => {
+            const nextLevel = currentLevel + 1;
+            if (levelMap[dep] === undefined || nextLevel < levelMap[dep]) {
+                levelMap[dep] = nextLevel;
+                queue.push(dep);
+            }
+        });
+    }
+    data.forEach(t => {
+        if (levelMap[t.id] === undefined) levelMap[t.id] = 0;
+        t.level = levelMap[t.id];
+    });
+
+    const eraOrder = {
+        Ancient: 0,
+        Classical: 1,
+        Medieval: 2,
+        Renaissance: 3,
+        Industrial: 4,
+        Modern: 5,
+        Future: 6
+    };
+
+    data.sort((a, b) => {
+        const eraDiff = (eraOrder[a.era] ?? 99) - (eraOrder[b.era] ?? 99);
+        if (eraDiff !== 0) return eraDiff;
+        const levelDiff = a.level - b.level;
+        if (levelDiff !== 0) return levelDiff;
+        return a.name.localeCompare(b.name);
+    });
+
+    const tbody = document.querySelector('#tech-table tbody');
+    data.forEach((t, idx) => {
+        const tr = document.createElement('tr');
+        const prereqText = (t.prerequisites || []).join(', ');
+        tr.innerHTML = `<td>${idx + 1}</td><td>${t.name}</td><td>${t.era || ''}</td><td>${prereqText}</td>`;
+        tbody.appendChild(tr);
+    });
+});
+

--- a/style.css
+++ b/style.css
@@ -17,6 +17,20 @@ header {
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
+header nav {
+    margin-top: 10px;
+}
+
+header nav a {
+    color: #fff;
+    margin: 0 10px;
+    text-decoration: none;
+}
+
+header nav a:hover {
+    text-decoration: underline;
+}
+
 main {
     display: flex;
     flex-grow: 1;
@@ -42,6 +56,32 @@ main {
 /* min-height: 0 allows the container to shrink correctly if its own content tries to overflow. */
     min-height: 0;
     height: 80vh; /* Ensure the canvas has some initial height */
+}
+
+#sorted-tech-container {
+    flex: 1;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    background-color: #fff;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+    overflow: auto;
+    padding: 15px;
+}
+
+#tech-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#tech-table th, #tech-table td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+#tech-table th {
+    background-color: #2c3e50;
+    color: #fff;
 }
 
 #tech-info-panel {


### PR DESCRIPTION
## Summary
- Link to a new sorted view from the main header
- Add list-based page showing technologies ordered by era and dependency
- Provide basic styling for navigation and table layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1aabf29c8327b56a6dd91519ecc7