### PR TITLE
Source-check pigment creation at Blombos

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 611 / 1,660 (36.8%) |
-| Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,894 / 5,568 (34.0%) |
-| Era-default placeholder dates | 557 / 1,660 (33.6%) |
+| Source-checked nodes | 612 / 1,660 (36.9%) |
+| Nodes with node-level sources | 647 / 1,660 (39.0%) |
+| Dependency edges with edge-level sources | 1,896 / 5,567 (34.1%) |
+| Era-default placeholder dates | 556 / 1,660 (33.5%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -384,42 +384,82 @@
     "id": "pigment_creation",
     "name": "Pigment Creation",
     "era": "Ancient",
-    "description": "Sourcing and processing natural materials (ochre, charcoal, manganese) to create pigments for art and decoration.",
+    "description": "Sourcing, grinding, mixing, and storing ochre-rich pigment compounds using stone tools and containers.",
     "prerequisites": [
-      "foraging_and_botany",
       "stone_tool_making",
       "fire_control"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -100000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Blombos Cave, Western Cape, South Africa",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
-        "prerequisite": "foraging_and_botany",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Foraging & Botany provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
         "prerequisite": "stone_tool_making",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Stone Tool Making is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "type": "required",
+        "confidence": 0.86,
+        "evidence_level": "primary_source",
+        "note": "The Blombos toolkit included grindstones and hammerstones for processing ochre-rich mixtures, making stone tools part of the documented production method.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "A 100,000-Year-Old Ochre-Processing Workshop at Blombos Cave, South Africa",
+            "url": "https://pubmed.ncbi.nlm.nih.gov/21998386/",
+            "publisher": "Science / PubMed",
+            "year": 2011,
+            "source_type": "primary_paper",
+            "supports": [
+              "node",
+              "maturity",
+              "edge"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "fire_control",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Fire Control is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "type": "common_dependency",
+        "confidence": 0.56,
+        "evidence_level": "primary_source",
+        "note": "Charcoal was part of the documented Blombos pigment toolkit, but fire is contextual rather than a universal hard prerequisite for pigment creation.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "A 100,000-Year-Old Ochre-Processing Workshop at Blombos Cave, South Africa",
+            "url": "https://pubmed.ncbi.nlm.nih.gov/21998386/",
+            "publisher": "Science / PubMed",
+            "year": 2011,
+            "source_type": "primary_paper",
+            "supports": [
+              "node",
+              "maturity",
+              "edge"
+            ]
+          }
+        ]
       }
