### PR TITLE
Source-check horseback riding chronology

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 614 / 1,660 (37.0%) |
-| Nodes with node-level sources | 649 / 1,660 (39.1%) |
+| Source-checked nodes | 615 / 1,660 (37.0%) |
+| Nodes with node-level sources | 650 / 1,660 (39.2%) |
 | Dependency edges with edge-level sources | 1,896 / 5,566 (34.1%) |
 | Era-default placeholder dates | 555 / 1,660 (33.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -4307,14 +4307,14 @@
     "id": "horseback_riding",
     "name": "Horseback Riding",
     "era": "Ancient",
-    "description": "Domesticating and riding horses, revolutionizing travel, communication, herding, and warfare.",
+    "description": "Using horses as ridden mounts for mobility, herding, communication, and later warfare, distinct from the broader process of horse domestication.",
     "prerequisites": [
       "animal_husbandry"
     ],
-    "firstKnownDate": -9500,
-    "datePrecision": "unknown",
-    "region": "Afro-Eurasia and other historical societies",
-    "reviewStatus": "structurally_validated",
+    "firstKnownDate": -3000,
+    "datePrecision": "century",
+    "region": "Yamnaya contexts in Romania, Bulgaria, and Hungary",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "animal_husbandry",
@@ -4324,7 +4324,22 @@
         "note": "Animal Husbandry provides a capability that enables this technology without being the only possible path.",
         "reviewStatus": "structurally_validated"
       }
-    ]
+    ],
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "First bioanthropological evidence for Yamnaya horsemanship",
+        "url": "https://www.science.org/doi/10.1126/sciadv.ade2451",
+        "publisher": "Science Advances",
+        "year": 2023,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "scopeNote": "Covers direct bioanthropological evidence for humans riding horses, not earlier horse domestication, milking, harnessing, or chariot traction."
   },
   {
     "id": "charcoal_production",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T17:45:35.565Z",
+  "generatedAt": "2026-06-11T17:49:54.217Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,17 +11,17 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 614,
+      "value": 615,
       "denominator": 1660,
-      "formatted": "614 / 1,660",
+      "formatted": "615 / 1,660",
       "note": "37.0%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 649,
+      "value": 650,
       "denominator": 1660,
-      "formatted": "649 / 1,660",
-      "note": "39.1%"
+      "formatted": "650 / 1,660",
+      "note": "39.2%"
     },
     {
       "label": "Dependency edges with edge-level sources",
@@ -54,8 +54,8 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 649,
-    "sourceChecked": 614,
+    "nodesWithSources": 650,
+    "sourceChecked": 615,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,14 +1,14 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T17:45:35.565Z
+Generated: 2026-06-11T17:49:54.217Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 614 / 1,660 (37.0%) |
-| Nodes with node-level sources | 649 / 1,660 (39.1%) |
+| Source-checked nodes | 615 / 1,660 (37.0%) |
+| Nodes with node-level sources | 650 / 1,660 (39.2%) |
 | Dependency edges with edge-level sources | 1,896 / 5,566 (34.1%) |
 | Era-default placeholder dates | 555 / 1,660 (33.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |

--- a/docs/graph-invariants/2026-06-11-horseback-riding-scope.json
+++ b/docs/graph-invariants/2026-06-11-horseback-riding-scope.json
@@ -1,0 +1,12 @@
+{
+  "id": "2026-06-11-horseback-riding-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "horseback_riding",
+      "operator": "eq",
+      "value": -3000,
+      "reason": "The node is scoped to direct Yamnaya bioanthropological evidence for horseback riding around 3021-2501 BCE, not a Neolithic domestication placeholder."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One ancient claim-only correction for `horseback_riding`.

## Old Claim
`horseback_riding` was structurally validated, unsourced, dated to an unknown 9500 BCE placeholder, and conflated horse domestication with riding.

## New Claim
The node is scoped to direct bioanthropological evidence for humans riding horses, dated around 3000 BCE in Yamnaya contexts in Romania, Bulgaria, and Hungary.

## Source
- `First bioanthropological evidence for Yamnaya horsemanship`, Science Advances, 2023: https://www.science.org/doi/10.1126/sciadv.ade2451

## Why This Is Better
The correction separates horseback riding from earlier domestication, milking, harnessing, and chariot traction. It replaces a Neolithic placeholder with a sourced approximate date based on direct rider evidence.

## Edge Changes
None. This PR keeps topology stable and only corrects the node claim, date, region, source, and scope note.

## Adversarial Note
The strongest reason this could be wrong is that indirect evidence for horse management, harnessing, or possible riding may predate the Yamnaya skeletal evidence. The node is intentionally scoped to direct bioanthropological riding evidence rather than all horse domestication or traction.

## Validation
- `npm run node-snapshot-diff -- /tmp/horseback_riding.before.json /tmp/horseback_riding.after.json` passed with claim changed and graph behavior unchanged.
- `npm run graph-invariants` passed for 56 invariant files / 358 checks.
- `npm run agent:check -- --run` passed: `git diff --check`, `npm test`, `npm run quality`, `npm run coverage`, and `npm run source-urls`.
- `npm run source-urls` passed for 740 unique URLs.
- `npm run accuracy:risks -- --markdown --limit 24` ran; source-checked nodes are now 615/1660 and node-level sources 650/1660.