### PR TITLE
[codex] Remove weak bronze edge from metal coinage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,899 / 5,574 (34.1%) |
+| Dependency edges with edge-level sources | 1,899 / 5,573 (34.1%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/classical.json
+++ b/data/classical.json
@@ -3567,7 +3567,6 @@
     "prerequisites": [
       "gold_and_silver_working",
       "mining",
-      "bronze_working",
       "standardized_weights_and_measures"
     ],
     "fields": [
@@ -3638,14 +3637,6 @@
             ]
           }
         ]
-      },
-      {
-        "prerequisite": "bronze_working",
-        "type": "enabling",
-        "confidence": 0.64,
-        "evidence_level": "expert_inference",
-        "note": "Base-metal casting and working practices supported later coinage metals, but earliest Lydian electrum coins did not strictly require bronze.",
-        "reviewStatus": "source_checked"
       },
       {
         "prerequisite": "standardized_weights_and_measures",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T14:45:07.863Z",
+  "generatedAt": "2026-06-11T16:15:04.873Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -26,8 +26,8 @@
     {
       "label": "Dependency edges with edge-level sources",
       "value": 1899,
-      "denominator": 5574,
-      "formatted": "1,899 / 5,574",
+      "denominator": 5573,
+      "formatted": "1,899 / 5,573",
       "note": "34.1%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 557,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5574,
+    "totalEdges": 5573,
     "edgesWithSources": 1899
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T14:45:07.863Z
+Generated: 2026-06-11T16:15:04.873Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,899 / 5,574 (34.1%) |
+| Dependency edges with edge-level sources | 1,899 / 5,573 (34.1%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-metal-coinage-bronze-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-metal-coinage-bronze-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-metal-coinage-bronze-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "metal_coinage",
+    "prerequisite": "bronze_working"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.64,
+    "evidence_level": "expert_inference",
+    "note": "Base-metal casting and working practices supported later coinage metals, but earliest Lydian electrum coins did not strictly require bronze."
+  },
+  "new_claim_absent": "No direct edge remains from metal_coinage to bronze_working; the scoped first-coinage node is anchored in Lydian/western Anatolian electrum coinage, and the museum source describes electrum, regular weights, and minting marks rather than bronze-working capability.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.money.org/money-museum/virtual-exhibits-hom-case1/",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Lydia & the First Coins, opening paragraphs describing seventh-century Asia Minor coinage as electrum lumps with regular weights and impressed marks, followed by Lydian royal coinage.",
+    "source_claim_summary": "The American Numismatic Association describes the earliest coins as electrum, a naturally occurring gold-silver alloy, with regular weights and minting impressions.",
+    "source_support_rationale": "The source supports precious-metal/electrum material capability and standardized weight as direct scope claims; it does not support bronze working as a dependency for the earliest Lydian coinage represented by this node."
+  },
+  "ontology_before": "The node included bronze working as an enabling edge despite the note stating that bronze was not required for earliest Lydian electrum coins.",
+  "ontology_after": "The node keeps precious-metal working, metal supply, and standardized weights as direct dependencies while excluding later or parallel bronze coinage traditions from the Lydian/electrum origin scope.",
+  "invariant_preserved_or_changed": "Changed: bronze_working is absent as a direct prerequisite. Preserved: metal_coinage remains scoped to regular-weight marked metal coins beginning with Lydian/western Anatolian electrum coinage.",
+  "would_reject_if": [
+    "The node were explicitly rescoped to global bronze, copper, and base-metal coinage traditions rather than the Lydian/electrum origin of coinage.",
+    "A primary or museum source showed that earliest Lydian electrum coinage depended on bronze-working tools or processes."
+  ],
+  "short_reason": "The source-backed first-coinage scope is electrum, not bronze; bronze working should not remain as an unsourced direct dependency.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/metal_coinage.before.json /tmp/metal_coinage.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-metal-coinage-scope.json
+++ b/docs/graph-invariants/2026-06-11-metal-coinage-scope.json
@@ -1,0 +1,25 @@
+{
+  "id": "2026-06-11-metal-coinage-scope",
+  "checks": [
+    {
+      "type": "direct_edge_absent",
+      "dependent": "metal_coinage",
+      "prerequisite": "bronze_working",
+      "reason": "The source-backed first-coinage scope is Lydian/western Anatolian electrum coinage, not later or parallel bronze coinage traditions."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "metal_coinage",
+      "prerequisite": "gold_and_silver_working",
+      "expected": "required",
+      "reason": "The cited museum source describes earliest coins as electrum, a naturally occurring gold-silver alloy."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "metal_coinage",
+      "prerequisite": "standardized_weights_and_measures",
+      "expected": "required",
+      "reason": "The cited museum source identifies regular weights as a defining feature of the earliest coins."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
- Removed the direct `bronze_working -> metal_coinage` dependency edge.
- Added an edge-change receipt and graph invariant to keep that edge absent for the current Lydian/electrum first-coinage scope.
- Regenerated the generated quality snapshot so total dependency edges now reads `1,899 / 5,573`.

## Old claim vs new claim
- Old: bronze working was an enabling dependency for metal coinage, while the edge note admitted earliest Lydian electrum coins did not strictly require bronze.
- New: no direct bronze-working edge remains. The node stays scoped to regular-weight marked metal coinage beginning with Lydian/western Anatolian electrum coinage.

## Source locator
- American Numismatic Association Money Museum, `Lydia & the First Coins`: opening paragraphs describing seventh-century Asia Minor coinage as electrum lumps with regular weights and impressed marks.
- URL: https://www.money.org/money-museum/virtual-exhibits-hom-case1/

## Why this is better
The source supports electrum/precious-metal capability and standardized weight as direct scope claims. It does not support bronze working as a direct dependency for the earliest coinage represented by this node. Keeping the bronze edge made later or parallel base-metal coinage look causally necessary for the Lydian/electrum origin scope.

## Adversarial note
This would be wrong if the node were deliberately rescoped to global base-metal coinage traditions, or if a stronger source showed earliest Lydian electrum coinage depended on bronze-working tools or processes.

## Validation
- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run node-snapshot-diff -- /tmp/metal_coinage.before.json /tmp/metal_coinage.after.json --require-behavior-change`
- `npm run agent:check -- --run` passed through test/quality/coverage; first `source-urls` attempt hit transient unrelated network failures.
- `npm run source-urls` passed on rerun: 729 unique URLs returned non-404/non-5xx statuses.
- `npm run accuracy:risks -- --markdown --limit 24` reports an empty manual review queue.