-    ]
+    ],
+    "fields": [
+      "Materials Science & Manufacturing"
+    ],
+    "fieldLanes": {
+      "Materials Science & Manufacturing": "Foundations"
+    },
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "A 100,000-Year-Old Ochre-Processing Workshop at Blombos Cave, South Africa",
+        "url": "https://pubmed.ncbi.nlm.nih.gov/21998386/",
+        "publisher": "Science / PubMed",
+        "year": 2011,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "scopeNote": "Covers archaeologically documented ochre-rich pigment-compound production, not every later artistic paint, dye, ink, or symbolic-art practice."
   },
   {
     "id": "early_symbolic_communication",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T17:22:54.992Z",
+  "generatedAt": "2026-06-11T17:32:29.773Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 611,
+      "value": 612,
       "denominator": 1660,
-      "formatted": "611 / 1,660",
-      "note": "36.8%"
+      "formatted": "612 / 1,660",
+      "note": "36.9%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 646,
+      "value": 647,
       "denominator": 1660,
-      "formatted": "646 / 1,660",
-      "note": "38.9%"
+      "formatted": "647 / 1,660",
+      "note": "39.0%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1894,
-      "denominator": 5568,
-      "formatted": "1,894 / 5,568",
-      "note": "34.0%"
+      "value": 1896,
+      "denominator": 5567,
+      "formatted": "1,896 / 5,567",
+      "note": "34.1%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 557,
+      "value": 556,
       "denominator": 1660,
-      "formatted": "557 / 1,660",
-      "note": "33.6%"
+      "formatted": "556 / 1,660",
+      "note": "33.5%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 646,
-    "sourceChecked": 611,
+    "nodesWithSources": 647,
+    "sourceChecked": 612,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 557,
+    "eraDefaultDates": 556,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5568,
-    "edgesWithSources": 1894
+    "totalEdges": 5567,
+    "edgesWithSources": 1896
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T17:22:54.992Z
+Generated: 2026-06-11T17:32:29.773Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 611 / 1,660 (36.8%) |
-| Nodes with node-level sources | 646 / 1,660 (38.9%) |
-| Dependency edges with edge-level sources | 1,894 / 5,568 (34.0%) |
-| Era-default placeholder dates | 557 / 1,660 (33.6%) |
+| Source-checked nodes | 612 / 1,660 (36.9%) |
+| Nodes with node-level sources | 647 / 1,660 (39.0%) |
+| Dependency edges with edge-level sources | 1,896 / 5,567 (34.1%) |
+| Era-default placeholder dates | 556 / 1,660 (33.5%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-pigment-creation-botany-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-pigment-creation-botany-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-11-pigment-creation-botany-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "pigment_creation",
+    "prerequisite": "foraging_and_botany"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+      "note": "Foraging & Botany provides a capability that enables this technology without being the only possible path."
+    },
+  "new_claim_absent": "No direct edge remains from pigment_creation to foraging_and_botany; the node is now scoped to mineral ochre-rich pigment-compound production at Blombos Cave, where the documented toolkit is ochre, shells, bone, charcoal, grindstones, and hammerstones rather than botanical identification.",
+  "source_supports_edge": "no",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/21998386/",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract listing the Blombos ochre-rich mixture and toolkit components.",
+    "source_claim_summary": "The source documents an ochre-processing toolkit without treating botanical knowledge as a necessary production component.",
+    "source_support_rationale": "Foraging knowledge may be background subsistence knowledge, but it is not part of the scoped mineral pigment production chain."
+  },
+  "ontology_before": "The node treated foraging_and_botany as an enabling prerequisite for pigment creation.",
+  "ontology_after": "The node is scoped to mineral ochre-rich pigment-compound production and no longer models botanical foraging knowledge as a direct prerequisite.",
+  "invariant_preserved_or_changed": "Changed: foraging_and_botany no longer points directly into pigment_creation.",
+  "would_reject_if": [
+    "The node were rescoped to plant dye or botanical pigment extraction.",
+    "A source showed botanical identification was a necessary part of the Blombos ochre-production toolkit."
+  ],
+  "short_reason": "Removed an over-broad contextual prerequisite from a mineral pigment-processing node.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-pigment-creation-fire-common.json
+++ b/docs/edge-change-receipts/2026-06-11-pigment-creation-fire-common.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-11-pigment-creation-fire-common",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "pigment_creation",
+    "prerequisite": "fire_control"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Fire Control is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim": {
+    "type": "common_dependency",
+    "confidence": 0.56,
+    "evidence_level": "primary_source",
+    "note": "Charcoal was part of the documented Blombos pigment toolkit, but fire is contextual rather than a universal hard prerequisite for pigment creation."
+  },
+  "source_supports_edge": "partial",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/21998386/",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Abstract listing charcoal as one component of the Blombos ochre-processing toolkit.",
+    "source_claim_summary": "The source documents charcoal in the toolkit but does not make controlled fire the defining production method.",
+    "source_support_rationale": "Charcoal makes fire relevant context for this toolkit, while the edge must not be read as a universal or hard prerequisite for pigment creation."
+  },
+  "ontology_before": "The edge treated fire_control as a broad historical predecessor of pigment creation.",
+  "ontology_after": "The edge now treats fire_control as a common contextual dependency because charcoal appears in the scoped Blombos toolkit, without making fire a universal hard prerequisite.",
+  "invariant_preserved_or_changed": "Changed: fire_control remains connected but is downgraded from historical predecessor to common_dependency.",
+  "would_reject_if": [
+    "The edge were promoted to required for pigment creation generally.",
+    "The node were narrowed to charcoal-only pigment production."
+  ],
+  "short_reason": "Fire is relevant through charcoal in the toolkit, but too broad as a hard or primary lineage claim for pigment creation.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-pigment-creation-stone-tools-required.json
+++ b/docs/edge-change-receipts/2026-06-11-pigment-creation-stone-tools-required.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-11-pigment-creation-stone-tools-required",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "pigment_creation",
+    "prerequisite": "stone_tool_making"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Stone Tool Making is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.86,
+    "evidence_level": "primary_source",
+    "note": "The Blombos toolkit included grindstones and hammerstones for processing ochre-rich mixtures, making stone tools part of the documented production method."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/21998386/",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "demonstrates_method_dependency",
+    "source_locator": "Abstract listing grindstones and hammerstones as part of the Blombos ochre-processing toolkit.",
+    "source_claim_summary": "The source identifies stone tools as components of the documented pigment-production method.",
+    "source_support_rationale": "For the scoped Blombos ochre-processing workshop, grindstones and hammerstones are direct method components rather than merely historical background."
+  },
+  "ontology_before": "The edge treated stone_tool_making as only a broad historical predecessor for pigment creation.",
+  "ontology_after": "The edge now treats stone_tool_making as a required method dependency for the scoped Blombos ochre-processing toolkit.",
+  "invariant_preserved_or_changed": "Changed: stone_tool_making is now a required method dependency for the scoped pigment-production node.",
+  "would_reject_if": [
+    "The node were broadened to all pigment gathering without processing.",
+    "A source showed the Blombos pigment mixtures were produced without stone processing tools."
+  ],
+  "short_reason": "Stone tools are documented production components in the source-checked pigment toolkit.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-pigment-creation-scope.json
+++ b/docs/graph-invariants/2026-06-11-pigment-creation-scope.json
@@ -1,0 +1,32 @@
+{
+  "id": "2026-06-11-pigment-creation-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "pigment_creation",
+      "operator": "eq",
+      "value": -100000,
+      "reason": "The node is scoped to the 100 ka Blombos ochre-processing workshop rather than a generic Neolithic pigment placeholder."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "pigment_creation",
+      "prerequisite": "foraging_and_botany",
+      "reason": "Mineral ochre processing should not depend directly on botanical foraging knowledge."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "pigment_creation",
+      "prerequisite": "stone_tool_making",
+      "expected": "required",
+      "reason": "The source-documented toolkit includes grindstones and hammerstones for processing the pigment compound."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "pigment_creation",
+      "prerequisite": "fire_control",
+      "expected": "common_dependency",
+      "reason": "Charcoal appears in the toolkit, but fire is contextual rather than a universal hard prerequisite for pigment creation."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One foundational ancient data correction for `pigment_creation`.

## Old Claim
`pigment_creation` was structurally validated, unsourced, dated to 10,000 BCE, regioned as global/multiple regions, and depended on `foraging_and_botany`, `stone_tool_making`, and `fire_control` through generic inferred edges.

## New Claim
`pigment_creation` is scoped to the 100,000-year-old Blombos Cave ochre-processing workshop: sourcing, grinding, mixing, and storing ochre-rich pigment compounds using stone tools and containers.

## Source
- Henshilwood et al., `A 100,000-Year-Old Ochre-Processing Workshop at Blombos Cave, South Africa`, Science, 2011: https://pubmed.ncbi.nlm.nih.gov/21998386/

## Edge Changes
- Removed `foraging_and_botany -> pigment_creation`; botanical foraging is not part of the documented mineral ochre-processing toolkit.
- Retyped `stone_tool_making -> pigment_creation` to `required`; the source lists grindstones and hammerstones as toolkit components.
- Retyped `fire_control -> pigment_creation` to `common_dependency`; charcoal appears in the toolkit, but fire is contextual rather than a universal hard prerequisite for pigment creation.

## Why This Is Better
The old node was a generic Neolithic placeholder. The new node is a specific archaeological claim with a primary source, a clearer date/region/scope, and edge semantics that distinguish method components from contextual materials.

## Adversarial Note
The strongest reason this could be wrong is that `pigment_creation` has broad downstream art/materials dependents, while this PR scopes the node to an early ochre compound workshop. A future split may still be useful for later paint, dye, ink, and artistic pigment traditions.

## Validation
- `npm run edge-receipts` passed for 152 receipts.
- `npm run graph-invariants` passed for 53 invariant files / 350 checks.
- `npm run node-snapshot-diff -- /tmp/pigment_creation.before.json /tmp/pigment_creation.after.json --require-behavior-change` passed.
- `npm run agent:check -- --run` passed through `git diff --check`, `npm test`, `npm run quality`, and `npm run coverage`.
- Initial `npm run source-urls` hit an unrelated timeout on `local_area_networks`; rerun passed for 735 unique URLs.
- `npm run accuracy:risks -- --markdown --limit 24` ran; source-checked nodes are now 612/1660, node-level sources 647/1660, edge-level sources 1896/5567, era-default placeholders 556/1660.