### PR TITLE
[codex] Source-check masonry direct edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,897 / 5,574 (34.0%) |
+| Dependency edges with edge-level sources | 1,899 / 5,574 (34.1%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -3366,7 +3366,8 @@
         "year": 2026,
         "source_type": "generic_overview",
         "supports": [
-          "node"
+          "node",
+          "edge"
         ]
       }
     ],
@@ -3377,19 +3378,45 @@
     "dependencyEdges": [
       {
         "prerequisite": "advanced_stone_tools",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Stone Tools is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "type": "enabling",
+        "confidence": 0.7,
+        "evidence_level": "textbook",
+        "note": "Masonry stone shaping and dressing use stone-working tools such as hammers, chisels, and gouges; advanced stone tools enable shaped-stone construction without being masonry itself.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Masonry",
+            "url": "https://www.britannica.com/technology/masonry",
+            "publisher": "Encyclopaedia Britannica",
+            "year": 2026,
+            "source_type": "generic_overview",
+            "supports": [
+              "node",
+              "edge"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "mining",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Mining provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "confidence": 0.76,
+        "evidence_level": "textbook",
+        "note": "Masonry begins with extractive materials such as stone, clay, sand, and gravel, commonly mined from surface pits or quarries; extraction enables reliable material supply.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Masonry",
+            "url": "https://www.britannica.com/technology/masonry",
+            "publisher": "Encyclopaedia Britannica",
+            "year": 2026,
+            "source_type": "generic_overview",
+            "supports": [
+              "node",
+              "edge"
+            ]
+          }
+        ]
       }
     ],
     "scopeNote": "Covers durable stone construction and shaped-stone architectural assemblies; excludes stone tool making and loose stone use without built structural masonry."

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T14:34:09.748Z",
+  "generatedAt": "2026-06-11T14:45:07.863Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,10 +25,10 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1897,
+      "value": 1899,
       "denominator": 5574,
