### PR TITLE
[codex] Tighten public latrines evidence

### DIFF
--- a/data/classical.json
+++ b/data/classical.json
@@ -7833,30 +7833,30 @@
     "id": "public_latrines",
     "name": "Public Latrines",
     "era": "Classical",
-    "description": "Shared sanitation facilities connected to drains, water channels, cleaning routines, and dense urban public health systems.",
+    "description": "Roman-style shared sanitation facilities, often near baths or markets, using drain channels and water flow to carry waste into sewers or disposal systems.",
     "prerequisites": [
       "sewers_and_drainage",
       "water_distribution_pipes"
     ],
     "firstKnownDate": -200,
     "datePrecision": "century",
-    "region": "Mediterranean and other classical cities",
+    "region": "Roman cities, forts, and bath complexes",
     "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "sewers_and_drainage",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Sewers and Drainage provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.76,
+        "evidence_level": "review",
+        "note": "Roman public toilets were commonly tied to sewer or drainage systems that carried waste away; drainage enables the scoped public-latrine system without proving every latrine was sewer-connected.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Sanitation Safety",
-            "url": "https://www.who.int/teams/environment-climate-change-and-health/water-sanitation-and-health/sanitation-safety",
-            "publisher": "World Health Organization",
-            "year": 2026,
-            "source_type": "official_agency",
+            "title": "The Aqueducts and Water Supply of Ancient Rome",
+            "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7004096/",
+            "publisher": "Groundwater / PubMed Central",
+            "year": 2020,
+            "source_type": "review",
             "supports": [
               "node",
               "maturity",
@@ -7868,17 +7868,17 @@
       {
         "prerequisite": "water_distribution_pipes",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Water Distribution Pipes provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.74,
+        "evidence_level": "review",
+        "note": "Roman public toilets were commonly connected to city water systems or flushed by bath wastewater, making water distribution an enabling supply path rather than a universal hard prerequisite.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Sanitation Safety",
-            "url": "https://www.who.int/teams/environment-climate-change-and-health/water-sanitation-and-health/sanitation-safety",
-            "publisher": "World Health Organization",
-            "year": 2026,
-            "source_type": "official_agency",
+            "title": "The Aqueducts and Water Supply of Ancient Rome",
+            "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7004096/",
+            "publisher": "Groundwater / PubMed Central",
+            "year": 2020,
+            "source_type": "review",
             "supports": [
               "node",
               "maturity",
@@ -7897,17 +7897,19 @@
     "maturity": "established",
     "sources": [
       {
-        "title": "Sanitation Safety",
-        "url": "https://www.who.int/teams/environment-climate-change-and-health/water-sanitation-and-health/sanitation-safety",
-        "publisher": "World Health Organization",
-        "year": 2026,
-        "source_type": "official_agency",
+        "title": "The Aqueducts and Water Supply of Ancient Rome",
+        "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7004096/",
+        "publisher": "Groundwater / PubMed Central",
+        "year": 2020,
+        "source_type": "review",
         "supports": [
           "node",
-          "maturity"
+          "maturity",
+          "edge"
         ]
       }
-    ]
+    ],
+    "scopeNote": "Covers Roman-style public latrines integrated with water supply and drainage infrastructure. It does not claim that every ancient latrine was public, sewer-connected, or continuously flushed."
   },
   {
     "id": "glass_window_panes",

--- a/docs/edge-change-receipts/2026-06-11-public-latrines-sewers-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-public-latrines-sewers-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-public-latrines-sewers-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "public_latrines",
+    "prerequisite": "sewers_and_drainage"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Sewers and Drainage provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.76,
+    "evidence_level": "review",
+    "note": "Roman public toilets were commonly tied to sewer or drainage systems that carried waste away; drainage enables the scoped public-latrine system without proving every latrine was sewer-connected."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7004096/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "documents_application_use",
+    "source_locator": "The Aqueducts and Water Supply of Ancient Rome, Roman public toilets discussion noting public toilets near markets or baths and connections to city water systems and sewers.",
+    "source_claim_summary": "The review describes Roman public toilets as commonly located near baths or markets and almost always connected to city water systems and sewers.",
+    "source_support_rationale": "The source directly supports sewers/drainage as infrastructure enabling Roman public latrines, while the wording avoids a universal hard-prerequisite claim."
+  },
+  "invariant_preserved_or_changed": "Preserved: sewers_and_drainage remains an enabling edge, now backed by a Roman water-system review rather than a generic modern sanitation page.",
+  "would_reject_if": [
+    "The node were rescoped to non-Roman public latrines with no sewer or drainage integration.",
+    "A stronger source showed Roman public latrines were normally independent of sewer or drainage systems."
+  ],
+  "short_reason": "Roman public latrines were commonly tied to sewers or drains, but not every latrine should be modeled as sewer-required.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-public-latrines-water-distribution-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-public-latrines-water-distribution-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-public-latrines-water-distribution-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "public_latrines",
+    "prerequisite": "water_distribution_pipes"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Water Distribution Pipes provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.74,
+    "evidence_level": "review",
+    "note": "Roman public toilets were commonly connected to city water systems or flushed by bath wastewater, making water distribution an enabling supply path rather than a universal hard prerequisite."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7004096/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "documents_application_use",
+    "source_locator": "The Aqueducts and Water Supply of Ancient Rome, Roman public toilets discussion noting city water-system connections and bath wastewater used to flush latrines.",
+    "source_claim_summary": "The review describes Roman public toilets as commonly connected to city water systems and notes bath wastewater or overflow could flush them.",
+    "source_support_rationale": "The source supports water distribution as an enabling supply path for Roman public latrines, not a claim that every latrine had a direct piped supply."
+  },
+  "invariant_preserved_or_changed": "Preserved: water_distribution_pipes remains an enabling edge, now backed by a Roman water-system review rather than a generic modern sanitation page.",
+  "would_reject_if": [
+    "The node were rescoped to dry latrines or cesspit-only public toilets.",
+    "A stronger source showed Roman public latrines were normally independent of water supply systems."
+  ],
+  "short_reason": "Roman public latrines commonly used city water systems or bath wastewater for flushing.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-public-latrines-edge-scope.json
+++ b/docs/graph-invariants/2026-06-11-public-latrines-edge-scope.json
@@ -1,0 +1,19 @@
+{
+  "id": "2026-06-11-public-latrines-edge-scope",
+  "checks": [
+    {
+      "type": "edge_type",
+      "dependent": "public_latrines",
+      "prerequisite": "sewers_and_drainage",
+      "expected": "enabling",
+      "reason": "Sewers and drainage enabled many Roman public latrines, but the node should not claim every ancient latrine required sewer connection."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "public_latrines",
+      "prerequisite": "water_distribution_pipes",
+      "expected": "enabling",
+      "reason": "City water systems and bath wastewater enabled flushing, but not every latrine had direct piped water."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
- Replaced the generic modern WHO sanitation source on `public_latrines` with a Roman water-infrastructure review.
- Tightened the node description and region to Roman-style public latrines in cities, forts, and bath complexes.
- Upgraded the direct edge evidence for:
  - `sewers_and_drainage -> public_latrines`
  - `water_distribution_pipes -> public_latrines`
- Added a scope note clarifying that not every ancient latrine was public, sewer-connected, or continuously flushed.
- Added two edge-change receipts and one graph invariant.

## Source locator
- `The Aqueducts and Water Supply of Ancient Rome`, Groundwater / PubMed Central, Roman public toilets discussion noting that public toilets were commonly near markets or baths and almost always connected to city water systems and sewers; bath wastewater or overflow could flush them.
- URL: https://pmc.ncbi.nlm.nih.gov/articles/PMC7004096/

## Why this is better
The previous source was a modern WHO sanitation overview, which did not specifically support the Roman/classical historical claim. The new source directly supports the latrine-water-sewer relationship while keeping both edges as `enabling`, not universal hard prerequisites.

## Adversarial note
This could be wrong if the node is intended to cover all ancient public latrines globally rather than Roman-style latrines integrated with water and drainage infrastructure. In that case it should be split or broadened with additional regional sources.

## Validation
- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run node-snapshot-diff -- /tmp/public_latrines.before.json /tmp/public_latrines.after.json --require-behavior-change`
- `npm run agent:check -- --run` passed through test/quality/coverage; first URL audit hit an unrelated transient FHWA timeout.
- `npm run source-urls` passed on rerun: 733 unique URLs returned non-404/non-5xx statuses.
- `npm run accuracy:risks -- --markdown --limit 24` reports an empty manual review queue.