### PR TITLE
[codex] Tighten pumped hydro storage scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,898 / 5,575 (34.0%) |
+| Dependency edges with edge-level sources | 1,897 / 5,574 (34.0%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/modern.json
+++ b/data/modern.json
@@ -33873,11 +33873,10 @@
     "id": "pumped_hydro_storage",
     "name": "Pumped Hydro Storage",
     "era": "Modern",
-    "description": "Grid-scale storage that pumps water uphill when power is cheap and releases it through turbines when power is needed.",
+    "description": "Pumped storage hydropower that stores grid electricity by pumping water to an upper reservoir and releases it through turbines when power is needed.",
     "prerequisites": [
       "hydroelectric_power_plants",
-      "electrical_grid_early_distribution",
-      "process_control_instrumentation"
+      "electrical_grid_early_distribution"
     ],
     "fields": [
       "Energy Systems & Grid"
@@ -33887,6 +33886,17 @@
     },
     "maturity": "established",
     "sources": [
+      {
+        "title": "Pumped Storage Hydropower",
+        "url": "https://www.energy.gov/cmei/water/pumped-storage-hydropower",
+        "publisher": "U.S. Department of Energy",
+        "year": 2026,
+        "source_type": "official_agency",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
       {
         "title": "History of Hydropower",
         "url": "https://www.energy.gov/cmei/water/history-hydropower",
@@ -33910,10 +33920,11 @@
         ]
       }
     ],
-    "firstKnownDate": 1929,
-    "datePrecision": "exact",
-    "region": "Rocky River, Connecticut, United States; earlier European pumped-storage examples existed",
+    "firstKnownDate": 1890,
+    "datePrecision": "decade",
+    "region": "Italy and Switzerland; United States adoption from Rocky River/New Milford, Connecticut by 1929-1930",
     "reviewStatus": "source_checked",
+    "scopeNote": "Covers pumped storage hydropower as an electric-grid storage technology; the date follows DOE's global first-known 1890s Italy/Switzerland cases rather than the later Rocky River U.S. milestone.",
     "dependencyEdges": [
       {
         "prerequisite": "hydroelectric_power_plants",
@@ -33939,37 +33950,15 @@
       },
       {
         "prerequisite": "electrical_grid_early_distribution",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
+        "type": "required",
+        "confidence": 0.84,
         "evidence_level": "expert_inference",
-        "note": "Electrical Grid (Early Distribution) is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
+        "note": "Pumped storage hydropower is scoped as electric-grid storage: it requires electricity to pump water uphill and releases stored power back when needed.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Energy Storage",
-            "url": "https://www.energy.gov/oe/energy-storage",
-            "publisher": "U.S. Department of Energy",
-            "year": 2026,
-            "source_type": "official_agency",
-            "supports": [
-              "node",
-              "maturity",
-              "edge"
-            ]
-          }
-        ]
-      },
-      {
-        "prerequisite": "process_control_instrumentation",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Process Control Instrumentation provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "source_checked",
-        "sources": [
-          {
-            "title": "Energy Storage",
-            "url": "https://www.energy.gov/oe/energy-storage",
+            "title": "Pumped Storage Hydropower",
+            "url": "https://www.energy.gov/cmei/water/pumped-storage-hydropower",
             "publisher": "U.S. Department of Energy",
             "year": 2026,
             "source_type": "official_agency",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T14:02:26.582Z",
+  "generatedAt": "2026-06-11T14:34:09.748Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,9 +25,9 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1898,
-      "denominator": 5575,
-      "formatted": "1,898 / 5,575",
+      "value": 1897,
+      "denominator": 5574,
+      "formatted": "1,897 / 5,574",
       "note": "34.0%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 557,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5575,
-    "edgesWithSources": 1898
+    "totalEdges": 5574,
+    "edgesWithSources": 1897
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T14:02:26.582Z
+Generated: 2026-06-11T14:34:09.748Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,898 / 5,575 (34.0%) |
+| Dependency edges with edge-level sources | 1,897 / 5,574 (34.0%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-pumped-hydro-grid-required.json
+++ b/docs/edge-change-receipts/2026-06-11-pumped-hydro-grid-required.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-11-pumped-hydro-grid-required",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "pumped_hydro_storage",
+    "prerequisite": "electrical_grid_early_distribution"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Electrical Grid (Early Distribution) is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.84,
+    "evidence_level": "expert_inference",
+    "note": "Pumped storage hydropower is scoped as electric-grid storage: it requires electricity to pump water uphill and releases stored power back when needed."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.energy.gov/cmei/water/pumped-storage-hydropower",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "demonstrates_method_dependency",
+    "source_locator": "Pumped Storage Hydropower, What is Pumped Storage Hydropower? section describing two reservoirs, discharge through a turbine, required power for recharge, and grid storage role.",
+    "source_claim_summary": "DOE describes pumped storage hydropower as electric energy storage that requires power to pump water back to the upper reservoir and releases stored power when needed.",
+    "source_support_rationale": "Because this node is scoped to electric-grid storage, the DOE mechanism makes electrical supply/distribution a direct method dependency rather than only earlier historical context."
+  },
+  "ontology_before": "The edge treated early electrical grids as historical background for pumped hydro storage.",
+  "ontology_after": "The edge now treats electric distribution as required for the scoped grid-storage method, while preserving hydropower machinery as a separate enabling dependency.",
+  "invariant_preserved_or_changed": "Changed: grid edge is now required. Preserved: pumped hydro remains a hydropower storage node with no new prerequisites.",
+  "would_reject_if": [
+    "The node were rescoped to non-electric pumped water storage rather than grid-scale pumped storage hydropower.",
+    "The DOE page did not state that PSH requires power for pumping and functions as storage on the electric grid."
+  ],
+  "short_reason": "Grid-scale pumped hydro storage is not just historically downstream of grids; the scoped method requires electric power for recharge and grid-connected release.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-pumped-hydro-process-control-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-pumped-hydro-process-control-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-11-pumped-hydro-process-control-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "pumped_hydro_storage",
+    "prerequisite": "process_control_instrumentation"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Process Control Instrumentation provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from pumped_hydro_storage to process_control_instrumentation; early 1890s PSH use cases predate this node and the DOE PSH source defines the method through reservoirs, pumping power, turbines, and grid storage rather than modern process-control instrumentation.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.energy.gov/cmei/water/pumped-storage-hydropower",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Pumped Storage Hydropower, What is Pumped Storage Hydropower? section describing reservoirs at different elevations, pumping power, discharge through a turbine, and electric-grid storage role.",
+    "source_claim_summary": "DOE defines PSH by two reservoirs, pumping water to recharge, discharge through a turbine, and storage/release of electric power.",
+    "source_support_rationale": "The source supports the core hydropower/grid mechanism and an 1890s first-known chronology, but it does not support a later process-control instrumentation prerequisite for the scoped early technology."
+  },
+  "ontology_before": "The node depended on a later process-control instrumentation node, creating a chronology conflict after the global first-known date correction.",
+  "ontology_after": "The node keeps hydropower and grid dependencies but no longer requires later instrumentation that is not necessary for early PSH.",
+  "invariant_preserved_or_changed": "Changed: process_control_instrumentation is absent as a direct prerequisite. Preserved: pumped hydro remains connected to hydropower and electric-grid infrastructure.",
+  "would_reject_if": [
+    "The node were rescoped to modern digitally controlled PSH plants rather than first-known pumped storage hydropower.",
+    "A source showed 1890s Italy/Switzerland PSH depended on instrumentation equivalent to the process_control_instrumentation node."
+  ],
+  "short_reason": "A later process-control node cannot be a prerequisite for the corrected 1890s global PSH scope.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-10-energy-chronology-scope.json
+++ b/docs/graph-invariants/2026-06-10-energy-chronology-scope.json
@@ -25,8 +25,8 @@
       "type": "first_known_date",
       "node": "pumped_hydro_storage",
       "operator": "eq",
-      "value": 1929,
-      "reason": "The pumped-hydro node is scoped to major grid-scale pumped-storage development."
+      "value": 1890,
+      "reason": "The pumped-hydro node follows DOE's global first-known PSH use cases in Italy and Switzerland in the 1890s, not only the later U.S. Rocky River milestone."
     },
     {
       "type": "first_known_date",

--- a/docs/graph-invariants/2026-06-11-pumped-hydro-storage-scope.json
+++ b/docs/graph-invariants/2026-06-11-pumped-hydro-storage-scope.json
@@ -1,0 +1,25 @@
+{
+  "id": "2026-06-11-pumped-hydro-storage-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "pumped_hydro_storage",
+      "operator": "eq",
+      "value": 1890,
+      "reason": "DOE places the first known PSH use cases in Italy and Switzerland in the 1890s, earlier than the U.S. Rocky River milestone."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "pumped_hydro_storage",
+      "prerequisite": "electrical_grid_early_distribution",
+      "expected": "required",
+      "reason": "The scoped grid-storage method requires electricity for pumping and releases stored power back to the grid."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "pumped_hydro_storage",
+      "prerequisite": "process_control_instrumentation",
+      "reason": "The corrected 1890s global PSH scope predates and does not require later process-control instrumentation."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

This is a one-node data-quality correction for `pumped_hydro_storage`.

- Changed `firstKnownDate` from the U.S.-specific `1929` anchor to DOE's global first-known `1890s` Italy/Switzerland scope.
- Changed `datePrecision` from `exact` to `decade`.
- Updated region and scope note to distinguish global first-known PSH cases from later Rocky River U.S. adoption.
- Added the specific DOE `Pumped Storage Hydropower` source.
- Retyped `electrical_grid_early_distribution -> pumped_hydro_storage` from `historical_predecessor` to `required` for the grid-storage scope.
- Removed `process_control_instrumentation -> pumped_hydro_storage`, because the corrected 1890s scope predates that node and the DOE mechanism does not require it.
- Added two edge-change receipts and graph invariants.

## Old claim vs new claim

Old: pumped hydro was anchored to the 1929 Rocky River U.S. milestone and depended on later process-control instrumentation.

New: pumped hydro follows DOE's global first-known 1890s Italy/Switzerland cases; the grid edge is a direct method dependency, and later process-control instrumentation is not a prerequisite for the first-known technology.

## Source locator

U.S. Department of Energy, `Pumped Storage Hydropower`, `What is Pumped Storage Hydropower?` section: describes two reservoirs, pumping water to recharge, discharge through a turbine, grid storage role, and first known use cases in Italy and Switzerland in the 1890s.

## Adversarial note

The correction would be too broad if this node were meant to represent only the first major U.S. pumped-storage plant rather than pumped storage hydropower globally. The prior region text already acknowledged earlier European examples, so the global chronology is the cleaner scope.

## Validation

Passed:

```bash
npm run edge-receipts
npm run graph-invariants
npm run node-packet -- pumped_hydro_storage --json
npm test
npm run agent:check -- --run
npm run accuracy:risks -- --markdown --limit 24
```

`agent:check -- --run` included `git diff --check`, `npm test`, `npm run quality`, `npm run coverage`, and `npm run source-urls`.