### PR TITLE
[codex] Tighten standardized weights edge semantics

### DIFF
--- a/data/ancient.json
+++ b/data/ancient.json
@@ -4910,41 +4910,41 @@
     "dependencyEdges": [
       {
         "prerequisite": "trade_routes",
-        "type": "enabling",
-        "confidence": 0.68,
+        "type": "commercial_or_scaling_dependency",
+        "confidence": 0.72,
         "evidence_level": "expert_inference",
-        "note": "Trade Routes provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated",
+        "note": "Long-distance merchants carried weights and compared regional weight systems; trade routes commercially scaled standard weights without being a hard prerequisite for local metrology.",
+        "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Trade routes",
-            "url": "https://en.wikipedia.org/wiki/Trade_route",
-            "source_type": "weak_web",
+            "title": "Mesopotamian City Life",
+            "url": "https://www.penn.museum/sites/expedition/mesopotamian-city-life/",
+            "source_type": "museum",
             "supports": [
               "edge"
             ],
-            "publisher": "Wikipedia",
-            "year": 2026
+            "publisher": "Penn Museum",
+            "year": 2018
           }
         ]
       },
       {
         "prerequisite": "writing",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
+        "type": "common_dependency",
+        "confidence": 0.62,
         "evidence_level": "expert_inference",
-        "note": "Writing is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated",
+        "note": "Cuneiform records and administration documented weight systems, but writing is a shared administrative context rather than a direct historical predecessor of physical standard weights.",
+        "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Writing",
-            "url": "https://en.wikipedia.org/wiki/Writing",
-            "source_type": "weak_web",
+            "title": "Hanging in the Balance: Precision Weighing in Antiquity",
+            "url": "https://www.penn.museum/sites/expedition/hanging-in-the-balance-2/",
+            "source_type": "museum",
             "supports": [
               "edge"
             ],
-            "publisher": "Wikipedia",
-            "year": 2026
+            "publisher": "Penn Museum",
+            "year": 2005
           }
         ]
       }

