### PR TITLE
Source-check tungsten filament production

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 612 / 1,660 (36.9%) |
-| Nodes with node-level sources | 647 / 1,660 (39.0%) |
+| Source-checked nodes | 613 / 1,660 (36.9%) |
+| Nodes with node-level sources | 648 / 1,660 (39.0%) |
 | Dependency edges with edge-level sources | 1,896 / 5,567 (34.1%) |
-| Era-default placeholder dates | 556 / 1,660 (33.5%) |
+| Era-default placeholder dates | 555 / 1,660 (33.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/modern.json
+++ b/data/modern.json
@@ -2042,17 +2042,17 @@
     "id": "tungsten_filament_production",
     "name": "Tungsten Filament Production",
     "era": "Modern",
-    "description": "Manufacturing high-melting-point tungsten wires for light bulbs and vacuum tubes.",
+    "description": "Coolidge-style production of ductile drawn tungsten wire for incandescent lamp filaments and related vacuum devices.",
     "prerequisites": [
       "advanced_metallurgy_medieval",
       "mining",
       "electricity",
-      "advanced_chemistry"
+      "powder_metallurgy"
     ],
-    "firstKnownDate": 1945,
-    "datePrecision": "decade",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "firstKnownDate": 1909,
+    "datePrecision": "exact",
+    "region": "General Electric Research Laboratory, Schenectady, New York",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "advanced_metallurgy_medieval",
@@ -2079,26 +2079,60 @@
         "reviewStatus": "structurally_validated"
       },
       {
-        "prerequisite": "advanced_chemistry",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Chemistry provides a capability that enables this technology without being the only possible path.",
+        "prerequisite": "powder_metallurgy",
+        "type": "required",
+        "confidence": 0.84,
+        "evidence_level": "review",
+        "note": "Coolidge's ductile tungsten process began from sintered tungsten and used hot swaging and drawing to make bendable wire, making powder metallurgy directly relevant to the scoped production method.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Photoresist",
-            "url": "https://en.wikipedia.org/wiki/Photoresist",
-            "publisher": "Wikipedia",
+            "title": "Lighting A Revolution: William D. Coolidge",
+            "url": "https://americanhistory.si.edu/lighting/bios/coolidge.htm",
+            "publisher": "Smithsonian National Museum of American History",
             "year": 2026,
-            "source_type": "weak_web",
+            "source_type": "museum",
             "supports": [
+              "node",
+              "maturity",
               "edge"
             ]
           }
         ]
       }
