### PR TITLE
Source-check early inertial guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 613 / 1,660 (36.9%) |
-| Nodes with node-level sources | 648 / 1,660 (39.0%) |
-| Dependency edges with edge-level sources | 1,896 / 5,567 (34.1%) |
+| Source-checked nodes | 614 / 1,660 (37.0%) |
+| Nodes with node-level sources | 649 / 1,660 (39.1%) |
+| Dependency edges with edge-level sources | 1,896 / 5,566 (34.1%) |
 | Era-default placeholder dates | 555 / 1,660 (33.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/modern.json
+++ b/data/modern.json
@@ -12191,18 +12191,17 @@
     "id": "guidance_systems_early",
     "name": "Guidance Systems (Early Inertial)",
     "era": "Modern",
-    "description": "Systems using gyroscopes and accelerometers to navigate vehicles like missiles and spacecraft without external references.",
+    "description": "Early inertial rocket guidance and stability-control systems using gyroscopes, accelerometers, and analog/electromechanical control to guide vehicles without external references.",
     "prerequisites": [
       "rocketry",
       "electronics",
-      "precision_machine_tools",
-      "computers_early",
+      "precision_mechanics_miniaturization",
       "mathematics"
     ],
-    "firstKnownDate": 1947,
-    "datePrecision": "decade",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "firstKnownDate": 1944,
+    "datePrecision": "exact",
+    "region": "Germany / V-2 ballistic missile program",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "rocketry",
@@ -12221,32 +12220,26 @@
         "reviewStatus": "structurally_validated"
       },
       {
-        "prerequisite": "precision_machine_tools",
+        "prerequisite": "precision_mechanics_miniaturization",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Precision Machine Tools provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.72,
+        "evidence_level": "review",
+        "note": "The V-2 guidance hardware used gyroscopic accelerometers and related precision instruments; this supports precision mechanics as the immediate enabling capability rather than generic machine tools.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Photomask",
-            "url": "https://en.wikipedia.org/wiki/Photomask",
-            "publisher": "Wikipedia",
+            "title": "Accelerometer, Gyroscopic, V-2",
+            "url": "https://airandspace.si.edu/collection-objects/accelerometer-gyroscopic-v-2/nasm_A19880369000",
+            "publisher": "Smithsonian National Air and Space Museum",
             "year": 2026,
-            "source_type": "weak_web",
+            "source_type": "museum",
             "supports": [
+              "node",
+              "maturity",
               "edge"
             ]
           }
         ]
-      },
-      {
-        "prerequisite": "computers_early",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Computers (Mainframe/Early) is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
       },
       {
         "prerequisite": "mathematics",
@@ -12256,7 +12249,33 @@
         "note": "Mathematics provides a capability that enables this technology without being the only possible path.",
         "reviewStatus": "structurally_validated"
       }
