### PR TITLE
[codex] Tighten urban sewer inspection scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,899 / 5,576 (34.1%) |
+| Dependency edges with edge-level sources | 1,898 / 5,575 (34.0%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/classical.json
+++ b/data/classical.json
@@ -10003,8 +10003,7 @@
     "era": "Classical",
     "description": "Documented inspection and maintenance of urban sewers, drains, branches, and culverts to keep civic drainage systems operational.",
     "prerequisites": [
-      "sewers_and_drainage",
-      "construction"
+      "sewers_and_drainage"
     ],
     "fields": [
       "Water & Sanitation Systems",
@@ -10043,7 +10042,7 @@
     "datePrecision": "exact",
     "region": "Rome, Roman Republic",
     "reviewStatus": "source_checked",
-    "scopeNote": "Covers documented inspection and maintenance of existing Roman sewer/drainage infrastructure, anchored to Agrippa's 33 BCE inspection of the Cloaca Maxima system. It excludes the earlier invention of sewers and modern sanitary sewer networks.",
+    "scopeNote": "Covers documented inspection and maintenance of existing Roman sewer/drainage infrastructure, anchored to Agrippa's 33 BCE inspection of the Cloaca Maxima system. It excludes the earlier invention or construction of sewers and modern sanitary sewer networks.",
     "dependencyEdges": [
       {
         "prerequisite": "sewers_and_drainage",
@@ -10051,28 +10050,6 @@
         "confidence": 0.86,
         "evidence_level": "textbook",
         "note": "Inspection and maintenance of urban sewers presupposes an existing sewer/drainage system; the Cloaca Maxima entry describes the sewer network and Agrippa's inspection of the system.",
-        "reviewStatus": "source_checked",
-        "sources": [
-          {
-            "title": "Cloaca Maxima",
-            "url": "https://penelope.uchicago.edu/Thayer/E/Gazetteer/Places/Europe/Italy/Lazio/Roma/Rome/_Texts/PLATOP%2A/Cloaca_Maxima.html",
-            "publisher": "A Topographical Dictionary of Ancient Rome / LacusCurtius",
-            "year": 1929,
-            "source_type": "textbook",
-            "supports": [
-              "node",
-              "edge",
-              "maturity"
-            ]
-          }
-        ]
-      },
-      {
-        "prerequisite": "construction",
-        "type": "enabling",
-        "confidence": 0.7,
-        "evidence_level": "textbook",
-        "note": "The inspected Cloaca Maxima system included built, vaulted, paved, restored, and branch-drain sections; construction practice enabled durable access and repair without making aqueducts necessary.",
         "reviewStatus": "source_checked",
         "sources": [
           {

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T13:19:19.878Z",
+  "generatedAt": "2026-06-11T14:02:26.582Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,10 +25,10 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1899,
-      "denominator": 5576,
-      "formatted": "1,899 / 5,576",
-      "note": "34.1%"
+      "value": 1898,
+      "denominator": 5575,
+      "formatted": "1,898 / 5,575",
+      "note": "34.0%"
     },
     {
       "label": "Era-default placeholder dates",
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 557,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5576,
-    "edgesWithSources": 1899
+    "totalEdges": 5575,
+    "edgesWithSources": 1898
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T13:19:19.878Z
+Generated: 2026-06-11T14:02:26.582Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,899 / 5,576 (34.1%) |
+| Dependency edges with edge-level sources | 1,898 / 5,575 (34.0%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-urban-sewer-inspection-construction-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-urban-sewer-inspection-construction-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-urban-sewer-inspection-construction-removal",
+  "decision_date": "2026-06-11",
+  "edge": {
+    "dependent": "urban_sewer_inspection",
+    "prerequisite": "construction"
+  },
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "old_claim": {
+    "type": "enabling",
+    "evidence_level": "textbook",
+    "confidence": 0.7,
+    "note": "The inspected Cloaca Maxima system included built, vaulted, paved, restored, and branch-drain sections; construction practice enabled durable access and repair without making aqueducts necessary."
+  },
+  "new_claim_absent": "No direct dependency remains from urban_sewer_inspection to generic construction; the scoped practice presupposes an existing sewer/drainage system, not the construction technology that originally built it.",
+  "source_supports_edge": "no",
+  "source_url": "https://penelope.uchicago.edu/Thayer/E/Gazetteer/Places/Europe/Italy/Lazio/Roma/Rome/_Texts/PLATOP%2A/Cloaca_Maxima.html",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Cloaca Maxima entry, passages describing the sewer and Pliny's report that Agrippa inspected the whole system in 33 BCE; construction details describe the sewer fabric rather than a separate inspection prerequisite.",
+    "source_claim_summary": "Platner and Ashby describe the Cloaca Maxima as a sewer/drainage system and report Agrippa's 33 BCE inspection of the system.",
+    "source_support_rationale": "This supports existing sewers/drainage as the direct prerequisite and treats generic construction as upstream of the sewer object itself, not as a separate direct dependency for inspection."
+  },
+  "ontology_before": "Urban sewer inspection depended both on sewers_and_drainage and broad construction, duplicating upstream sewer-creation context as a direct inspection dependency.",
+  "ontology_after": "Urban sewer inspection is scoped to inspection and maintenance of existing sewer/drainage infrastructure, with sewers_and_drainage as the single direct prerequisite.",
+  "invariant_preserved_or_changed": "Graph invariant 2026-06-10-urban-sewer-inspection-scope now keeps construction absent alongside aqueducts while preserving the required sewers_and_drainage edge.",
+  "would_reject_if": [
+    "The node were rescoped from inspection and maintenance to original sewer construction.",
+    "A source showed that the documented 33 BCE inspection required a distinct construction technology beyond the existing sewer/drainage system.",
+    "A later split introduced a sewer_repair_construction_methods node specifically about reconstruction rather than inspection."
+  ],
+  "short_reason": "Inspection depends on the existing sewer system; generic construction is upstream context, not a direct edge.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-10-urban-sewer-inspection-scope.json
+++ b/docs/graph-invariants/2026-06-10-urban-sewer-inspection-scope.json
@@ -1,6 +1,6 @@
 {
   "id": "2026-06-10-urban-sewer-inspection-scope",
-  "description": "Adversarial invariant for the civic/admin manual sample: urban sewer inspection must stay scoped to sewer/drainage maintenance rather than aqueduct infrastructure.",
+  "description": "Adversarial invariant for the civic/admin manual sample: urban sewer inspection must stay scoped to sewer/drainage maintenance rather than aqueduct infrastructure or generic construction.",
   "checks": [
     {
       "type": "first_known_date",
@@ -21,6 +21,12 @@
       "dependent": "urban_sewer_inspection",
       "prerequisite": "aqueducts",
       "reason": "Aqueducts are water-supply infrastructure, not a prerequisite for sewer inspection."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "urban_sewer_inspection",
+      "prerequisite": "construction",
+      "reason": "Generic construction is upstream of sewer creation; the direct prerequisite for sewer inspection is the existing sewer/drainage system."
     }
   ]
 }


### PR DESCRIPTION
## Scope

One-node correction for `urban_sewer_inspection` only.

## Old Claim

`urban_sewer_inspection` had two direct prerequisites:

- `sewers_and_drainage` as `required`
- `construction` as `enabling`

The `construction` edge treated generic construction practice as a direct dependency of sewer inspection.

## New Claim

`urban_sewer_inspection` now has a single direct prerequisite:

- `sewers_and_drainage` as `required`

The node scope note now makes the boundary explicit: it covers documented inspection and maintenance of existing Roman sewer/drainage infrastructure, not the earlier invention or construction of sewers.

## Source URLs / Locators

- `https://penelope.uchicago.edu/Thayer/E/Gazetteer/Places/Europe/Italy/Lazio/Roma/Rome/_Texts/PLATOP%2A/Cloaca_Maxima.html`
  - Locator: Cloaca Maxima entry passages describing the sewer, Pliny's report that Agrippa inspected the whole system in 33 BCE, and separate construction details about the sewer fabric.
- `https://www.britannica.com/technology/sewerage-system`
  - Locator: general sewerage-system background source already attached to the node.

## Why This Is Better

The date, precision, and region were already source-backed and remain unchanged:

- `firstKnownDate`: `-33`
- `datePrecision`: `exact`
- `region`: `Rome, Roman Republic`

The correction improves direct edge semantics. Inspection and maintenance require an existing sewer/drainage system. Generic construction is upstream of creating the sewer object and is already contextually captured by `sewers_and_drainage`; keeping it as a second direct edge overstates the dependency.

## Adversarial Note

Strongest reason this could be wrong: if the node were intentionally scoped to sewer reconstruction or repair methods rather than inspection/maintenance, a construction-method edge could be appropriate. The current description and source anchor are inspection of an existing system, so the edge is removed.

## Validation

Ran:

```bash
npm run node-packet -- urban_sewer_inspection --json
npm test
npm run quality
npm run coverage
npm run accuracy:risks -- --markdown --limit 24
```

Results:

- `npm test`: passed, 1660 technologies validated, no missing prerequisites or cycles; temporal and semantic edge audit passed.
- `npm run quality`: passed; edge receipts, graph invariants, invariant coverage, trust audit, and snapshot checks passed.
- `npm run coverage`: passed; coverage report generated.
- `npm run accuracy:risks -- --markdown --limit 24`: passed; current report shows 1660 technologies, 610 source-checked nodes, 557 era-default placeholder dates, and 1898 / 5575 dependency edges with edge-level sources.

## Receipts

Added `docs/edge-change-receipts/2026-06-11-urban-sewer-inspection-construction-removal.json` and extended `docs/graph-invariants/2026-06-10-urban-sewer-inspection-scope.json` so `construction` stays absent from this node.