### PR TITLE
Retype superalloys jet aircraft dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 615 / 1,660 (37.0%) |
 | Nodes with node-level sources | 650 / 1,660 (39.2%) |
-| Dependency edges with edge-level sources | 1,896 / 5,566 (34.1%) |
+| Dependency edges with edge-level sources | 1,897 / 5,566 (34.1%) |
 | Era-default placeholder dates | 555 / 1,660 (33.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/modern.json
+++ b/data/modern.json
@@ -41446,24 +41446,14 @@
     "maturity": "established",
     "sources": [
       {
-        "title": "Materials",
-        "url": "https://www.nist.gov/materials",
-        "publisher": "NIST",
-        "year": 2026,
-        "source_type": "generic_overview",
+        "title": "A History of Superalloy Metallurgy for Superalloy Metallurgists",
+        "url": "https://www.tms.org/superalloys/10.7449/1984/Superalloys_1984_399_419.pdf",
+        "publisher": "The Minerals, Metals & Materials Society",
+        "year": 1984,
+        "source_type": "review",
         "supports": [
           "node",
           "maturity"
-        ]
-      },
-      {
-        "title": "Superalloy",
-        "url": "https://en.wikipedia.org/wiki/Superalloy",
-        "publisher": "Wikipedia",
-        "year": 2026,
-        "source_type": "weak_web",
-        "supports": [
-          "node"
         ]
       }
     ],
@@ -41490,13 +41480,28 @@
       },
       {
         "prerequisite": "jet_aircraft_high_speed_flight",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Jet Aircraft (High-Speed Flight) provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "commercial_or_scaling_dependency",
+        "confidence": 0.74,
+        "evidence_level": "review",
+        "note": "Jet-engine and gas-turbine demand drove superalloy improvement and deployment; aircraft are an application and scaling context, not a material prerequisite.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "A History of Superalloy Metallurgy for Superalloy Metallurgists",
+            "url": "https://www.tms.org/superalloys/10.7449/1984/Superalloys_1984_399_419.pdf",
+            "publisher": "The Minerals, Metals & Materials Society",
+            "year": 1984,
+            "source_type": "review",
+            "supports": [
+              "node",
+              "maturity",
+              "edge"
+            ]
+          }
+        ]
       }
