### PR TITLE
[codex] Tighten modern wind power scope

### DIFF
--- a/data/modern.json
+++ b/data/modern.json
@@ -14953,7 +14953,7 @@
     "id": "wind_power_modern",
     "name": "Wind Power (Modern)",
     "era": "Modern",
-    "description": "Generating electricity from large-scale wind turbines.",
+    "description": "Utility-scale electricity generation from modern wind turbines, anchored by the 1941 Smith-Putnam turbine and later grid-connected wind plants.",
     "prerequisites": [
       "construction",
       "windmills",
@@ -14995,6 +14995,7 @@
     "datePrecision": "exact",
     "region": "Grandpa's Knob, Vermont, United States; later global utility-scale wind industry",
     "reviewStatus": "source_checked",
+    "scopeNote": "Covers modern wind-electric generation at large or grid-connected scale; excludes earlier windmills used primarily for milling, pumping, or other mechanical work.",
     "dependencyEdges": [
       {
         "prerequisite": "construction",
@@ -15020,17 +15021,17 @@
       },
       {
         "prerequisite": "windmills",
-        "type": "enabling",
-        "confidence": 0.68,
+        "type": "historical_predecessor",
+        "confidence": 0.78,
         "evidence_level": "expert_inference",
-        "note": "Windmills provides a capability that enables this technology without being the only possible path.",
+        "note": "Earlier windmills are the mechanical and chronological lineage for wind turbines, while modern wind-electric generation depends on electrical conversion rather than milling or pumping machinery.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Wind Energy Basics",
-            "url": "https://www.energy.gov/eere/wind/wind-energy-basics",
-            "publisher": "U.S. Department of Energy",
-            "year": 2024,
+            "title": "Wind Timeline",
+            "url": "https://www.eia.gov/kids/history-of-energy/timelines/wind.php",
+            "publisher": "U.S. Energy Information Administration",
+            "year": 2026,
             "source_type": "official_agency",
             "supports": [
               "node",

--- a/docs/edge-change-receipts/2026-06-11-wind-power-windmills-historical.json
+++ b/docs/edge-change-receipts/2026-06-11-wind-power-windmills-historical.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-11-wind-power-windmills-historical",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "wind_power_modern",
+    "prerequisite": "windmills"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Windmills provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.78,
+    "evidence_level": "expert_inference",
+    "note": "Earlier windmills are the mechanical and chronological lineage for wind turbines, while modern wind-electric generation depends on electrical conversion rather than milling or pumping machinery."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.eia.gov/kids/history-of-energy/timelines/wind.php",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "establishes_historical_lineage",
+    "source_locator": "Wind timeline entries for 500-900 AD Persian windmills, about 1300 horizontal-axis windmills, 1888 Brush electricity-generating windmill, and 1941 Smith-Putnam turbine.",
+    "source_claim_summary": "The EIA timeline presents mechanical windmills before electricity-generating wind turbines and separately identifies the 1941 Smith-Putnam turbine supplying power.",
+    "source_support_rationale": "The chronological sequence supports a lineage relationship from windmills to wind-electric turbines, but not a generic capability dependency on milling or pumping machinery."
+  },
+  "ontology_before": "The edge treated windmills as a generic enabling capability for modern wind power.",
+  "ontology_after": "The edge now treats windmills as a historical predecessor while the modern node remains scoped to wind-electric generation.",
+  "invariant_preserved_or_changed": "Changed: edge verb narrowed to historical lineage. Preserved: modern wind power still depends on electrical generation and remains connected to the wind technology lineage.",
+  "would_reject_if": [
+    "A stronger source showed that medieval or mechanical windmill machinery was directly necessary for modern wind-electric turbine operation.",
+    "The EIA timeline did not distinguish earlier windmills from later electricity-generating wind turbines."
+  ],
+  "short_reason": "Windmills are the historical lineage for wind turbines, not a direct enabling subsystem of modern wind-electric generation.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-wind-power-modern-scope.json
+++ b/docs/graph-invariants/2026-06-11-wind-power-modern-scope.json
@@ -1,0 +1,19 @@
+{
+  "id": "2026-06-11-wind-power-modern-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "wind_power_modern",
+      "operator": "eq",
+      "value": 1941,
+      "reason": "The scoped node is anchored to the 1941 Smith-Putnam wind turbine supplying community power, not earlier mechanical windmills."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "wind_power_modern",
+      "prerequisite": "windmills",
+      "expected": "historical_predecessor",
+      "reason": "Earlier windmills are lineage for wind turbines rather than a generic enabling subsystem."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

This is a one-node data-quality correction for `wind_power_modern`.

- Clarified the node description as utility-scale/grid-connected wind-electric generation anchored by the 1941 Smith-Putnam turbine.
- Added a scope note excluding earlier windmills used primarily for milling, pumping, or other mechanical work.
- Retyped `windmills -> wind_power_modern` from `enabling` to `historical_predecessor`.
- Swapped the edge source to the EIA wind timeline, which directly presents the chronology from early windmills to electricity-generating wind turbines.
- Added an edge-change receipt and graph invariant for the corrected edge verb and 1941 scope anchor.

## Old claim vs new claim

Old: windmills generically enabled modern wind power.

New: windmills are the historical/mechanical lineage for wind turbines, while modern wind-electric generation is scoped to electrical conversion and grid/utility-scale deployment.

## Source locator

U.S. Energy Information Administration, `Wind Timeline`:

- 500-900 AD: first Persian windmills for pumping water and grinding grain.
- About 1300: horizontal-axis windmills in Western Europe.
- 1888: Brush windmill generated electricity and these machines began being called wind turbines.
- 1941: Smith-Putnam turbine supplied power at Grandpa's Knob, Vermont.

## Why this is better

The EIA source supports chronology and lineage. It does not support treating medieval windmill machinery as a generic enabling subsystem for modern wind-electric generation.

## Adversarial note

The correction could be too narrow if a stronger engineering-history source argues that specific windmill mechanisms were directly inherited as required subsystems in early wind-electric turbines, rather than just forming the historical lineage.

## Validation

Passed:

```bash
npm run edge-receipts
npm run graph-invariants
npm run node-packet -- wind_power_modern --json
git diff --check
npm run agent:check -- --run
npm run source-urls
npm run accuracy:risks -- --markdown --limit 24
```

`agent:check -- --run` included `npm test`, `npm run quality`, and `npm run coverage`. The first source URL audit attempt hit an unrelated transient timeout on `computerhistory.org` for `system_on_chip_soc`; rerunning `npm run source-urls` passed for all 729 URLs.