### PR TITLE
[codex] Rescope civic water meters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,897 / 5,571 (34.1%) |
+| Dependency edges with edge-level sources | 1,896 / 5,570 (34.0%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/classical.json
+++ b/data/classical.json
@@ -9833,54 +9833,31 @@
   },
   {
     "id": "civic_water_meters",
-    "name": "Early Civic Water Meters",
+    "name": "Civic Water Allotment Gauges",
     "era": "Classical",
-    "description": "Regulated outlets, calibrated pipes, permits, and fees for distributing public water to baths, fountains, homes, and workshops.",
+    "description": "Roman water-allotment practice using delivery tanks, calibrated pipe bores such as the quinaria, official records, and legal grants to allocate public water.",
     "prerequisites": [
       "water_distribution_pipes",
-      "portable_scales",
       "public_archives"
     ],
-    "firstKnownDate": -300,
+    "firstKnownDate": -50,
     "datePrecision": "century",
-    "region": "Mediterranean, South Asia, East Asia, and other classical societies",
+    "region": "Rome / Roman aqueduct administration",
     "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "water_distribution_pipes",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Water Distribution Pipes provides a capability that enables this technology without being the only possible path.",
+        "type": "required",
+        "confidence": 0.82,
+        "evidence_level": "primary_source",
+        "note": "Frontinus describes water allotments through delivery tanks, pipe bores, and quinariae; the allotment gauge system requires an operating distribution-pipe network.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Water Supply System",
-            "url": "https://www.britannica.com/technology/water-supply-system",
-            "publisher": "Encyclopaedia Britannica",
-            "year": 2026,
-            "source_type": "textbook",
-            "supports": [
-              "node",
-              "maturity",
-              "edge"
-            ]
-          }
-        ]
-      },
-      {
-        "prerequisite": "portable_scales",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Portable Balance Scales provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "source_checked",
-        "sources": [
-          {
-            "title": "Water Supply System",
-            "url": "https://www.britannica.com/technology/water-supply-system",
-            "publisher": "Encyclopaedia Britannica",
-            "year": 2026,
+            "title": "Frontinus, The Water Supply of the City of Rome",
+            "url": "https://waters.iath.virginia.edu/frontinus.html",
+            "publisher": "University of Virginia Institute for Advanced Technology in the Humanities",
+            "year": 2003,
             "source_type": "textbook",
             "supports": [
               "node",
@@ -9892,17 +9869,17 @@
       },
       {
         "prerequisite": "public_archives",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Public Archives provides a capability that enables this technology without being the only possible path.",
+        "type": "common_dependency",
+        "confidence": 0.74,
+        "evidence_level": "primary_source",
+        "note": "Frontinus compares pipe gauges and water allotments against official records; public recordkeeping is contextual administrative infrastructure, not a physical meter component.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Water Supply System",
-            "url": "https://www.britannica.com/technology/water-supply-system",
-            "publisher": "Encyclopaedia Britannica",
-            "year": 2026,
+            "title": "Frontinus, The Water Supply of the City of Rome",
+            "url": "https://waters.iath.virginia.edu/frontinus.html",
+            "publisher": "University of Virginia Institute for Advanced Technology in the Humanities",
+            "year": 2003,
             "source_type": "textbook",
             "supports": [
               "node",
@@ -9931,8 +9908,21 @@
           "node",
           "maturity"
         ]
+      },
+      {
+        "title": "Frontinus, The Water Supply of the City of Rome",
+        "url": "https://waters.iath.virginia.edu/frontinus.html",
+        "publisher": "University of Virginia Institute for Advanced Technology in the Humanities",
+        "year": 2003,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity",
+          "edge"
+        ]
       }
-    ]
+    ],
+    "scopeNote": "Covers Roman allotment gauges and administrative pipe-caliber accounting, especially quinaria-based delivery records. It is not a modern volumetric or velocity-compensated water meter."
   },
   {
     "id": "military_road_waystations",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T16:48:29.252Z",
+  "generatedAt": "2026-06-11T16:55:52.595Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,10 +25,10 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1897,
-      "denominator": 5571,
-      "formatted": "1,897 / 5,571",
-      "note": "34.1%"
+      "value": 1896,
+      "denominator": 5570,
+      "formatted": "1,896 / 5,570",
+      "note": "34.0%"
     },
     {
       "label": "Era-default placeholder dates",
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 557,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5571,
-    "edgesWithSources": 1897
+    "totalEdges": 5570,
+    "edgesWithSources": 1896
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T16:48:29.252Z
+Generated: 2026-06-11T16:55:52.595Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,897 / 5,571 (34.1%) |
+| Dependency edges with edge-level sources | 1,896 / 5,570 (34.0%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-civic-water-meters-archives-common.json
+++ b/docs/edge-change-receipts/2026-06-11-civic-water-meters-archives-common.json
@@ -1,0 +1,46 @@
+{
+  "id": "2026-06-11-civic-water-meters-archives-common",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "civic_water_meters",
+    "prerequisite": "public_archives"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Public Archives provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "common_dependency",
+    "confidence": 0.74,
+    "evidence_level": "primary_source",
+    "note": "Frontinus compares pipe gauges and water allotments against official records; public recordkeeping is contextual administrative infrastructure, not a physical meter component."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://waters.iath.virginia.edu/frontinus.html",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Frontinus, section 25 describing ajutages verified in imperial records, and distribution sections listing allocated quinariae by category and ward.",
+    "source_claim_summary": "Frontinus repeatedly relates water allotment gauges and quantities to official records and schedules.",
+    "source_support_rationale": "The source supports public records as administrative context for water allotments, but not as a physical prerequisite for the gauge itself."
+  },
+  "ontology_before": "The edge treated public archives as a generic enabling technology.",
+  "ontology_after": "The edge now models public records as contextual administrative infrastructure shared by civic utility accounting.",
+  "invariant_preserved_or_changed": "Changed: edge type is common_dependency. Preserved: administrative records remain connected to the allotment-gauge node.",
+  "would_reject_if": [
+    "The node were scoped only to physical pipe bores with no administrative allotment records.",
+    "A source showed public records were not part of Roman water allotment administration."
+  ],
+  "short_reason": "Records support civic water allotment administration but are not a physical meter component.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/civic_water_meters.before.json /tmp/civic_water_meters.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-civic-water-meters-distribution-required.json
+++ b/docs/edge-change-receipts/2026-06-11-civic-water-meters-distribution-required.json
@@ -1,0 +1,46 @@
+{
+  "id": "2026-06-11-civic-water-meters-distribution-required",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "civic_water_meters",
+    "prerequisite": "water_distribution_pipes"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Water Distribution Pipes provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.82,
+    "evidence_level": "primary_source",
+    "note": "Frontinus describes water allotments through delivery tanks, pipe bores, and quinariae; the allotment gauge system requires an operating distribution-pipe network."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://waters.iath.virginia.edu/frontinus.html",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Frontinus, sections 19, 25, 78-88, and 105 describing catch basins, delivery tanks, quinariae, city distribution, and restrictions on pipe size from delivery tanks.",
+    "source_claim_summary": "Frontinus describes water measurement and allotment through delivery tanks, pipe sizes, and quinariae within Rome's distribution system.",
+    "source_support_rationale": "The allotment gauge concept is part of the physical distribution-pipe network, so distribution pipes are a direct prerequisite for the scoped node."
+  },
+  "ontology_before": "The edge treated water distribution pipes as a generic enabler for civic metering.",
+  "ontology_after": "The edge now treats distribution pipes and delivery tanks as required physical infrastructure for pipe-bore water allotment gauges.",
+  "invariant_preserved_or_changed": "Changed: water_distribution_pipes is now required. Preserved: the node remains about civic water allocation rather than generic plumbing.",
+  "would_reject_if": [
+    "The node were rescoped to a purely administrative fee schedule without physical gauges or distribution pipes.",
+    "A source showed quinaria-based allotments were independent of distribution tanks and pipes."
+  ],
+  "short_reason": "Pipe-bore water allotment gauges require a distribution-pipe system.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/civic_water_meters.before.json /tmp/civic_water_meters.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-civic-water-meters-portable-scales-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-civic-water-meters-portable-scales-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-civic-water-meters-portable-scales-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "civic_water_meters",
+    "prerequisite": "portable_scales"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Portable Balance Scales provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from civic_water_meters to portable_scales; Frontinus describes Roman water allotments in terms of pipe bores, delivery tanks, quinariae, and records, not weighing devices or balance scales.",
+  "source_supports_edge": "no",
+  "source_url": "https://waters.iath.virginia.edu/frontinus.html",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Frontinus, The Water Supply of the City of Rome, sections 19, 25, 78-88, and 105 describing gauges, quinariae, delivery tanks, pipe-size limits, and records.",
+    "source_claim_summary": "Frontinus describes water allocation and measurement through pipe gauges and administrative records rather than portable weighing scales.",
+    "source_support_rationale": "The source supports a pipe-caliber/allotment system and gives no basis for balance scales as a prerequisite."
+  },
+  "ontology_before": "The node implied portable weighing scales enabled civic water metering.",
+  "ontology_after": "The node is scoped to pipe-bore allotment gauges and administrative records, with no weighing-scale dependency.",
+  "invariant_preserved_or_changed": "Changed: portable_scales is absent as a direct prerequisite. Preserved: the node still represents civic water allocation and monitoring.",
+  "would_reject_if": [
+    "A stronger source showed Roman civic water allotment gauges used portable balance scales.",
+    "The node were rescoped to commodity weighing or fee collection rather than pipe-bore water allotment."
+  ],
+  "short_reason": "Frontinus supports pipe-caliber water allotment, not weighing scales.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/civic_water_meters.before.json /tmp/civic_water_meters.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-civic-water-meters-scope.json
+++ b/docs/graph-invariants/2026-06-11-civic-water-meters-scope.json
@@ -1,0 +1,32 @@
+{
+  "id": "2026-06-11-civic-water-meters-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "civic_water_meters",
+      "operator": "eq",
+      "value": -50,
+      "reason": "The node is scoped to Roman quinaria/ajutage allotment gauges associated with late Republican or early Imperial water administration, not a broad 300 BCE metering technology."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "civic_water_meters",
+      "prerequisite": "portable_scales",
+      "reason": "Frontinus describes pipe bores, quinariae, delivery tanks, and records rather than weighing scales."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "civic_water_meters",
+      "prerequisite": "water_distribution_pipes",
+      "expected": "required",
+      "reason": "Pipe-bore allotment gauges require a distribution network and delivery tanks."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "civic_water_meters",
+      "prerequisite": "public_archives",
+      "expected": "common_dependency",
+      "reason": "Official records support allotment administration but are not the physical gauge component."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
- Renamed `civic_water_meters` display name from `Early Civic Water Meters` to `Civic Water Allotment Gauges`.
- Rescoped the node to Roman quinaria/ajutage pipe-bore allotment practice rather than modern-style water meters.
- Corrected chronology from broad `-300` to late Republican / early Imperial Roman administration (`firstKnownDate: -50`, century precision).
- Removed the unsupported `portable_scales` prerequisite.
- Retyped:
  - `water_distribution_pipes -> civic_water_meters` to `required`.
  - `public_archives -> civic_water_meters` to `common_dependency`.
- Added Frontinus as the source anchor plus three edge-change receipts and one invariant.
- Regenerated the quality snapshot: dependency edges now `1,896 / 5,570`.

## Source locators
- Frontinus, `The Water Supply of the City of Rome`, sections 19, 25, 78-88, and 105: gauges, quinariae, delivery tanks, distribution quantities, pipe-size limits, and records.
  https://waters.iath.virginia.edu/frontinus.html
- Britannica, `Water Supply System`, Roman aqueduct/distribution background.
  https://www.britannica.com/technology/water-supply-system

## Why this is better
The old node title implied a modern meter and had an unsupported scales dependency. The revised node says what the sources actually support: Roman pipe-caliber allotment and administrative accounting, not volumetric or velocity-compensated metering.

## Adversarial note
This could be wrong if the project wants a broad node for all ancient water-meter-like devices rather than the Roman Frontinus/quinaria system. In that case this should become a split: one Roman allotment-gauge node and a separate broader historical water-meter node.

## Validation
- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run node-snapshot-diff -- /tmp/civic_water_meters.before.json /tmp/civic_water_meters.after.json --require-behavior-change`
- `npm run agent:check -- --run` passed through test/quality/coverage; first URL audit hit an unrelated transient CableLabs timeout.
- `npm run source-urls` passed on rerun: 732 unique URLs returned non-404/non-5xx statuses.
- `npm run quality` passed after regenerating the final quality snapshot.
- `npm run accuracy:risks -- --markdown --limit 24` reports an empty manual review queue.