### PR TITLE
Source-check fire control chronology

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 610 / 1,660 (36.7%) |
+| Source-checked nodes | 611 / 1,660 (36.8%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
 | Dependency edges with edge-level sources | 1,894 / 5,568 (34.0%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -3,25 +3,47 @@
     "id": "fire_control",
     "name": "Fire Control",
     "era": "Ancient",
-    "description": "Mastery of fire for warmth, cooking, protection, and altering landscapes.",
+    "description": "Controlled use and maintenance of fire by hominins, evidenced archaeologically by in situ burning, ash, and burned bone.",
     "prerequisites": [],
-    "firstKnownDate": -400000,
+    "firstKnownDate": -1000000,
     "datePrecision": "millennium",
-    "region": "Africa and Eurasia",
-    "reviewStatus": "structurally_validated",
+    "region": "Wonderwerk Cave, Northern Cape, South Africa",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [],
+    "fields": [
+      "Energy Systems & Grid",
+      "Materials Science & Manufacturing"
+    ],
+    "fieldLanes": {
+      "Energy Systems & Grid": "Foundations",
+      "Materials Science & Manufacturing": "Foundations"
+    },
+    "maturity": "established",
     "sources": [
       {
-        "title": "Fire",
-        "url": "https://www.britannica.com/science/fire-combustion",
-        "publisher": "Encyclopaedia Britannica",
-        "year": 2026,
-        "source_type": "generic_overview",
+        "title": "Microstratigraphic evidence of in situ fire in the Acheulean strata of Wonderwerk Cave, Northern Cape province, South Africa",
+        "url": "https://www.pnas.org/doi/10.1073/pnas.1117620109",
+        "publisher": "Proceedings of the National Academy of Sciences",
+        "year": 2012,
+        "source_type": "primary_paper",
         "supports": [
-          "node"
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "The discovery of fire by humans: a long and convoluted process",
+        "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4874402/",
+        "publisher": "Philosophical Transactions of the Royal Society B",
+        "year": 2016,
+        "source_type": "review",
+        "supports": [
+          "node",
+          "maturity"
         ]
       }
-    ]
+    ],
+    "scopeNote": "Covers secure evidence for controlled fire use and maintenance, not independent fire-making technology. The 1.0 Ma date is pinned to Wonderwerk Cave; later fire-making evidence should be modeled separately if needed."
   },
   {
     "id": "oral_tradition_storytelling",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T17:10:11.405Z",
+  "generatedAt": "2026-06-11T17:22:54.992Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,10 +11,10 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 610,
+      "value": 611,
       "denominator": 1660,
-      "formatted": "610 / 1,660",
-      "note": "36.7%"
+      "formatted": "611 / 1,660",
+      "note": "36.8%"
     },
     {
       "label": "Nodes with node-level sources",
@@ -55,7 +55,7 @@
   "riskReportTotals": {
     "technologies": 1660,
     "nodesWithSources": 646,
-    "sourceChecked": 610,
+    "sourceChecked": 611,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,

--- a/data/renaissance.json
+++ b/data/renaissance.json
@@ -1226,20 +1226,22 @@
       {
         "prerequisite": "printing_press",
         "type": "accelerates",
-        "confidence": 0.58,
-        "evidence_level": "expert_inference",
-        "note": "Print culture helped disseminate commercial information, but the source-checked exchange is not defined by printing alone.",
+        "confidence": 0.62,
+        "evidence_level": "review",
+        "note": "Printed broker forms and later printed stock-price lists helped publish market information, but printing was not a hard prerequisite for the 1602 Amsterdam VOC share market.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Stock market information",
-            "url": "https://en.wikipedia.org/wiki/Financial_news",
-            "source_type": "weak_web",
+            "title": "The World's First Stock Exchange: Amsterdam VOC Shares, 1602-1700",
+            "url": "https://dare.uva.nl/document/201694",
+            "publisher": "University of Amsterdam",
+            "year": 2011,
+            "source_type": "review",
             "supports": [
+              "node",
+              "maturity",
               "edge"
-            ],
-            "publisher": "Wikipedia",
-            "year": 2026
+            ]
           }
         ]
       },

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,13 +1,13 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T17:10:11.405Z
+Generated: 2026-06-11T17:22:54.992Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 610 / 1,660 (36.7%) |
+| Source-checked nodes | 611 / 1,660 (36.8%) |
 | Nodes with node-level sources | 646 / 1,660 (38.9%) |
 | Dependency edges with edge-level sources | 1,894 / 5,568 (34.0%) |
 | Era-default placeholder dates | 557 / 1,660 (33.6%) |