--- a/docs/edge-change-receipts/2026-06-11-standardized-weights-trade-routes-scaling.json
+++ b/docs/edge-change-receipts/2026-06-11-standardized-weights-trade-routes-scaling.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-11-standardized-weights-trade-routes-scaling",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "standardized_weights_and_measures",
+    "prerequisite": "trade_routes"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Trade Routes provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "commercial_or_scaling_dependency",
+    "confidence": 0.72,
+    "evidence_level": "expert_inference",
+    "note": "Long-distance merchants carried weights and compared regional weight systems; trade routes commercially scaled standard weights without being a hard prerequisite for local metrology."
+  },
+  "source_supports_edge": "partial",
+  "source_url": "https://www.penn.museum/sites/expedition/mesopotamian-city-life/",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "documents_application_use",
+    "source_locator": "Mesopotamian City Life, trade and commerce sections discussing shekel weights, merchants carrying weights, and comparison with neighboring systems for international business.",
+    "source_claim_summary": "Penn Museum describes shekel weights used in trading and notes that merchants carried weights and compared them with neighboring regional systems during international business.",
+    "source_support_rationale": "The passage supports a commercial scaling role for trade networks, but it does not show that trade routes were necessary before any local standardized weight system could exist."
+  },
+  "ontology_before": "The edge implied trade routes generally enabled standardized weights and measures.",
+  "ontology_after": "The edge now models long-distance exchange as a commercial scaling pressure rather than a hard or generic enabling prerequisite.",
+  "invariant_preserved_or_changed": "The node remains scoped to ancient source-backed metrology; only the edge verb is narrowed.",
+  "would_reject_if": [
+    "A primary or museum source showed standardized Mesopotamian weights originated specifically as a required component of long-distance trade routes rather than broader administration and commerce.",
+    "The cited Penn Museum page did not discuss merchants carrying weights or comparing regional systems."
+  ],
+  "short_reason": "Trade routes scaled and coordinated ancient metrology, but the source does not make them a prerequisite for local standardized weights.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-standardized-weights-writing-common.json
+++ b/docs/edge-change-receipts/2026-06-11-standardized-weights-writing-common.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-11-standardized-weights-writing-common",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "standardized_weights_and_measures",
+    "prerequisite": "writing"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Writing is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim": {
+    "type": "common_dependency",
+    "confidence": 0.62,
+    "evidence_level": "expert_inference",
+    "note": "Cuneiform records and administration documented weight systems, but writing is a shared administrative context rather than a direct historical predecessor of physical standard weights."
+  },
+  "source_supports_edge": "partial",
+  "source_url": "https://www.penn.museum/sites/expedition/hanging-in-the-balance-2/",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Hanging in the Balance, discussion of Mesopotamian cuneiform texts defining the weighing system through barley grains and the shekel.",
+    "source_claim_summary": "Penn Museum describes cuneiform texts that define Mesopotamian weighing systems, including grain-based units and the shekel.",
+    "source_support_rationale": "The source links writing to documented administration of weights, but it does not establish writing as the historical predecessor of physical standard weights themselves."
+  },
+  "ontology_before": "The edge treated writing as a historical predecessor of standardized weights and measures.",
+  "ontology_after": "The edge now treats writing as a shared administrative/documentary context for the scoped Mesopotamian weighing system.",
+  "invariant_preserved_or_changed": "The node remains a Bronze Age metrology node; the edge avoids laundering documentary evidence into a direct predecessor claim.",
+  "would_reject_if": [
+    "A source showed physical standardized weights were derived from writing rather than merely documented and administered through written systems.",
+    "The cited source did not discuss cuneiform texts defining Mesopotamian weighing systems."
+  ],
+  "short_reason": "Writing supports the documented administrative context for metrology, not a direct predecessor relationship to physical standard weights.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-standardized-weights-scope.json
+++ b/docs/graph-invariants/2026-06-11-standardized-weights-scope.json
@@ -1,0 +1,19 @@
+{
+  "id": "2026-06-11-standardized-weights-scope",
+  "checks": [
+    {
+      "type": "edge_type",
+      "dependent": "standardized_weights_and_measures",
+      "prerequisite": "trade_routes",
+      "expected": "commercial_or_scaling_dependency",
+      "reason": "Long-distance trade scales and coordinates ancient metrology but is not modeled as a hard prerequisite."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "standardized_weights_and_measures",
+      "prerequisite": "writing",
+      "expected": "common_dependency",
+      "reason": "Cuneiform documentation is administrative context, not a direct predecessor of physical standard weights."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

This is a one-node data-quality correction for `standardized_weights_and_measures`.

- Retyped `trade_routes -> standardized_weights_and_measures` from `enabling` to `commercial_or_scaling_dependency`.
- Retyped `writing -> standardized_weights_and_measures` from `historical_predecessor` to `common_dependency`.
- Replaced generic Wikipedia edge sources with Penn Museum sources already aligned to the scoped Mesopotamian metrology claim.
- Added two edge-change receipts and a graph invariant to preserve the narrower edge semantics.

## Old claim vs new claim

Old: trade routes generally enabled standardized weights, and writing was treated as a historical predecessor.

New: long-distance trade commercially scaled and coordinated weight systems, while writing/cuneiform administration documented and helped administer the system. Neither edge is treated as a hard prerequisite.

## Source locators

- Penn Museum, `Mesopotamian City Life`: sections describing shekel weights, trading, merchants carrying weights, and comparing neighboring regional systems for international business.
- Penn Museum, `Hanging in the Balance: Precision Weighing in Antiquity`: discussion of Mesopotamian cuneiform texts defining weighing systems through barley grains and the shekel.

## Why this is better

The cited sources support administrative and commercial context for Mesopotamian standard weights, but they do not prove a strict prerequisite or direct predecessor relationship. The edge verbs now match that evidence more closely.

## Adversarial note

The correction could be too conservative if a stronger source shows that long-distance trade or written administration was causally necessary for the earliest standardized weight systems, rather than one of several contexts in which they were used and documented.

## Validation

Passed:

```bash
npm run edge-receipts
npm run graph-invariants
npm run node-packet -- standardized_weights_and_measures --json
git diff --check
npm run agent:check -- --run
npm run accuracy:risks -- --markdown --limit 24
```

`agent:check -- --run` included `npm test`, `npm run quality`, `npm run coverage`, and `npm run source-urls`.