### PR TITLE
[codex] Tighten aqueduct siphon edge evidence

### DIFF
--- a/data/classical.json
+++ b/data/classical.json
@@ -507,10 +507,10 @@
     "dependencyEdges": [
       {
         "prerequisite": "aqueducts",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Aqueducts provides a capability that enables this technology without being the only possible path.",
+        "type": "required",
+        "confidence": 0.82,
+        "evidence_level": "textbook",
+        "note": "Inverted siphons and lead distribution pipes are scoped here as advanced aqueduct features, so an aqueduct system is a direct prerequisite rather than loose context.",
         "reviewStatus": "source_checked",
         "sources": [
           {
@@ -530,9 +530,9 @@
       {
         "prerequisite": "hydraulics",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Hydraulics provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.76,
+        "evidence_level": "textbook",
+        "note": "Inverted siphons use pressure-pipe behavior to carry water down and back up across valleys; hydraulic understanding enables the design without being the physical component.",
         "reviewStatus": "source_checked",
         "sources": [
           {
@@ -552,9 +552,9 @@
       {
         "prerequisite": "masonry",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Masonry provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.72,
+        "evidence_level": "textbook",
+        "note": "Aqueduct siphons could use masonry, brick, concrete, or stone support works such as arcades, venter bridges, tanks, and pipe sleeves; masonry enables much of the built infrastructure but is not the siphon mechanism.",
         "reviewStatus": "source_checked",
         "sources": [
           {
@@ -573,10 +573,10 @@
       },
       {
         "prerequisite": "lead_working",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Lead Working provides a capability that enables this technology without being the only possible path.",
+        "type": "required",
+        "confidence": 0.8,
+        "evidence_level": "textbook",
+        "note": "The node explicitly includes lead pipes, and Roman siphon and distribution pipework commonly used soldered lead pipes, so lead working is required for this combined lead-pipe scope.",
         "reviewStatus": "source_checked",
         "sources": [
           {
@@ -593,7 +593,8 @@
           }
         ]
       }
-    ]
+    ],
+    "scopeNote": "Covers advanced aqueduct pressure-pipe sections and distribution pipework, especially inverted siphons and lead-pipe use. It does not claim that every aqueduct used siphons or lead pipes, nor that ceramic or stone pressure pipes were absent."
   },
   {
     "id": "aqueducts",

--- a/docs/edge-change-receipts/2026-06-11-aqueduct-siphons-aqueducts-required.json
+++ b/docs/edge-change-receipts/2026-06-11-aqueduct-siphons-aqueducts-required.json
@@ -1,0 +1,46 @@
+{
+  "id": "2026-06-11-aqueduct-siphons-aqueducts-required",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "aqueduct_siphons_lead_pipes",
+    "prerequisite": "aqueducts"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Aqueducts provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.82,
+    "evidence_level": "textbook",
+    "note": "Inverted siphons and lead distribution pipes are scoped here as advanced aqueduct features, so an aqueduct system is a direct prerequisite rather than loose context."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/technology/aqueduct-engineering",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Aqueduct article, sections on bridgework, siphons, tunnels, and distribution describing inverted siphons, aqueduct conduits, and lead or ceramic pipes.",
+    "source_claim_summary": "Britannica describes inverted siphons and distribution pipes as parts of aqueduct engineering systems.",
+    "source_support_rationale": "Because the dependent node is scoped as advanced aqueduct siphons and pipework, the aqueduct system is not merely contextual."
+  },
+  "ontology_before": "The edge treated aqueducts as a generic enabler for an advanced aqueduct-specific node.",
+  "ontology_after": "The edge now models aqueducts as the parent system required by aqueduct siphons and distribution pipework.",
+  "invariant_preserved_or_changed": "Changed: aqueducts is now required. Preserved: the dependent node remains an advanced aqueduct feature, not generic plumbing.",
+  "would_reject_if": [
+    "The node were rescoped away from aqueduct systems to generic pressure pipes.",
+    "A source showed the named siphon/lead-pipe technologies were independent of aqueduct engineering."
+  ],
+  "short_reason": "Aqueduct siphons and lead distribution pipes are advanced features of aqueduct systems.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/aqueduct_siphons_lead_pipes.before.json /tmp/aqueduct_siphons_lead_pipes.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-aqueduct-siphons-hydraulics-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-aqueduct-siphons-hydraulics-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-aqueduct-siphons-hydraulics-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "aqueduct_siphons_lead_pipes",
+    "prerequisite": "hydraulics"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Hydraulics provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.76,
+    "evidence_level": "textbook",
+    "note": "Inverted siphons use pressure-pipe behavior to carry water down and back up across valleys; hydraulic understanding enables the design without being the physical component."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/technology/aqueduct-engineering",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "demonstrates_method_dependency",
+    "source_locator": "Aqueduct article, bridgework/siphons/tunnels section describing header tanks, pipes crossing valleys, receiving tanks, maintained gradients, and pressure problems.",
+    "source_claim_summary": "Britannica describes inverted siphons as pressure-pipe systems used to cross valleys while maintaining an overall aqueduct gradient.",
+    "source_support_rationale": "The passage supports hydraulic behavior as method-enabling knowledge, but the physical system still consists of aqueduct structures and pipes."
+  },
+  "invariant_preserved_or_changed": "Preserved: hydraulics remains an enabling edge, now with source-locatable pressure-pipe rationale.",
+  "would_reject_if": [
+    "The node were rescoped to non-pressure open-channel aqueduct conduits only.",
+    "A source showed inverted siphons did not rely on pressure-pipe behavior."
+  ],
+  "short_reason": "Inverted siphons are pressure-pipe aqueduct features, so hydraulics is an enabling method dependency.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-aqueduct-siphons-lead-working-required.json
+++ b/docs/edge-change-receipts/2026-06-11-aqueduct-siphons-lead-working-required.json
@@ -1,0 +1,46 @@
+{
+  "id": "2026-06-11-aqueduct-siphons-lead-working-required",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "aqueduct_siphons_lead_pipes",
+    "prerequisite": "lead_working"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Lead Working provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.8,
+    "evidence_level": "textbook",
+    "note": "The node explicitly includes lead pipes, and Roman siphon and distribution pipework commonly used soldered lead pipes, so lead working is required for this combined lead-pipe scope."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/technology/aqueduct-engineering",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Aqueduct article, bridgework/siphons/tunnels and distribution sections describing soldered lead siphon pipes and lead or ceramic distribution pipes.",
+    "source_claim_summary": "Britannica describes soldered lead pipes as usual siphon pipes and lead pipes as part of aqueduct distribution systems.",
+    "source_support_rationale": "Because the node title and description explicitly include lead pipes, lead-working capability is a direct prerequisite for the combined lead-pipe scope, while the scope note avoids claiming all aqueduct siphons used lead."
+  },
+  "ontology_before": "The edge treated lead working as a generic enabler even though the node explicitly included lead pipes.",
+  "ontology_after": "The edge now treats lead working as required for the combined lead-pipe scope while acknowledging other pressure-pipe materials in the scope note.",
+  "invariant_preserved_or_changed": "Changed: lead_working is now required for the lead-pipe part of this combined node. Preserved: the node still admits non-lead ceramic or stone pressure pipes in the broader aqueduct record.",
+  "would_reject_if": [
+    "The node were split so inverted siphons and lead distribution pipes became separate nodes.",
+    "The node were rescoped to pressure-pipe aqueducts regardless of material, dropping the explicit lead-pipe claim."
+  ],
+  "short_reason": "A node explicitly covering lead pipes should require lead-working capability for that subclaim.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/aqueduct_siphons_lead_pipes.before.json /tmp/aqueduct_siphons_lead_pipes.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-aqueduct-siphons-masonry-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-aqueduct-siphons-masonry-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-aqueduct-siphons-masonry-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "aqueduct_siphons_lead_pipes",
+    "prerequisite": "masonry"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Masonry provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.72,
+    "evidence_level": "textbook",
+    "note": "Aqueduct siphons could use masonry, brick, concrete, or stone support works such as arcades, venter bridges, tanks, and pipe sleeves; masonry enables much of the built infrastructure but is not the siphon mechanism."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/technology/aqueduct-engineering",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Aqueduct article, bridgework/siphons/tunnels section describing masonry, brick, or concrete arcades, venter bridges, tanks, concrete encasements, and stone sleeves.",
+    "source_claim_summary": "Britannica describes aqueduct siphon support and protection works using masonry-related structures and materials.",
+    "source_support_rationale": "The source supports masonry as built-infrastructure support rather than as the pressure-pipe mechanism itself."
+  },
+  "invariant_preserved_or_changed": "Preserved: masonry remains an enabling edge, now scoped to support works rather than generic construction capability.",
+  "would_reject_if": [
+    "The node were rescoped to pipe-only siphons with no tanks, bridges, encasement, sleeves, or built support works.",
+    "A source showed masonry support works were irrelevant to the Hellenistic/Roman siphon examples represented here."
+  ],
+  "short_reason": "Masonry enables aqueduct siphon support and protection works without being the siphon mechanism.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-aqueduct-siphons-edge-scope.json
+++ b/docs/graph-invariants/2026-06-11-aqueduct-siphons-edge-scope.json
@@ -1,0 +1,33 @@
+{
+  "id": "2026-06-11-aqueduct-siphons-edge-scope",
+  "checks": [
+    {
+      "type": "edge_type",
+      "dependent": "aqueduct_siphons_lead_pipes",
+      "prerequisite": "aqueducts",
+      "expected": "required",
+      "reason": "The node is scoped as advanced aqueduct siphons and pipework, so an aqueduct system is a direct prerequisite."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "aqueduct_siphons_lead_pipes",
+      "prerequisite": "hydraulics",
+      "expected": "enabling",
+      "reason": "Hydraulic pressure-pipe behavior enables inverted siphons without being the physical aqueduct component."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "aqueduct_siphons_lead_pipes",
+      "prerequisite": "masonry",
+      "expected": "enabling",
+      "reason": "Masonry enables support and protection works such as arcades, tanks, bridges, encasements, and sleeves."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "aqueduct_siphons_lead_pipes",
+      "prerequisite": "lead_working",
+      "expected": "required",
+      "reason": "The current combined node explicitly includes lead pipes, so lead working is required for the lead-pipe subclaim."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
- Tightened `aqueduct_siphons_lead_pipes` direct dependency semantics.
- Retyped:
  - `aqueducts -> aqueduct_siphons_lead_pipes` from `enabling` to `required`.
  - `lead_working -> aqueduct_siphons_lead_pipes` from `enabling` to `required` for the current combined lead-pipe scope.
- Upgraded `hydraulics` and `masonry` edge notes/evidence from generic expert inference to source-locatable textbook rationale.
- Added a `scopeNote` clarifying that the node covers advanced pressure-pipe aqueduct sections and lead-pipe use, not every aqueduct or every pressure-pipe material.
- Added four edge-change receipts and one graph invariant.

## Source locator
- Britannica, `Aqueduct`: bridgework/siphons/tunnels and distribution sections describing inverted siphons, lead or ceramic pipes, masonry/brick/concrete support works, header/receiving tanks, maintained gradients, and pressure problems.
  https://www.britannica.com/technology/aqueduct-engineering

## Why this is better
The old node used four generic `enabling` edges even though the node itself is an advanced aqueduct subtechnology. The revised edges separate parent-system requirements (`aqueducts`, lead-pipe scope needing `lead_working`) from method/support enablers (`hydraulics`, `masonry`).

## Adversarial note
The strongest reason this could be wrong is that the node should eventually be split into separate `inverted_aqueduct_siphons` and `lead_water_distribution_pipes` nodes. Until that split happens, the scope note makes the combined-node boundary explicit.

## Validation
- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run node-snapshot-diff -- /tmp/aqueduct_siphons_lead_pipes.before.json /tmp/aqueduct_siphons_lead_pipes.after.json --require-behavior-change`
- `npm run agent:check -- --run` passed through test/quality/coverage; first `source-urls` attempt hit an unrelated transient timeout.
- `npm run source-urls` passed on rerun: 731 unique URLs returned non-404/non-5xx statuses.