--- a/docs/edge-change-receipts/2026-06-11-stock-exchange-printing-source-replacement.json
+++ b/docs/edge-change-receipts/2026-06-11-stock-exchange-printing-source-replacement.json
@@ -1,0 +1,46 @@
+{
+  "id": "2026-06-11-stock-exchange-printing-source-replacement",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "stock_exchange_early",
+    "prerequisite": "printing_press"
+  },
+  "old_claim": {
+    "type": "accelerates",
+    "confidence": 0.58,
+    "evidence_level": "expert_inference",
+    "note": "Print culture helped disseminate commercial information, but the source-checked exchange is not defined by printing alone.",
+    "source_url": "https://en.wikipedia.org/wiki/Financial_news"
+  },
+  "new_claim": {
+    "type": "accelerates",
+    "confidence": 0.62,
+    "evidence_level": "review",
+    "note": "Printed broker forms and later printed stock-price lists helped publish market information, but printing was not a hard prerequisite for the 1602 Amsterdam VOC share market.",
+    "source_url": "https://dare.uva.nl/document/201694"
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://dare.uva.nl/document/201694",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Petram thesis discussion of pre-printed broker forms from the 1720s and the first printed stock-price list dating from 1747.",
+    "source_claim_summary": "The source places printed forms and printed stock-price lists inside the Amsterdam securities-market information system.",
+    "source_support_rationale": "This supports printing as an accelerant for market information publication while preserving that the 1602 exchange itself depended on transferable VOC shares, not printing."
+  },
+  "invariant_preserved_or_changed": "Preserved: printing_press remains an accelerates edge, not a required dependency.",
+  "would_reject_if": [
+    "The edge were promoted to required for the 1602 Amsterdam exchange.",
+    "The source no longer documented printed broker forms or printed stock-price lists in the Amsterdam exchange context."
+  ],
+  "short_reason": "Replaced a dead weak Wikipedia URL with the source already used for the scoped Amsterdam exchange node and clarified the edge as market-information acceleration.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage",
+    "npm run source-urls"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-fire-control-scope.json
+++ b/docs/graph-invariants/2026-06-11-fire-control-scope.json
@@ -1,0 +1,12 @@
+{
+  "id": "2026-06-11-fire-control-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "fire_control",
+      "operator": "eq",
+      "value": -1000000,
+      "reason": "Fire control is scoped to secure Wonderwerk Cave in situ fire evidence around 1.0 Ma, not the later 400 ka common-use threshold."
+    }
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-stock-exchange-printing-edge.json
+++ b/docs/graph-invariants/2026-06-11-stock-exchange-printing-edge.json
@@ -1,0 +1,12 @@
+{
+  "id": "2026-06-11-stock-exchange-printing-edge",
+  "checks": [
+    {
+      "type": "edge_type",
+      "dependent": "stock_exchange_early",
+      "prerequisite": "printing_press",
+      "expected": "accelerates",
+      "reason": "Printing supports dissemination of securities-market information, but it is not a required component of the 1602 Amsterdam VOC share market."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
Small data-quality correction focused on the foundational `fire_control` node, plus one source URL cleanup exposed by validation.

## Fire Control: Old Claim
`fire_control` was structurally validated, dated to 400 ka, regioned broadly as Africa and Eurasia, and cited a generic Britannica fire overview.

## Fire Control: New Claim
`fire_control` is now source-checked and scoped to controlled fire use and maintenance evidenced archaeologically at Wonderwerk Cave around 1.0 Ma. The node explicitly does not claim independent fire-making technology.

## Sources
- Berna et al., `Microstratigraphic evidence of in situ fire in the Acheulean strata of Wonderwerk Cave, Northern Cape province, South Africa`, PNAS, 2012: https://www.pnas.org/doi/10.1073/pnas.1117620109
- Gowlett, `The discovery of fire by humans: a long and convoluted process`, Philosophical Transactions B, 2016: https://pmc.ncbi.nlm.nih.gov/articles/PMC4874402/

## Additional URL Cleanup
Validation surfaced a dead `https://en.wikipedia.org/wiki/Financial_news` URL on `stock_exchange_early -> printing_press`. I replaced it with the existing Petram Amsterdam exchange thesis source, tightened the note, and kept the edge as `accelerates`, not `required`.

## Why This Is Better
This upgrades a heavily reused foundational node from generic overview evidence to primary/review support and prevents the graph from confusing controlled fire use with later fire-making technology. It also removes a real 404 from a source-checked edge.

## Adversarial Note
The strongest reason this could be wrong is that newer 2026 Wonderwerk work may push possible fire use earlier than 1.0 Ma. This PR intentionally uses the conservative secure 1.0 Ma claim rather than encoding a newer, broader range into a foundational node.

## Validation
- `npm run agent:check -- --run` passed through `git diff --check`, `npm test`, `npm run quality`, and `npm run coverage`.
- Initial `npm run source-urls` attempts exposed unrelated intermittent timeouts and then the real dead Financial_news URL; after replacement, source URL audit passed for 734 unique URLs.
- `npm run node-snapshot-diff -- /tmp/fire_control.before.json /tmp/fire_control.after.json` passed with claim changed and graph behavior unchanged.
- `npm run accuracy:risks -- --markdown --limit 24` ran; source-checked nodes are now 611/1660 and the manual review queue remains empty.