### PR TITLE
Rescope public health inspections to aedile oversight

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,896 / 5,570 (34.0%) |
+| Dependency edges with edge-level sources | 1,894 / 5,568 (34.0%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/classical.json
+++ b/data/classical.json
@@ -8374,77 +8374,31 @@
   },
   {
     "id": "public_health_inspections",
-    "name": "Public Health Inspections",
+    "name": "Aedile Urban Sanitation Oversight",
     "era": "Classical",
-    "description": "Civic inspection of baths, markets, water sources, streets, latrines, burial sites, and food sellers to reduce urban hazards.",
+    "description": "Roman civic oversight of streets, drainage, cloacae, markets, baths, and related urban order by aediles and similar municipal officials.",
     "prerequisites": [
-      "sewers_and_drainage",
-      "public_latrines",
-      "municipal_building_codes"
+      "sewers_and_drainage"
     ],
-    "firstKnownDate": -200,
+    "firstKnownDate": -500,
     "datePrecision": "century",
-    "region": "Mediterranean, South Asia, East Asia, and other classical societies",
+    "region": "Rome / Roman municipal administration",
     "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "sewers_and_drainage",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Sewers and Drainage provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.76,
+        "evidence_level": "textbook",
+        "note": "Aedile duties included care of streets, cleansing and draining the city, and care of the cloacae; drainage infrastructure is an oversight domain, not the whole institution.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Sanitation Safety",
-            "url": "https://www.who.int/teams/environment-climate-change-and-health/water-sanitation-and-health/sanitation-safety",
-            "publisher": "World Health Organization",
-            "year": 2026,
-            "source_type": "official_agency",
-            "supports": [
-              "node",
-              "maturity",
-              "edge"
-            ]
-          }
-        ]
-      },
-      {
-        "prerequisite": "public_latrines",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Public Latrines provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "source_checked",
-        "sources": [
-          {
-            "title": "Sanitation Safety",
-            "url": "https://www.who.int/teams/environment-climate-change-and-health/water-sanitation-and-health/sanitation-safety",
-            "publisher": "World Health Organization",
-            "year": 2026,
-            "source_type": "official_agency",
-            "supports": [
-              "node",
-              "maturity",
-              "edge"
-            ]
-          }
-        ]
-      },
-      {
-        "prerequisite": "municipal_building_codes",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Municipal Building Codes provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "source_checked",
-        "sources": [
-          {
-            "title": "Sanitation Safety",
-            "url": "https://www.who.int/teams/environment-climate-change-and-health/water-sanitation-and-health/sanitation-safety",
-            "publisher": "World Health Organization",
-            "year": 2026,
-            "source_type": "official_agency",
+            "title": "Aediles",
+            "url": "https://penelope.uchicago.edu/Thayer/E/Roman/Texts/secondary/SMIGRA%2A/Aediles.html",
+            "publisher": "LacusCurtius / University of Chicago",
+            "year": 1875,
+            "source_type": "textbook",
             "supports": [
               "node",
               "maturity",
@@ -8463,17 +8417,19 @@
     "maturity": "established",
     "sources": [
       {
-        "title": "Sanitation Safety",
-        "url": "https://www.who.int/teams/environment-climate-change-and-health/water-sanitation-and-health/sanitation-safety",
-        "publisher": "World Health Organization",
-        "year": 2026,
-        "source_type": "official_agency",
+        "title": "Aediles",
+        "url": "https://penelope.uchicago.edu/Thayer/E/Roman/Texts/secondary/SMIGRA%2A/Aediles.html",
+        "publisher": "LacusCurtius / University of Chicago",
+        "year": 1875,
+        "source_type": "textbook",
         "supports": [
           "node",
-          "maturity"
+          "maturity",
+          "edge"
         ]
       }
-    ]
+    ],
+    "scopeNote": "Covers Roman aedile-style civic oversight of streets, drainage, markets, baths, and urban order. It is not modern epidemiological inspection, laboratory public health, or a claim that public latrines or building codes caused the office."
   },
   {
     "id": "state_medical_supply_stores",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T16:55:52.595Z",
+  "generatedAt": "2026-06-11T17:10:11.405Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,9 +25,9 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1896,
-      "denominator": 5570,
-      "formatted": "1,896 / 5,570",
+      "value": 1894,
+      "denominator": 5568,
+      "formatted": "1,894 / 5,568",
       "note": "34.0%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 557,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5570,
-    "edgesWithSources": 1896
+    "totalEdges": 5568,
+    "edgesWithSources": 1894
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T16:55:52.595Z
+Generated: 2026-06-11T17:10:11.405Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 610 / 1,660 (36.7%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,896 / 5,570 (34.0%) |
+| Dependency edges with edge-level sources | 1,894 / 5,568 (34.0%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-public-health-building-codes-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-public-health-building-codes-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-public-health-building-codes-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "public_health_inspections",
+    "prerequisite": "municipal_building_codes"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Municipal Building Codes provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from public_health_inspections to municipal_building_codes; the aedile source supports civic oversight of streets, markets, baths, and drainage, not a dependency on formal building-code technology.",
+  "source_supports_edge": "no",
+  "source_url": "https://penelope.uchicago.edu/Thayer/E/Roman/Texts/secondary/SMIGRA%2A/Aediles.html",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Aediles article, duties section describing aedile street, drainage, market, bath, and police/order responsibilities.",
+    "source_claim_summary": "The source supports civic administrative duties, not an engineering dependency on municipal building codes.",
+    "source_support_rationale": "Municipal rules may share an administrative setting, but the source does not make building-code technology a prerequisite for aedile urban oversight."
+  },
+  "ontology_before": "The node depended on municipal building codes as an enabling technology.",
+  "ontology_after": "The node is scoped to aedile civic oversight and no longer imports a broad building-code dependency.",
+  "invariant_preserved_or_changed": "Changed: municipal_building_codes is absent as a direct prerequisite. Preserved: the node remains about municipal oversight and urban order.",
+  "would_reject_if": [
+    "The node were rescoped to sanitary building-code inspection rather than aedile urban oversight.",
+    "A source showed formal municipal building codes were a prerequisite for the relevant Roman oversight office."
+  ],
+  "short_reason": "Aedile civic oversight does not require a direct municipal-building-code prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/public_health_inspections.before.json /tmp/public_health_inspections.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-public-health-latrines-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-public-health-latrines-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-public-health-latrines-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "public_health_inspections",
+    "prerequisite": "public_latrines"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Public Latrines provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from public_health_inspections to public_latrines; the node is now scoped to Roman aedile urban oversight, whose duties covered streets, drains, markets, baths, and order without requiring public latrines as a causal prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://penelope.uchicago.edu/Thayer/E/Roman/Texts/secondary/SMIGRA%2A/Aediles.html",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Aediles article, duties section describing care of streets, cleansing and draining the city, cloacae, markets, baths, and police/order functions.",
+    "source_claim_summary": "The source describes an administrative office with broad urban oversight duties rather than an institution caused by public latrines.",
+    "source_support_rationale": "Public latrines may be an object of sanitation concern, but the aedile oversight institution does not depend on public_latrines as a prerequisite."
+  },
+  "ontology_before": "The node modeled public latrines as an enabling prerequisite for public-health inspection.",
+  "ontology_after": "The node is scoped to aedile urban oversight and no longer treats one inspected facility type as a prerequisite.",
+  "invariant_preserved_or_changed": "Changed: public_latrines is absent as a direct prerequisite. Preserved: sanitation-related dependents can still connect to the oversight node.",
+  "would_reject_if": [
+    "The node were rescoped specifically to inspection regimes for public latrines.",
+    "A source showed Roman aedile sanitary oversight emerged only after and because of public latrine systems."
+  ],
+  "short_reason": "Public latrines are an inspected facility type, not a prerequisite for aedile urban oversight.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/public_health_inspections.before.json /tmp/public_health_inspections.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-public-health-sewers-evidence-upgrade.json
+++ b/docs/edge-change-receipts/2026-06-11-public-health-sewers-evidence-upgrade.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-public-health-sewers-evidence-upgrade",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "public_health_inspections",
+    "prerequisite": "sewers_and_drainage"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Sewers and Drainage provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.76,
+    "evidence_level": "textbook",
+    "note": "Aedile duties included care of streets, cleansing and draining the city, and care of the cloacae; drainage infrastructure is an oversight domain, not the whole institution."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://penelope.uchicago.edu/Thayer/E/Roman/Texts/secondary/SMIGRA%2A/Aediles.html",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "documents_application_use",
+    "source_locator": "Aediles article, duties section describing care of streets and pavements, cleansing and draining the city, and care of the cloacae.",
+    "source_claim_summary": "The source connects aedile urban oversight with street cleaning, drainage, and sewer/cloaca care.",
+    "source_support_rationale": "The source supports sewers_and_drainage as a key domain enabling sanitation oversight while not reducing the office to drainage alone."
+  },
+  "invariant_preserved_or_changed": "Preserved: sewers_and_drainage remains an enabling edge, now backed by an aedile-specific source.",
+  "would_reject_if": [
+    "The node were rescoped away from urban sanitation and drainage oversight.",
+    "A source showed aediles had no responsibility for streets, cleansing, drainage, or cloacae."
+  ],
+  "short_reason": "Aedile duties directly included street cleansing, drainage, and cloaca care.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-public-health-inspections-scope.json
+++ b/docs/graph-invariants/2026-06-11-public-health-inspections-scope.json
@@ -1,0 +1,31 @@
+{
+  "id": "2026-06-11-public-health-inspections-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "public_health_inspections",
+      "operator": "eq",
+      "value": -500,
+      "reason": "The node is now scoped to Roman aedile-style urban oversight rather than a broad 200 BCE public-health inspection regime."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "public_health_inspections",
+      "prerequisite": "public_latrines",
+      "reason": "Public latrines are an inspected facility type, not a prerequisite for aedile urban oversight."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "public_health_inspections",
+      "prerequisite": "municipal_building_codes",
+      "reason": "The aedile source supports civic oversight duties, not dependence on formal municipal building-code technology."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "public_health_inspections",
+      "prerequisite": "sewers_and_drainage",
+      "expected": "enabling",
+      "reason": "Drainage and cloacae were a key oversight domain but not the whole institution."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node correction for `public_health_inspections`.

## Old Claim
`public_health_inspections` was modeled as broad public-health inspection of baths, markets, water sources, streets, latrines, burial sites, and food sellers across multiple classical societies, dated around 200 BCE. It depended on `sewers_and_drainage`, `public_latrines`, and `municipal_building_codes` via weak inferred enabling edges.

## New Claim
The node is now scoped to Roman aedile-style urban sanitation oversight: civic oversight of streets, drainage, cloacae, markets, baths, and related urban order. Earliest date is set to the 6th century BCE Roman magistracy scope (`firstKnownDate: -500`, `datePrecision: century`, region `Rome / Roman municipal administration`).

## Source
- `Aediles`, LacusCurtius / University of Chicago: https://penelope.uchicago.edu/Thayer/E/Roman/Texts/secondary/SMIGRA%2A/Aediles.html

## Edge Changes
- Kept `sewers_and_drainage -> public_health_inspections` as `enabling`, upgraded to textbook evidence with edge-level source. The source directly describes aedile duties including streets, cleansing/draining the city, and cloacae.
- Removed `public_latrines -> public_health_inspections`; latrines are a sanitation target/context, not a prerequisite for the office or oversight practice.
- Removed `municipal_building_codes -> public_health_inspections`; building-code style regulation is not required for Roman aedile sanitation oversight.

## Why This Is Better
The old node name and WHO source implied a modern generalized public-health inspection regime. The corrected node has a narrower historical scope, a period-appropriate source, and avoids laundering contextual urban sanitation facilities into causal prerequisites.

## Adversarial Note
The strongest reason this could still be wrong is that `public_health_inspections` might deserve a separate later node for modern public-health inspection regimes rather than being renamed. This PR intentionally fixes the existing classical claim without adding a new modern node.

## Validation
- `npm run agent:check -- --run` passed: `git diff --check`, `npm test`, `npm run quality`, `npm run coverage`, `npm run source-urls`.
- `npm run source-urls` passed for 734 unique URLs.
- `npm run node-snapshot-diff -- /tmp/public_health_inspections.before.json /tmp/public_health_inspections.after.json --require-behavior-change` passed.
- `npm run accuracy:risks -- --markdown --limit 24` ran; next manual review queue is empty.