### PR TITLE
[codex] Tighten water distribution edge evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,898 / 5,572 (34.1%) |
+| Dependency edges with edge-level sources | 1,897 / 5,571 (34.1%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/classical.json
+++ b/data/classical.json
@@ -7563,7 +7563,6 @@
     "description": "Pipe networks, valves, tanks, and gradients used to move water from aqueducts and reservoirs into baths, fountains, homes, and workshops.",
     "prerequisites": [
       "aqueducts",
-      "sewers_and_drainage",
       "concrete"
     ],
     "firstKnownDate": -300,
@@ -7574,31 +7573,9 @@
       {
         "prerequisite": "aqueducts",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Aqueducts provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "source_checked",
-        "sources": [
-          {
-            "title": "Water Supply System",
-            "url": "https://www.britannica.com/technology/water-supply-system",
-            "publisher": "Encyclopaedia Britannica",
-            "year": 2026,
-            "source_type": "textbook",
-            "supports": [
-              "node",
-              "maturity",
-              "edge"
-            ]
-          }
-        ]
-      },
-      {
-        "prerequisite": "sewers_and_drainage",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Sewers and Drainage provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.76,
+        "evidence_level": "textbook",
+        "note": "Roman aqueducts ended at distribution reservoirs from which water was conveyed to baths, fountains, and some homes; aqueducts are an upstream supply enabler, not the only possible water source.",
         "reviewStatus": "source_checked",
         "sources": [
           {
@@ -7618,9 +7595,9 @@
       {
         "prerequisite": "concrete",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Concrete provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.7,
+        "evidence_level": "textbook",
+        "note": "Ancient water-conveyance channels could be built of cut stone, brick, rubble, or rough concrete; concrete enables some distribution infrastructure but is not a universal pipe material.",
         "reviewStatus": "source_checked",
         "sources": [
           {
@@ -7657,7 +7634,8 @@
           "maturity"
         ]
       }
-    ]
+    ],
+    "scopeNote": "Covers clean-water conveyance and distribution from aqueducts or reservoirs to users. It excludes wastewater drainage and sewer flushing, which may use surplus water but are not prerequisites for water distribution pipes."
   },
   {
     "id": "municipal_building_codes",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T16:36:15.628Z",
+  "generatedAt": "2026-06-11T16:48:29.252Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,9 +25,9 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1898,
-      "denominator": 5572,
-      "formatted": "1,898 / 5,572",
+      "value": 1897,
+      "denominator": 5571,
+      "formatted": "1,897 / 5,571",
       "note": "34.1%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 557,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5572,
-    "edgesWithSources": 1898
+    "totalEdges": 5571,
+    "edgesWithSources": 1897
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T16:36:15.628Z
+Generated: 2026-06-11T16:48:29.252Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,898 / 5,572 (34.1%) |
+| Dependency edges with edge-level sources | 1,897 / 5,571 (34.1%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-water-distribution-aqueducts-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-water-distribution-aqueducts-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-water-distribution-aqueducts-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "water_distribution_pipes",
+    "prerequisite": "aqueducts"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Aqueducts provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.76,
+    "evidence_level": "textbook",
+    "note": "Roman aqueducts ended at distribution reservoirs from which water was conveyed to baths, fountains, and some homes; aqueducts are an upstream supply enabler, not the only possible water source."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/technology/water-supply-system",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "documents_application_use",
+    "source_locator": "Water Supply System article, historical background section on Roman aqueducts ending at distribution reservoirs and conveying water to baths, fountains, and some homes.",
+    "source_claim_summary": "Britannica describes aqueduct-fed distribution reservoirs and pipes conveying water to urban users.",
+    "source_support_rationale": "The passage supports aqueducts as an upstream water-supply enabler for distribution pipes while leaving room for reservoirs and other local supply routes."
+  },
+  "invariant_preserved_or_changed": "Preserved: aqueducts remains an enabling edge, now with source-locatable rationale.",
+  "would_reject_if": [
+    "The node were narrowed to non-aqueduct local water distribution only.",
+    "A stronger source showed the represented classical distribution pipes were independent of aqueduct or reservoir supply."
+  ],
+  "short_reason": "Aqueducts fed distribution reservoirs and pipes but were not the only possible water source.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-water-distribution-concrete-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-water-distribution-concrete-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-water-distribution-concrete-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "water_distribution_pipes",
+    "prerequisite": "concrete"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Concrete provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.7,
+    "evidence_level": "textbook",
+    "note": "Ancient water-conveyance channels could be built of cut stone, brick, rubble, or rough concrete; concrete enables some distribution infrastructure but is not a universal pipe material."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/technology/water-supply-system",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Water Supply System article, historical background section stating channels were constructed of cut stone, brick, rubble, or rough concrete and pipes were made of drilled stone, hollowed wood, clay, or lead.",
+    "source_claim_summary": "Britannica identifies rough concrete as one possible ancient channel material and distinguishes it from pipe materials such as stone, wood, clay, and lead.",
+    "source_support_rationale": "The passage supports concrete as an enabling material for some conveyance infrastructure, not as a required pipe technology."
+  },
+  "invariant_preserved_or_changed": "Preserved: concrete remains an enabling edge, now scoped to channels and associated infrastructure rather than a universal pipe prerequisite.",
+  "would_reject_if": [
+    "The node were rescoped strictly to pipes with no channels, tanks, or reservoir distribution infrastructure.",
+    "A stronger source showed concrete was absent from the classical distribution infrastructure represented here."
+  ],
+  "short_reason": "Concrete is one possible ancient water-conveyance material, not a universal distribution-pipe requirement.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-water-distribution-sewers-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-water-distribution-sewers-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-water-distribution-sewers-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "water_distribution_pipes",
+    "prerequisite": "sewers_and_drainage"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Sewers and Drainage provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from water_distribution_pipes to sewers_and_drainage; the source treats Roman distribution reservoirs and pipes as water-supply infrastructure, while sewers are downstream recipients of excess water used for street cleaning and sewer flushing.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.britannica.com/technology/water-supply-system",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Water Supply System article, historical background section describing aqueducts ending at distribution reservoirs and excess water being used to clean streets and flush sewers.",
+    "source_claim_summary": "Britannica describes sewers as a downstream use of excess aqueduct water, not as a prerequisite for distribution reservoirs or pipes.",
+    "source_support_rationale": "The passage supports the opposite direction of relationship: distribution water can flush sewers, but sewers do not enable clean-water distribution pipes."
+  },
+  "ontology_before": "The node modeled sewers and drainage as an enabling prerequisite for clean-water distribution pipes.",
+  "ontology_after": "The clean-water distribution node no longer depends on wastewater drainage infrastructure; the scope note explicitly separates supply distribution from sewer flushing.",
+  "invariant_preserved_or_changed": "Changed: sewers_and_drainage is absent as a direct prerequisite. Preserved: water_distribution_pipes remains a clean-water conveyance and distribution node.",
+  "would_reject_if": [
+    "The node were rescoped to combined water supply and wastewater drainage networks rather than clean-water distribution.",
+    "A stronger source showed classical clean-water distribution pipes required pre-existing sewer infrastructure."
+  ],
+  "short_reason": "Sewers are downstream recipients of surplus water, not prerequisites for water distribution pipes.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/water_distribution_pipes.before.json /tmp/water_distribution_pipes.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-water-distribution-edge-scope.json
+++ b/docs/graph-invariants/2026-06-11-water-distribution-edge-scope.json
@@ -1,0 +1,25 @@
+{
+  "id": "2026-06-11-water-distribution-edge-scope",
+  "checks": [
+    {
+      "type": "direct_edge_absent",
+      "dependent": "water_distribution_pipes",
+      "prerequisite": "sewers_and_drainage",
+      "reason": "Sewers are downstream recipients of excess distribution water, not prerequisites for clean-water distribution pipes."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "water_distribution_pipes",
+      "prerequisite": "aqueducts",
+      "expected": "enabling",
+      "reason": "Aqueducts can feed distribution reservoirs and pipes but are not the only possible water source."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "water_distribution_pipes",
+      "prerequisite": "concrete",
+      "expected": "enabling",
+      "reason": "Concrete can enable some channels and associated distribution infrastructure but is not a universal pipe material."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
- Removed `sewers_and_drainage -> water_distribution_pipes`.
- Upgraded `aqueducts -> water_distribution_pipes` and `concrete -> water_distribution_pipes` from generic expert-inference notes to source-locatable textbook evidence.
- Added a scope note separating clean-water conveyance/distribution from wastewater drainage and sewer flushing.
- Added three edge-change receipts and one graph invariant.
- Regenerated the quality snapshot: dependency edges now `1,897 / 5,571`.

## Old claim vs new claim
- Old: sewers and drainage enabled water distribution pipes.
- New: no direct sewer prerequisite remains. Britannica describes excess aqueduct water being used to clean streets and flush sewers, which is downstream from clean-water distribution rather than a prerequisite.

- Old: aqueducts and concrete had generic enabling notes.
- New: aqueducts are an upstream supply enabler via distribution reservoirs; concrete is only one possible ancient conveyance/channel material, not a universal pipe material.

## Source locator
- Britannica, `Water Supply System`, historical background section:
  - Roman aqueducts ended at distribution reservoirs, from which water was conveyed to public baths, fountains, and some homes.
  - Excess water was used to clean streets and flush sewers.
  - Ancient channels could be cut stone, brick, rubble, or rough concrete; pipes could be drilled stone, hollowed wood, clay, or lead.
- URL: https://www.britannica.com/technology/water-supply-system

## Why this is better
The previous graph made wastewater drainage look causally upstream of clean-water distribution. The revised node preserves useful aqueduct and concrete relationships while removing that reversed/contextual edge.

## Adversarial note
This would be wrong if the node were intentionally rescoped to combined supply-and-wastewater urban water networks, or if a stronger source showed classical clean-water distribution required pre-existing sewers.

## Validation
- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run node-snapshot-diff -- /tmp/water_distribution_pipes.before.json /tmp/water_distribution_pipes.after.json --require-behavior-change`
- `npm run agent:check -- --run`
- `npm run source-urls` passed: 731 unique URLs returned non-404/non-5xx statuses.
- `npm run quality` passed after regenerating the final quality snapshot.
- `npm run accuracy:risks -- --markdown --limit 24` reports an empty manual review queue.