-    ]
+    ],
+    "scopeNote": "Covers nickel-based high-temperature superalloys for turbine/hot-section service. Jet aircraft and gas turbines are demand/application contexts, not components required to invent the alloy family."
   },
   {
     "id": "high_performance_polymers",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T17:49:54.217Z",
+  "generatedAt": "2026-06-11T17:55:11.900Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,9 +25,9 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1896,
+      "value": 1897,
       "denominator": 5566,
-      "formatted": "1,896 / 5,566",
+      "formatted": "1,897 / 5,566",
       "note": "34.1%"
     },
     {
@@ -62,6 +62,6 @@
     "eraDefaultDates": 555,
     "sourceCheckedEraDefaultDates": 0,
     "totalEdges": 5566,
-    "edgesWithSources": 1896
+    "edgesWithSources": 1897
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T17:49:54.217Z
+Generated: 2026-06-11T17:55:11.900Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 615 / 1,660 (37.0%) |
 | Nodes with node-level sources | 650 / 1,660 (39.2%) |
-| Dependency edges with edge-level sources | 1,896 / 5,566 (34.1%) |
+| Dependency edges with edge-level sources | 1,897 / 5,566 (34.1%) |
 | Era-default placeholder dates | 555 / 1,660 (33.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-superalloys-jet-aircraft-scaling.json
+++ b/docs/edge-change-receipts/2026-06-11-superalloys-jet-aircraft-scaling.json
@@ -1,0 +1,47 @@
+{
+  "id": "2026-06-11-superalloys-jet-aircraft-scaling",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "superalloys",
+    "prerequisite": "jet_aircraft_high_speed_flight"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Jet Aircraft (High-Speed Flight) provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "commercial_or_scaling_dependency",
+    "confidence": 0.74,
+    "evidence_level": "review",
+    "note": "Jet-engine and gas-turbine demand drove superalloy improvement and deployment; aircraft are an application and scaling context, not a material prerequisite."
+  },
+  "source_supports_edge": "partial",
+  "source_url": "https://www.tms.org/superalloys/10.7449/1984/Superalloys_1984_399_419.pdf",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Sims history review discussion of World War II, jet engines, military use, and later industrial heavy-duty gas-turbine needs driving superalloy development.",
+    "source_claim_summary": "The review describes superalloy development as driven first by military jet-engine use and then by industrial gas turbines.",
+    "source_support_rationale": "This supports aircraft and turbine demand as a scaling/application driver while rejecting the stronger reading that jet aircraft technically enable the alloy family."
+  },
+  "ontology_before": "The edge treated high-speed jet aircraft as enabling superalloys, which risks reversing material/component dependency.",
+  "ontology_after": "The edge now treats jet aircraft and turbines as demand-side scaling context for high-temperature alloy development.",
+  "invariant_preserved_or_changed": "Changed: jet_aircraft_high_speed_flight remains connected only as commercial_or_scaling_dependency.",
+  "would_reject_if": [
+    "The node were rescoped specifically to aircraft operations rather than nickel superalloy metallurgy.",
+    "A source showed jet aircraft were a technical component required to make nickel superalloys.",
+    "The graph promoted this relationship back to enabling or required without component-level evidence."
+  ],
+  "short_reason": "Jet aircraft drove demand for superalloys; they did not technically enable the material.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/superalloys.before.json /tmp/superalloys.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-superalloys-jet-scope.json
+++ b/docs/graph-invariants/2026-06-11-superalloys-jet-scope.json
@@ -1,0 +1,12 @@
+{
+  "id": "2026-06-11-superalloys-jet-scope",
+  "checks": [
+    {
+      "type": "edge_type",
+      "dependent": "superalloys",
+      "prerequisite": "jet_aircraft_high_speed_flight",
+      "expected": "commercial_or_scaling_dependency",
+      "reason": "Jet aircraft are an application and demand driver for superalloys, not a technical prerequisite of the alloy family."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
Small semantic/source correction for `superalloys`.

## Old Claim
`superalloys` used generic/weak node sources (`NIST Materials`, Wikipedia) and modeled `jet_aircraft_high_speed_flight` as an `enabling` prerequisite.

## New Claim
The node now cites a superalloy-history review and treats jet aircraft/gas turbines as commercial and scaling demand context, not a technical prerequisite of the alloy family.

## Source
- `A History of Superalloy Metallurgy for Superalloy Metallurgists`, TMS, 1984: https://www.tms.org/superalloys/10.7449/1984/Superalloys_1984_399_419.pdf

## Edge Change
- `jet_aircraft_high_speed_flight -> superalloys`: `enabling` -> `commercial_or_scaling_dependency`.
- Added edge-level source and receipt.

## Why This Is Better
It avoids a product/component reversal. Jet aircraft and gas turbines drove demand and deployment for high-temperature superalloys, but they are not components required to make the material.

## Adversarial Note
The remaining `advanced_chemistry` and `stainless_steel` edges are still broad inferred context and should be audited later. This PR intentionally fixes the clearest product/application-edge issue without expanding scope.

## Validation
- `npm run edge-receipts` passed for 156 receipts.
- `npm run graph-invariants` passed for 57 invariant files / 359 checks.
- `npm run node-snapshot-diff -- /tmp/superalloys.before.json /tmp/superalloys.after.json --require-behavior-change` passed.
- `npm run agent:check -- --run` passed: `git diff --check`, `npm test`, `npm run quality`, `npm run coverage`, and `npm run source-urls`.
- `npm run source-urls` passed for 740 unique URLs.
- `npm run accuracy:risks -- --markdown --limit 24` ran; edge-level sources are now 1897/5566.