### PR TITLE
Add source locator for air traffic control chronology

### DIFF
--- a/docs/source-locator-contributions/2026-06-07-air-traffic-control-date.md
+++ b/docs/source-locator-contributions/2026-06-07-air-traffic-control-date.md
@@ -1,0 +1,44 @@
+# Source Locator Contribution: air_traffic_control chronology
+
+## Target node
+
+- `air_traffic_control`
+- Current risk report status: Modern source-checked era-default date (`1945`)
+- Suggested corrected scope: operational air traffic control as a tower/airport traffic-control practice, not later radar/computerized ATC.
+
+## Proposed correction
+
+```json
+{
+  "id": "air_traffic_control",
+  "firstKnownDate": 1920,
+  "datePrecision": "year",
+  "region": "United Kingdom / Croydon Airport",
+  "reviewStatus": "source_checked"
+}
+```
+
+## Source locator
+
+- Title: Air traffic control
+- Publisher: Encyclopaedia Britannica
+- URL: https://www.britannica.com/technology/air-traffic-control
+- Locator: history section describing the first airport traffic control tower at Croydon, London, in 1920.
+- Source type: textbook
+- Supports: node chronology and region
+
+## Rationale
+
+The current default `1945` makes the node look like a postwar technology. That is too late for the broad node scope if `air_traffic_control` means organized airport traffic control. Croydon's 1920 control tower is a better first-known anchor for the broad operational concept. Later radar-based and computerized ATC should remain downstream or more specific nodes rather than defining the first-known date of the broad node.
+
+## Conservative caveat
+
+This correction should not be used if the canonical node description is intended to mean radar-assisted or networked modern ATC systems. In that case, the node should be renamed/rescoped instead of simply redated.
+
+## Suggested validation
+
+```sh
+npm test
+npm run quality
+npm run accuracy:risks -- --markdown --limit 20
+```


### PR DESCRIPTION
## Summary

Proof-of-concept data improvement PR.

Adds a source-locator contribution for `air_traffic_control`, which is currently listed in the risk report as a Modern source-checked era-default date node (`1945`).

The contribution proposes anchoring the broad operational ATC node to Croydon Airport's 1920 traffic-control tower, with Britannica as the source locator.

## Why this is only a source-locator PR

I intentionally did not edit `data/modern.json` directly in this proof-of-concept because the canonical JSON file is large and should be changed with the normal local validation loop.

This PR provides a reviewable, source-backed packet that can be applied by Codex or a human as the next small data edit.

## Suggested follow-up implementation

Update the `air_traffic_control` node:

```json
{
  "firstKnownDate": 1920,
  "datePrecision": "year",
  "region": "United Kingdom / Croydon Airport"
}
```

Add the Britannica source with:

```json
{
  "source_type": "textbook",
  "supports": ["node"]
}
```

## Validation to run after applying canonical data change

```sh
npm test
npm run quality
npm run accuracy:risks -- --markdown --limit 20
```

## Caveat

If the canonical node is intended to mean radar-assisted or networked modern ATC systems rather than broad airport traffic-control practice, the node should be renamed/rescoped instead of simply redated.