-    ]
+    ],
+    "fields": [
+      "Materials Science & Manufacturing"
+    ],
+    "fieldLanes": {
+      "Materials Science & Manufacturing": "Metals & Alloys"
+    },
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "Lighting A Revolution: William D. Coolidge",
+        "url": "https://americanhistory.si.edu/lighting/bios/coolidge.htm",
+        "publisher": "Smithsonian National Museum of American History",
+        "year": 2026,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Tungsten and method of making the same for use as filaments of incandescent electric lamps and for other purposes",
+        "url": "https://patents.google.com/patent/US1082933A/en",
+        "publisher": "Google Patents / United States Patent Office",
+        "year": 1913,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "scopeNote": "Covers ductile drawn tungsten wire production associated with Coolidge's lamp-filament process. It is not a generic claim about all tungsten metallurgy, photoresists, or post-1945 vacuum electronics."
   },
   {
     "id": "vacuum_tubes_electron_control",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T17:32:29.773Z",
+  "generatedAt": "2026-06-11T17:40:09.233Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,16 +11,16 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 612,
+      "value": 613,
       "denominator": 1660,
-      "formatted": "612 / 1,660",
+      "formatted": "613 / 1,660",
       "note": "36.9%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 647,
+      "value": 648,
       "denominator": 1660,
-      "formatted": "647 / 1,660",
+      "formatted": "648 / 1,660",
       "note": "39.0%"
     },
     {
@@ -32,10 +32,10 @@
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 556,
+      "value": 555,
       "denominator": 1660,
-      "formatted": "556 / 1,660",
-      "note": "33.5%"
+      "formatted": "555 / 1,660",
+      "note": "33.4%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,12 +54,12 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 647,
-    "sourceChecked": 612,
+    "nodesWithSources": 648,
+    "sourceChecked": 613,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 556,
+    "eraDefaultDates": 555,
     "sourceCheckedEraDefaultDates": 0,
     "totalEdges": 5567,
     "edgesWithSources": 1896

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T17:32:29.773Z
+Generated: 2026-06-11T17:40:09.233Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 612 / 1,660 (36.9%) |
-| Nodes with node-level sources | 647 / 1,660 (39.0%) |
+| Source-checked nodes | 613 / 1,660 (36.9%) |
+| Nodes with node-level sources | 648 / 1,660 (39.0%) |
 | Dependency edges with edge-level sources | 1,896 / 5,567 (34.1%) |
-| Era-default placeholder dates | 556 / 1,660 (33.5%) |
+| Era-default placeholder dates | 555 / 1,660 (33.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-tungsten-filament-powder-metallurgy-replaces-chemistry.json
+++ b/docs/edge-change-receipts/2026-06-11-tungsten-filament-powder-metallurgy-replaces-chemistry.json
@@ -1,0 +1,51 @@
+{
+  "id": "2026-06-11-tungsten-filament-powder-metallurgy-replaces-chemistry",
+  "decision_date": "2026-06-11",
+  "edge": {
+    "dependent": "tungsten_filament_production",
+    "prerequisite": "powder_metallurgy"
+  },
+  "replaced_edge": {
+    "dependent": "tungsten_filament_production",
+    "prerequisite": "advanced_chemistry"
+  },
+  "change_class": "topology_change",
+  "old_claim": {
+    "type": "enabling",
+    "evidence_level": "expert_inference",
+    "confidence": 0.68,
+    "note": "Advanced Chemistry provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "evidence_level": "review",
+    "confidence": 0.84,
+    "note": "Coolidge's ductile tungsten process began from sintered tungsten and used hot swaging and drawing to make bendable wire, making powder metallurgy directly relevant to the scoped production method."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://americanhistory.si.edu/lighting/bios/coolidge.htm",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "demonstrates_method_dependency",
+    "source_locator": "Smithsonian Coolidge biography, discussion of non-ductile sintered tungsten filaments and Coolidge's 1909 hot swaging and wire-drawing process.",
+    "source_claim_summary": "The source describes tungsten filaments made by sintering and Coolidge's process of hot swaging and drawing sintered tungsten into bendable wire.",
+    "source_support_rationale": "This supports a powder-metallurgy dependency for the scoped production method and rejects the previous photoresist-backed advanced_chemistry edge as a topic mismatch."
+  },
+  "ontology_before": "The node depended on advanced_chemistry using an unrelated photoresist source, obscuring the actual tungsten wire-production method.",
+  "ontology_after": "The node depends on powder_metallurgy because the scoped Coolidge process starts from sintered tungsten and forms drawn wire.",
+  "invariant_preserved_or_changed": "Changed: advanced_chemistry is absent and powder_metallurgy is a required edge for tungsten_filament_production.",
+  "would_reject_if": [
+    "The node were rescoped to photoresist chemistry rather than tungsten wire production.",
+    "A source showed Coolidge-style ductile tungsten filaments did not use sintered tungsten or related powder-metallurgy processing.",
+    "The graph reintroduced the Photoresist source for tungsten filament production."
+  ],
+  "short_reason": "Tungsten filament production depends on sintered/drawn tungsten metallurgy, not photoresist chemistry.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/tungsten_filament_production.before.json /tmp/tungsten_filament_production.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-tungsten-filament-scope.json
+++ b/docs/graph-invariants/2026-06-11-tungsten-filament-scope.json
@@ -1,0 +1,25 @@
+{
+  "id": "2026-06-11-tungsten-filament-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "tungsten_filament_production",
+      "operator": "eq",
+      "value": 1909,
+      "reason": "The node is scoped to Coolidge's ductile drawn tungsten wire process, not a postwar 1945 placeholder."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "tungsten_filament_production",
+      "prerequisite": "advanced_chemistry",
+      "reason": "The previous advanced_chemistry edge used an unrelated photoresist source and over-broadened the production method."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "tungsten_filament_production",
+      "prerequisite": "powder_metallurgy",
+      "expected": "required",
+      "reason": "The scoped process starts from sintered tungsten and turns it into ductile drawn wire."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One modern data correction for `tungsten_filament_production`.

## Old Claim
`tungsten_filament_production` was structurally validated, unsourced, dated to 1945, regioned globally, and had an `advanced_chemistry` edge backed by an unrelated Wikipedia `Photoresist` source.

## New Claim
The node is scoped to Coolidge-style production of ductile drawn tungsten wire for incandescent lamp filaments and related vacuum devices, dated to 1909 at GE's Schenectady research laboratory.

## Sources
- Smithsonian National Museum of American History, `Lighting A Revolution: William D. Coolidge`: https://americanhistory.si.edu/lighting/bios/coolidge.htm
- Coolidge patent, `Tungsten and method of making the same for use as filaments of incandescent electric lamps and for other purposes`: https://patents.google.com/patent/US1082933A/en

## Edge Change
- Replaced `advanced_chemistry -> tungsten_filament_production` with `powder_metallurgy -> tungsten_filament_production`.
- New edge is `required`, review evidence, because the scoped process starts from sintered tungsten and turns it into ductile drawn wire.
- Removed the source-topic mismatch to `Photoresist`.

## Why This Is Better
The correction fixes a wrong era-default modern date, adds node-level sources, and replaces a hallucinated source-topic mismatch with a dependency that matches the documented manufacturing method.

## Adversarial Note
The strongest reason this could be wrong is that the node still retains broad inferred `advanced_metallurgy_medieval`, `mining`, and `electricity` context edges. This PR intentionally fixes the known wrong source-backed edge and source/date claim without broadening scope into a larger metallurgy refactor.

## Validation
- `npm run edge-receipts` passed for 153 receipts.
- `npm run graph-invariants` passed for 54 invariant files / 353 checks.
- `npm run node-snapshot-diff -- /tmp/tungsten_filament_production.before.json /tmp/tungsten_filament_production.after.json --require-behavior-change` passed.
- `npm run agent:check -- --run` passed through `git diff --check`, `npm test`, `npm run quality`, and `npm run coverage`.
- Initial `npm run source-urls` hit an unrelated DARPA timeout; rerun passed for 737 unique URLs.
- `npm run accuracy:risks -- --markdown --limit 24` ran; source-checked nodes are now 613/1660, node-level sources 648/1660, era-default placeholders 555/1660.