-    ]
+    ],
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "Accelerometer, Gyroscopic, V-2",
+        "url": "https://airandspace.si.edu/collection-objects/accelerometer-gyroscopic-v-2/nasm_A19880369000",
+        "publisher": "Smithsonian National Air and Space Museum",
+        "year": 2026,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "V-2 Gyroscope",
+        "url": "https://www.spacecentre.co.uk/collections/categories/rockets/v-2-gyroscope/",
+        "publisher": "National Space Centre",
+        "year": 2026,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "scopeNote": "Covers early inertial rocket guidance/stability-control hardware exemplified by V-2 gyroscopes and gyroscopic accelerometers. It is not a claim that later digital mainframe computers were prerequisites for the first systems."
   },
   {
     "id": "ballistic_missiles_icbm",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T17:40:09.233Z",
+  "generatedAt": "2026-06-11T17:45:35.565Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,23 +11,23 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 613,
+      "value": 614,
       "denominator": 1660,
-      "formatted": "613 / 1,660",
-      "note": "36.9%"
+      "formatted": "614 / 1,660",
+      "note": "37.0%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 648,
+      "value": 649,
       "denominator": 1660,
-      "formatted": "648 / 1,660",
-      "note": "39.0%"
+      "formatted": "649 / 1,660",
+      "note": "39.1%"
     },
     {
       "label": "Dependency edges with edge-level sources",
       "value": 1896,
-      "denominator": 5567,
-      "formatted": "1,896 / 5,567",
+      "denominator": 5566,
+      "formatted": "1,896 / 5,566",
       "note": "34.1%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 648,
-    "sourceChecked": 613,
+    "nodesWithSources": 649,
+    "sourceChecked": 614,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 555,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5567,
+    "totalEdges": 5566,
     "edgesWithSources": 1896
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,15 +1,15 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T17:40:09.233Z
+Generated: 2026-06-11T17:45:35.565Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 613 / 1,660 (36.9%) |
-| Nodes with node-level sources | 648 / 1,660 (39.0%) |
-| Dependency edges with edge-level sources | 1,896 / 5,567 (34.1%) |
+| Source-checked nodes | 614 / 1,660 (37.0%) |
+| Nodes with node-level sources | 649 / 1,660 (39.1%) |
+| Dependency edges with edge-level sources | 1,896 / 5,566 (34.1%) |
 | Era-default placeholder dates | 555 / 1,660 (33.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-guidance-computers-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-guidance-computers-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-guidance-computers-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "guidance_systems_early",
+    "prerequisite": "computers_early"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Computers (Mainframe/Early) is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from guidance_systems_early to computers_early; the node is now scoped to V-2-era electromechanical/analog inertial guidance hardware, which predates the graph's 1946 early-computers node.",
+  "source_supports_edge": "no",
+  "source_url": "https://airandspace.si.edu/collection-objects/accelerometer-gyroscopic-v-2/nasm_A19880369000",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Smithsonian object page describing V-2 guidance hardware as a gyroscope-based accelerometer fragment from the World War II V-2 guidance system.",
+    "source_claim_summary": "The source documents gyroscope-based V-2 guidance hardware rather than a mainframe-computer dependency.",
+    "source_support_rationale": "Because the scoped guidance system is World War II gyroscopic hardware, the graph's later computers_early node should not be a prerequisite."
+  },
+  "ontology_before": "The node treated 1946-era early computers as a historical predecessor for early inertial guidance.",
+  "ontology_after": "The node is scoped to V-2-era inertial guidance hardware and no longer depends on later mainframe computers.",
+  "invariant_preserved_or_changed": "Changed: computers_early is absent as a direct prerequisite.",
+  "would_reject_if": [
+    "The node were rescoped to postwar digital guidance computers.",
+    "A source showed V-2-era inertial guidance required mainframe computers.",
+    "The graph moved computers_early earlier than the V-2 guidance system."
+  ],
+  "short_reason": "V-2-era inertial guidance predates the graph's early-computers node.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/guidance_systems_early.before.json /tmp/guidance_systems_early.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-guidance-precision-mechanics-replaces-machine-tools.json
+++ b/docs/edge-change-receipts/2026-06-11-guidance-precision-mechanics-replaces-machine-tools.json
@@ -1,0 +1,51 @@
+{
+  "id": "2026-06-11-guidance-precision-mechanics-replaces-machine-tools",
+  "decision_date": "2026-06-11",
+  "edge": {
+    "dependent": "guidance_systems_early",
+    "prerequisite": "precision_mechanics_miniaturization"
+  },
+  "replaced_edge": {
+    "dependent": "guidance_systems_early",
+    "prerequisite": "precision_machine_tools"
+  },
+  "change_class": "topology_change",
+  "old_claim": {
+    "type": "enabling",
+    "evidence_level": "expert_inference",
+    "confidence": 0.68,
+    "note": "Precision Machine Tools provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "evidence_level": "review",
+    "confidence": 0.72,
+    "note": "The V-2 guidance hardware used gyroscopic accelerometers and related precision instruments; this supports precision mechanics as the immediate enabling capability rather than generic machine tools."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://airandspace.si.edu/collection-objects/accelerometer-gyroscopic-v-2/nasm_A19880369000",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "documents_application_use",
+    "source_locator": "Smithsonian object page describing a V-2 guidance-system fragment with a gyroscope that sensed acceleration and integrated it over time.",
+    "source_claim_summary": "The source identifies the V-2 gyroscopic accelerometer as guidance-system hardware that sensed acceleration and integrated the data into velocity.",
+    "source_support_rationale": "This supports precision mechanics as the closer enabling capability for early inertial guidance hardware while rejecting the previous photomask-backed machine-tools edge as a source-topic mismatch."
+  },
+  "ontology_before": "The node depended directly on precision_machine_tools and cited an unrelated photomask source.",
+  "ontology_after": "The node depends on precision_mechanics_miniaturization, preserving the precision-hardware requirement through a more specific graph node.",
+  "invariant_preserved_or_changed": "Changed: precision_machine_tools is absent as a direct prerequisite and precision_mechanics_miniaturization is the direct enabling edge.",
+  "would_reject_if": [
+    "The node were rescoped to semiconductor photomask production.",
+    "A source showed early inertial guidance did not use gyroscopic or other precision mechanical instruments.",
+    "The graph reintroduced the Photomask source for early guidance systems."
+  ],
+  "short_reason": "Early inertial guidance used precision gyroscopic instruments, not photomask technology.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/guidance_systems_early.before.json /tmp/guidance_systems_early.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-guidance-systems-scope.json
+++ b/docs/graph-invariants/2026-06-11-guidance-systems-scope.json
@@ -1,0 +1,31 @@
+{
+  "id": "2026-06-11-guidance-systems-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "guidance_systems_early",
+      "operator": "eq",
+      "value": 1944,
+      "reason": "The node is scoped to V-2-era inertial guidance/stability-control hardware."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "guidance_systems_early",
+      "prerequisite": "precision_machine_tools",
+      "reason": "The direct edge should use the more specific precision_mechanics_miniaturization node, not a photomask-backed machine-tools edge."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "guidance_systems_early",
+      "prerequisite": "computers_early",
+      "reason": "V-2-era inertial guidance should not depend on the graph's later early-computers node."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "guidance_systems_early",
+      "prerequisite": "precision_mechanics_miniaturization",
+      "expected": "enabling",
+      "reason": "Gyroscopic accelerometers and related precision instruments are the immediate enabling hardware context."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One modern data correction for `guidance_systems_early`.

## Old Claim
`guidance_systems_early` was structurally validated, unsourced, dated to a 1947 decade placeholder, regioned globally, and had a `precision_machine_tools` edge backed by an unrelated Wikipedia `Photomask` source. It also depended on `computers_early`, which is anachronistic for V-2-era inertial guidance.

## New Claim
The node is scoped to early inertial rocket guidance and stability-control hardware exemplified by V-2 gyroscopes and gyroscopic accelerometers, dated to 1944 in the German V-2 program.

## Sources
- Smithsonian National Air and Space Museum, `Accelerometer, Gyroscopic, V-2`: https://airandspace.si.edu/collection-objects/accelerometer-gyroscopic-v-2/nasm_A19880369000
- National Space Centre, `V-2 Gyroscope`: https://www.spacecentre.co.uk/collections/categories/rockets/v-2-gyroscope/

## Edge Changes
- Replaced `precision_machine_tools -> guidance_systems_early` with `precision_mechanics_miniaturization -> guidance_systems_early` as an enabling edge.
- Removed `computers_early -> guidance_systems_early`; V-2-era guidance hardware predates the graph's 1946 early-computers node.
- Removed the unrelated `Photomask` source from the guidance edge.

## Why This Is Better
The correction grounds the node in actual guidance hardware, fixes a source-topic mismatch, and removes an anachronistic dependency while preserving the precision-instrument lineage through the more specific graph node.

## Adversarial Note
The strongest reason this could be wrong is that the 1944 date uses V-2-era guided rocket hardware as the scope boundary; a stricter definition of full inertial navigation might date later, to postwar Draper-style systems. This PR explicitly scopes the node to early inertial rocket guidance/stability control.

## Validation
- `npm run edge-receipts` passed for 155 receipts.
- `npm run graph-invariants` passed for 55 invariant files / 357 checks.
- `npm run node-snapshot-diff -- /tmp/guidance_systems_early.before.json /tmp/guidance_systems_early.after.json --require-behavior-change` passed.
- `npm run agent:check -- --run` passed: `git diff --check`, `npm test`, `npm run quality`, `npm run coverage`, and `npm run source-urls`.
- `npm run source-urls` passed for 739 unique URLs.
- `npm run accuracy:risks -- --markdown --limit 24` ran; source-checked nodes are now 614/1660 and node-level sources 649/1660.