-      "formatted": "1,897 / 5,574",
-      "note": "34.0%"
+      "formatted": "1,899 / 5,574",
+      "note": "34.1%"
     },
     {
       "label": "Era-default placeholder dates",
@@ -62,6 +62,6 @@
     "eraDefaultDates": 557,
     "sourceCheckedEraDefaultDates": 0,
     "totalEdges": 5574,
-    "edgesWithSources": 1897
+    "edgesWithSources": 1899
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T14:34:09.748Z
+Generated: 2026-06-11T14:45:07.863Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,897 / 5,574 (34.0%) |
+| Dependency edges with edge-level sources | 1,899 / 5,574 (34.1%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-masonry-mining-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-masonry-mining-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-masonry-mining-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "masonry",
+    "prerequisite": "mining"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Mining provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.76,
+    "evidence_level": "textbook",
+    "note": "Masonry begins with extractive materials such as stone, clay, sand, and gravel, commonly mined from surface pits or quarries; extraction enables reliable material supply."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/technology/masonry",
+  "source_shape": {
+    "source_type": "generic_overview",
+    "support_relationship": "demonstrates_method_dependency",
+    "source_locator": "Masonry article, materials paragraph stating masonry begins with extractive materials such as clay, sand, gravel, and stone, usually mined from surface pits or quarries.",
+    "source_claim_summary": "Britannica states that masonry construction begins with extractive materials, including stone and clay, usually mined from pits or quarries.",
+    "source_support_rationale": "The passage directly supports material extraction as an enabling supply dependency while preserving that mining is not the masonry craft itself."
+  },
+  "invariant_preserved_or_changed": "Preserved: mining remains an enabling material-supply edge; changed evidence from generic inference to source-backed claim.",
+  "would_reject_if": [
+    "A stronger source showed early stone masonry did not depend on extracted or quarried materials.",
+    "The cited masonry source did not connect masonry materials with mining, pits, or quarries."
+  ],
+  "short_reason": "The mining edge now cites a source that directly links masonry materials to extraction from pits and quarries.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-masonry-stone-tools-enabling.json
+++ b/docs/edge-change-receipts/2026-06-11-masonry-stone-tools-enabling.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-11-masonry-stone-tools-enabling",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "masonry",
+    "prerequisite": "advanced_stone_tools"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Stone Tools is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.7,
+    "evidence_level": "textbook",
+    "note": "Masonry stone shaping and dressing use stone-working tools such as hammers, chisels, and gouges; advanced stone tools enable shaped-stone construction without being masonry itself."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/technology/masonry",
+  "source_shape": {
+    "source_type": "generic_overview",
+    "support_relationship": "demonstrates_method_dependency",
+    "source_locator": "Masonry article, paragraph on shaping and dressing stone with hand-held tools including hammers, mallets, chisels, and gouges.",
+    "source_claim_summary": "Britannica describes masonry stone shaping and dressing as using hand tools including hammers, mallets, chisels, and gouges.",
+    "source_support_rationale": "The passage supports a tool-enabled construction process; it does not make advanced stone tools the whole masonry technology or only a loose historical predecessor."
+  },
+  "ontology_before": "The edge treated advanced stone tools as only a historical predecessor for masonry.",
+  "ontology_after": "The edge now models stone-working tools as enabling technology for shaped-stone masonry construction.",
+  "invariant_preserved_or_changed": "Changed: edge verb is enabling. Preserved: masonry still remains a construction node, not a stone-tool-making node.",
+  "would_reject_if": [
+    "A stronger source showed early masonry as scoped here did not involve shaped or dressed stone.",
+    "The cited masonry source did not describe tools used for shaping and dressing stone."
+  ],
+  "short_reason": "Stone-working tools enable shaped-stone masonry rather than merely preceding it historically.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-masonry-edge-scope.json
+++ b/docs/graph-invariants/2026-06-11-masonry-edge-scope.json
@@ -1,0 +1,19 @@
+{
+  "id": "2026-06-11-masonry-edge-scope",
+  "checks": [
+    {
+      "type": "edge_type",
+      "dependent": "masonry",
+      "prerequisite": "advanced_stone_tools",
+      "expected": "enabling",
+      "reason": "Stone-working tools enable shaping and dressing stone without being the masonry technology itself."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "masonry",
+      "prerequisite": "mining",
+      "expected": "enabling",
+      "reason": "Extractive material supply enables masonry but is not a hard prerequisite for every local stone-building case."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

This is a one-node data-quality correction for `masonry`.

- Retyped `advanced_stone_tools -> masonry` from `historical_predecessor` to `enabling`.
- Replaced the generic note with a source-backed explanation that masonry stone shaping/dressing uses tools such as hammers, chisels, and gouges.
- Upgraded `mining -> masonry` evidence from `expert_inference` to `textbook` and replaced the generic note with a source-backed material-extraction explanation.
- Added edge-level sources, two receipts, and a graph invariant.
- Regenerated the quality snapshot; edge-level source coverage increased from `1,897 / 5,574` to `1,899 / 5,574`.

## Source locator

Encyclopaedia Britannica, `Masonry`:

- article definition and history section for masonry as stonework/building craft
- paragraph on extractive materials, usually mined from surface pits or quarries
- paragraph on shaping and dressing stone with tools including hammers, mallets, chisels, and gouges

## Why this is better

The previous direct edges were structurally valid but generic and unsourced. The updated claims keep the same node scope but make the edge semantics falsifiable and source-backed.

## Adversarial note

The stone-tool edge could be too strong if a reviewer wants `advanced_stone_tools` reserved only for microlithic or polished tool traditions rather than masonry tools generally. I kept it as `enabling`, not `required`, to avoid overstating the broad prerequisite.

## Validation

Passed:

```bash
npm run edge-receipts
npm run graph-invariants
npm run node-packet -- masonry --json
git diff --check
npm run agent:check -- --run
npm run accuracy:risks -- --markdown --limit 24
```

`agent:check -- --run` included `npm test`, `npm run quality`, `npm run coverage`, and `npm run source-urls`.