### PR TITLE
[codex] Tighten plumbing edge evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,899 / 5,573 (34.1%) |
+| Dependency edges with edge-level sources | 1,898 / 5,572 (34.1%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/classical.json
+++ b/data/classical.json
@@ -4247,7 +4247,6 @@
     "era": "Classical",
     "description": "Water supply and waste removal systems for buildings using pipes and channels.",
     "prerequisites": [
-      "construction",
       "aqueducts",
       "pottery",
       "hydraulics",
@@ -4259,33 +4258,11 @@
     "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
-        "prerequisite": "construction",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Construction provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "source_checked",
-        "sources": [
-          {
-            "title": "Plumbing",
-            "url": "https://www.britannica.com/technology/plumbing",
-            "publisher": "Encyclopaedia Britannica",
-            "year": 2026,
-            "source_type": "textbook",
-            "supports": [
-              "node",
-              "maturity",
-              "edge"
-            ]
-          }
-        ]
-      },
-      {
         "prerequisite": "aqueducts",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Aqueducts provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.74,
+        "evidence_level": "textbook",
+        "note": "Roman aqueducts supplied cities with potable water and could feed urban plumbing, but building plumbing can also use wells, cisterns, or local sources.",
         "reviewStatus": "source_checked",
         "sources": [
           {
@@ -4305,17 +4282,17 @@
       {
         "prerequisite": "pottery",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Pottery provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.76,
+        "evidence_level": "textbook",
+        "note": "Roman terracotta pipes show pottery as a practical pipe-material route for water supply networks; it is enabling rather than required because lead and other materials also existed.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Plumbing",
-            "url": "https://www.britannica.com/technology/plumbing",
-            "publisher": "Encyclopaedia Britannica",
+            "title": "Pottery water pipe, Roman, 100-350 CE",
+            "url": "https://collection.sciencemuseumgroup.org.uk/objects/co86051/pottery-water-pipe-roman-100-350-ce",
+            "publisher": "Science Museum Group Collection",
             "year": 2026,
-            "source_type": "textbook",
+            "source_type": "museum",
             "supports": [
               "node",
               "maturity",
@@ -4327,9 +4304,9 @@
       {
         "prerequisite": "hydraulics",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Hydraulics provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.74,
+        "evidence_level": "textbook",
+        "note": "Water distribution depends on pressure, gravity, flow, and pipe friction; hydraulic knowledge enables plumbing design without implying formal theory for every historical installation.",
         "reviewStatus": "source_checked",
         "sources": [
           {
@@ -4349,17 +4326,17 @@
       {
         "prerequisite": "lead_working",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Lead Working provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.76,
+        "evidence_level": "textbook",
+        "note": "Roman lead water pipes supplied some homes directly, making lead working an enabling material route, not a hard prerequisite for all plumbing.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Plumbing",
-            "url": "https://www.britannica.com/technology/plumbing",
-            "publisher": "Encyclopaedia Britannica",
+            "title": "Lead water pipe, Roman, 20-47 CE",
+            "url": "https://collection.sciencemuseumgroup.org.uk/objects/co84067/lead-water-pipe-roman-20-47-ce",
+            "publisher": "Science Museum Group Collection",
             "year": 2026,
-            "source_type": "textbook",
+            "source_type": "museum",
             "supports": [
               "node",
               "maturity",
@@ -4383,6 +4360,28 @@
         "publisher": "Encyclopaedia Britannica",
         "year": 2026,
         "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Pottery water pipe, Roman, 100-350 CE",
+        "url": "https://collection.sciencemuseumgroup.org.uk/objects/co86051/pottery-water-pipe-roman-100-350-ce",
+        "publisher": "Science Museum Group Collection",
+        "year": 2026,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Lead water pipe, Roman, 20-47 CE",
+        "url": "https://collection.sciencemuseumgroup.org.uk/objects/co84067/lead-water-pipe-roman-20-47-ce",
+        "publisher": "Science Museum Group Collection",
+        "year": 2026,
+        "source_type": "museum",
         "supports": [
           "node",
           "maturity"

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T16:15:04.873Z",
+  "generatedAt": "2026-06-11T16:36:15.628Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,9 +25,9 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1899,
-      "denominator": 5573,
-      "formatted": "1,899 / 5,573",
+      "value": 1898,
+      "denominator": 5572,
+      "formatted": "1,898 / 5,572",
       "note": "34.1%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 557,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5573,
-    "edgesWithSources": 1899
+    "totalEdges": 5572,
+    "edgesWithSources": 1898
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T16:15:04.873Z
+Generated: 2026-06-11T16:36:15.628Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,899 / 5,573 (34.1%) |
+| Dependency edges with edge-level sources | 1,898 / 5,572 (34.1%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-plumbing-aqueducts-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-plumbing-aqueducts-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-plumbing-aqueducts-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "plumbing",
+    "prerequisite": "aqueducts"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Aqueducts provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.74,
+    "evidence_level": "textbook",
+    "note": "Roman aqueducts supplied cities with potable water and could feed urban plumbing, but building plumbing can also use wells, cisterns, or local sources."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/technology/plumbing",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "documents_application_use",
+    "source_locator": "Plumbing article, historical paragraph noting Roman aqueducts supplied cities with potable water and contrasting city waterworks with building plumbing.",
+    "source_claim_summary": "Britannica links Roman aqueduct supply to adequate urban plumbing systems while keeping building plumbing distinct from citywide water systems.",
+    "source_support_rationale": "The passage supports aqueducts as an upstream urban water-supply enabler, not a hard prerequisite for every building-level plumbing system."
+  },
+  "invariant_preserved_or_changed": "Preserved: aqueducts remain an enabling edge, now with source-locatable rationale and higher evidence level.",
+  "would_reject_if": [
+    "A stronger source showed aqueducts were unnecessary even as an upstream enabler for the Roman urban plumbing cases represented here.",
+    "The node were rescoped to isolated well-fed household plumbing with no citywide water-supply relationship."
+  ],
+  "short_reason": "The source supports aqueducts as an urban water-supply enabler for plumbing, not as a generic placeholder edge.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-plumbing-construction-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-plumbing-construction-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-plumbing-construction-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "plumbing",
+    "prerequisite": "construction"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Construction provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from plumbing to construction; the source defines plumbing as pipes and fixtures installed in a building, but the construction node is scoped to classical monumental and civic construction rather than ordinary buildings or every built setting with water pipes.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.britannica.com/technology/plumbing",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Plumbing article, definition paragraph describing plumbing as pipes and fixtures installed in a building and distinguishing it from city water and sewage systems.",
+    "source_claim_summary": "Britannica defines plumbing as building-level pipe and fixture systems for potable water and waterborne waste removal.",
+    "source_support_rationale": "The source supports building-level scope but does not support a dependency on the neighboring node's narrower classical monumental/civic construction scope."
+  },
+  "ontology_before": "The plumbing node depended on a broad construction node whose actual scope is classical monumental and civic construction.",
+  "ontology_after": "The plumbing node keeps direct water-supply and pipe-material dependencies while no longer requiring the separate monumental/civic construction node.",
+  "invariant_preserved_or_changed": "Changed: construction is absent as a direct prerequisite. Preserved: plumbing remains a building-level water and waste pipe system, not a citywide waterworks node.",
+  "would_reject_if": [
+    "The construction node were rescoped to generic building construction rather than classical monumental/civic works.",
+    "A source showed that the earliest scoped plumbing systems specifically depended on the classical monumental construction practices represented by construction."
+  ],
+  "short_reason": "The cited plumbing definition supports buildings, not the narrower classical monumental construction node.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/plumbing.before.json /tmp/plumbing.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-plumbing-hydraulics-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-plumbing-hydraulics-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-plumbing-hydraulics-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "plumbing",
+    "prerequisite": "hydraulics"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Hydraulics provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.74,
+    "evidence_level": "textbook",
+    "note": "Water distribution depends on pressure, gravity, flow, and pipe friction; hydraulic knowledge enables plumbing design without implying formal theory for every historical installation."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/technology/plumbing",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "demonstrates_method_dependency",
+    "source_locator": "Plumbing article, water-distribution section describing pumps, gravity, pressure stabilization, and pressure/friction limits in pipes.",
+    "source_claim_summary": "Britannica explains that water distribution through plumbing is constrained by pressure and pipe friction and can use pumps, elevation, or gravity.",
+    "source_support_rationale": "The passage supports hydraulic principles as method-enabling knowledge for water distribution while avoiding a claim that every historical plumbing system used formal hydraulics."
+  },
+  "invariant_preserved_or_changed": "Preserved: hydraulics remains an enabling edge, now tied to pressure, gravity, flow, and friction rather than a generic capability note.",
+  "would_reject_if": [
+    "The node were rescoped only to purely empirical pipe-laying with no claim about water distribution design.",
+    "A source showed early plumbing systems in this scope did not rely on pressure, gravity, or flow constraints."
+  ],
+  "short_reason": "The source directly supports hydraulic distribution constraints for plumbing systems.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-plumbing-lead-working-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-plumbing-lead-working-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-plumbing-lead-working-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "plumbing",
+    "prerequisite": "lead_working"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Lead Working provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.76,
+    "evidence_level": "textbook",
+    "note": "Roman lead water pipes supplied some homes directly, making lead working an enabling material route, not a hard prerequisite for all plumbing."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://collection.sciencemuseumgroup.org.uk/objects/co84067/lead-water-pipe-roman-20-47-ce",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "documents_application_use",
+    "source_locator": "Science Museum Group object A635516, description of an inscribed Roman lead water pipe dated 20-47 CE.",
+    "source_claim_summary": "The collection record describes Roman lead water pipes supplying wealthy homes directly with water.",
+    "source_support_rationale": "The object record supports lead working as a real Roman pipe-material route for building-level water supply, while the wording keeps it enabling rather than required."
+  },
+  "invariant_preserved_or_changed": "Preserved: lead_working remains an enabling edge, now supported by a direct Roman lead water-pipe collection record.",
+  "would_reject_if": [
+    "The lead_working node were rescoped away from lead pipe fabrication capability.",
+    "The plumbing node were rescoped to exclude Roman lead-pipe house connections."
+  ],
+  "short_reason": "A Roman lead pipe object directly supports lead working as an enabling plumbing material route.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-plumbing-pottery-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-plumbing-pottery-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-plumbing-pottery-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "plumbing",
+    "prerequisite": "pottery"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Pottery provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.76,
+    "evidence_level": "textbook",
+    "note": "Roman terracotta pipes show pottery as a practical pipe-material route for water supply networks; it is enabling rather than required because lead and other materials also existed."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://collection.sciencemuseumgroup.org.uk/objects/co86051/pottery-water-pipe-roman-100-350-ce",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "documents_application_use",
+    "source_locator": "Science Museum Group object A167087, description of a Roman terracotta water pipe from York, dated 100-350 CE.",
+    "source_claim_summary": "The collection record describes Roman terracotta water pipes for supplying cities and towns and notes they were common, repairable, and cheap compared with lead pipes.",
+    "source_support_rationale": "The object record supports pottery/terracotta as an actual pipe-material route in Roman water-supply networks without making it the only possible plumbing material."
+  },
+  "invariant_preserved_or_changed": "Preserved: pottery remains an enabling edge, now supported by a direct Roman water-pipe collection record.",
+  "would_reject_if": [
+    "The pottery node were rescoped away from fired clay/ceramic manufacture.",
+    "The plumbing node were rescoped to exclude terracotta pipe systems."
+  ],
+  "short_reason": "A Roman terracotta pipe object directly supports pottery as an enabling plumbing material route.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-plumbing-edge-scope.json
+++ b/docs/graph-invariants/2026-06-11-plumbing-edge-scope.json
@@ -1,0 +1,39 @@
+{
+  "id": "2026-06-11-plumbing-edge-scope",
+  "checks": [
+    {
+      "type": "direct_edge_absent",
+      "dependent": "plumbing",
+      "prerequisite": "construction",
+      "reason": "The cited plumbing source supports building-level systems, not the narrower classical monumental/civic construction node."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "plumbing",
+      "prerequisite": "aqueducts",
+      "expected": "enabling",
+      "reason": "Aqueducts can feed urban plumbing supply but are not required for every building-level plumbing system."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "plumbing",
+      "prerequisite": "pottery",
+      "expected": "enabling",
+      "reason": "Terracotta pipes show pottery as one enabling material route, not the only possible plumbing material."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "plumbing",
+      "prerequisite": "hydraulics",
+      "expected": "enabling",
+      "reason": "Hydraulic pressure, gravity, flow, and friction enable water-distribution design without making formal hydraulics a hard prerequisite."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "plumbing",
+      "prerequisite": "lead_working",
+      "expected": "enabling",
+      "reason": "Roman lead pipes support lead working as one enabling pipe-material route, not a universal hard prerequisite."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
- Removed the direct `construction -> plumbing` edge because the cited plumbing source supports building-level systems, while `construction` is scoped to classical monumental/civic construction.
- Upgraded four remaining `plumbing` dependency edges from generic expert-inference notes to source-locatable textbook/museum evidence:
  - `aqueducts -> plumbing`
  - `hydraulics -> plumbing`
  - `pottery -> plumbing`
  - `lead_working -> plumbing`
- Added Science Museum Group object records for Roman terracotta and lead water pipes.
- Added five edge-change receipts and one graph invariant covering the new plumbing edge boundary.
- Regenerated quality snapshot: dependency edges now `1,898 / 5,572`.

## Source locators
- Britannica, `Plumbing`: definition paragraph describing building-level pipes/fixtures and historical paragraph on Roman aqueduct supply.
  https://www.britannica.com/technology/plumbing
- Science Museum Group, `Pottery water pipe, Roman, 100-350 CE`: object A167087; Roman terracotta water pipe from York; description says terracotta pipes were common and cheaper/easier to repair than lead.
  https://collection.sciencemuseumgroup.org.uk/objects/co86051/pottery-water-pipe-roman-100-350-ce
- Science Museum Group, `Lead water pipe, Roman, 20-47 CE`: object A635516; inscribed Roman lead water pipe; description says lead pipes supplied wealthy homes directly.
  https://collection.sciencemuseumgroup.org.uk/objects/co84067/lead-water-pipe-roman-20-47-ce

## Why this is better
The old node made several direct edges look equally generic. The revised node separates actual pipe-material routes from upstream urban water supply and removes a construction dependency whose neighboring node scope was too narrow for the cited claim.

## Adversarial note
This could be wrong if `construction` is later rescoped to generic building construction, or if `plumbing` is narrowed to only one regional tradition that excludes either terracotta or lead pipe routes.

## Validation
- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run node-snapshot-diff -- /tmp/plumbing.before.json /tmp/plumbing.after.json --require-behavior-change`
- `npm run agent:check -- --run`
- `npm run source-urls` passed: 731 unique URLs returned non-404/non-5xx statuses.
- `npm run accuracy:risks -- --markdown --limit 24` reports an empty manual review queue.