### PR TITLE
[codex] Rescope copper working to native copper

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 615 / 1,660 (37.0%) |
-| Nodes with node-level sources | 650 / 1,660 (39.2%) |
-| Dependency edges with edge-level sources | 1,897 / 5,566 (34.1%) |
-| Era-default placeholder dates | 555 / 1,660 (33.4%) |
+| Source-checked nodes | 616 / 1,660 (37.1%) |
+| Nodes with node-level sources | 651 / 1,660 (39.2%) |
+| Dependency edges with edge-level sources | 1,897 / 5,563 (34.1%) |
+| Era-default placeholder dates | 554 / 1,660 (33.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -4459,24 +4459,34 @@
     "id": "copper_working",
     "name": "Copper Working",
     "era": "Ancient",
-    "description": "The extraction and working of copper, one of the first metals to be smelted, used for tools, ornaments, and early weapons.",
-    "prerequisites": [
-      "smelting_basic"
+    "description": "Early working of native copper into beads, pins, ornaments, and small tools by hammering and annealing, before later smelted copper metallurgy.",
+    "prerequisites": [],
+    "firstKnownDate": -8200,
+    "datePrecision": "century",
+    "region": "Çayönü Tepesi, eastern Anatolia",
+    "reviewStatus": "source_checked",
+    "dependencyEdges": [],
+    "fields": [
+      "Materials Science & Manufacturing"
     ],
-    "firstKnownDate": -10000,
-    "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
-    "dependencyEdges": [
+    "fieldLanes": {
+      "Materials Science & Manufacturing": "Metals & Alloys"
+    },
+    "maturity": "established",
+    "sources": [
       {
-        "prerequisite": "smelting_basic",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Basic Smelting is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "title": "History of Mining and Metallurgy in Anatolia: The First Metal, Copper",
+        "url": "https://www.ancientportsantiques.com/wp-content/uploads/Documents/PLACES/Turkey/AnatoliaMetals-Yalcin2000.pdf",
+        "publisher": "Anatolian Civilizations Museum / Turkish Cultural Foundation",
+        "year": 2000,
+        "source_type": "review",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       }
-    ]
+    ],
+    "scopeNote": "Covers the earliest known native copper working and annealing. Smelted copper and extractive metallurgy are later developments and should not be required for this node's first-known date."
   },
   {
     "id": "casting_and_molding",
@@ -4484,7 +4494,6 @@
     "era": "Ancient",
     "description": "Pouring molten metal into molds made of stone or clay to create complex shapes for tools and artifacts.",
     "prerequisites": [
-      "copper_working",
       "pottery"
     ],
     "firstKnownDate": -10000,
@@ -4492,14 +4501,6 @@
     "region": "Global / multiple regions",
     "reviewStatus": "structurally_validated",
     "dependencyEdges": [
-      {
-        "prerequisite": "copper_working",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Copper Working provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
       {
         "prerequisite": "pottery",
         "type": "enabling",
@@ -6546,7 +6547,6 @@
     "description": "Reusable or expendable molds that enabled repeatable production of tools, weapons, ornaments, fittings, and ritual objects.",
     "prerequisites": [
       "casting_and_molding",
-      "copper_working",
       "clay_gathering_and_preparation"
     ],
     "firstKnownDate": -10000,
@@ -6560,14 +6560,6 @@
         "confidence": 0.68,
         "evidence_level": "expert_inference",
         "note": "Casting and Molding provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "copper_working",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Copper Working provides a capability that enables this technology without being the only possible path.",
         "reviewStatus": "structurally_validated"
       },
       {

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T17:55:11.900Z",
+  "generatedAt": "2026-06-11T18:09:58.096Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,30 +11,30 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 615,
+      "value": 616,
       "denominator": 1660,
-      "formatted": "615 / 1,660",
-      "note": "37.0%"
+      "formatted": "616 / 1,660",
+      "note": "37.1%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 650,
+      "value": 651,
       "denominator": 1660,
-      "formatted": "650 / 1,660",
+      "formatted": "651 / 1,660",
       "note": "39.2%"
     },
     {
       "label": "Dependency edges with edge-level sources",
       "value": 1897,
-      "denominator": 5566,
-      "formatted": "1,897 / 5,566",
+      "denominator": 5563,
+      "formatted": "1,897 / 5,563",
       "note": "34.1%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 555,
+      "value": 554,
       "denominator": 1660,
-      "formatted": "555 / 1,660",
+      "formatted": "554 / 1,660",
       "note": "33.4%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 650,
-    "sourceChecked": 615,
+    "nodesWithSources": 651,
+    "sourceChecked": 616,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 555,
+    "eraDefaultDates": 554,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5566,
+    "totalEdges": 5563,
     "edgesWithSources": 1897
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T17:55:11.900Z
+Generated: 2026-06-11T18:09:58.096Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 615 / 1,660 (37.0%) |
-| Nodes with node-level sources | 650 / 1,660 (39.2%) |
-| Dependency edges with edge-level sources | 1,897 / 5,566 (34.1%) |
-| Era-default placeholder dates | 555 / 1,660 (33.4%) |
+| Source-checked nodes | 616 / 1,660 (37.1%) |
+| Nodes with node-level sources | 651 / 1,660 (39.2%) |
+| Dependency edges with edge-level sources | 1,897 / 5,563 (34.1%) |
+| Era-default placeholder dates | 554 / 1,660 (33.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-casting-native-copper-edge-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-casting-native-copper-edge-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-casting-native-copper-edge-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "casting_and_molding",
+    "prerequisite": "copper_working"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Copper Working provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from casting_and_molding to copper_working. Early native copper working is a predecessor to later metallurgy, but the scoped casting node should not depend directly on the native-copper-working node.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.ancientportsantiques.com/wp-content/uploads/Documents/PLACES/Turkey/AnatoliaMetals-Yalcin2000.pdf",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Pages 1-3 distinguish native copper hammering and annealing after ca. 8200 BCE from later extractive metallurgy and casting after ca. 5000 BCE.",
+    "source_claim_summary": "Yalçın and Özbal describe native copper working as an early monometallic stage and metal casting as a later development after extractive metallurgy.",
+    "source_support_rationale": "The source supports a historical sequence, not a direct dependency from native copper working to the broader casting-and-molding node."
+  },
+  "ontology_before": "The graph made native copper working a direct enabling prerequisite for a broad molten-metal casting node.",
+  "ontology_after": "Native copper working remains separately scoped; casting and molding no longer claims a direct dependency on that earlier native-copper stage.",
+  "invariant_preserved_or_changed": "Changed: copper_working is absent as a direct prerequisite for casting_and_molding.",
+  "would_reject_if": [
+    "The casting_and_molding node were split into an early copper-casting node with a source-backed date after extractive metallurgy.",
+    "A source showed the first scoped casting practice required native copper working specifically rather than later smelting or melting capabilities.",
+    "The graph reintroduced copper_working as a direct prerequisite without changing the casting node scope and chronology."
+  ],
+  "short_reason": "Native copper working is not a direct dependency for the broad casting node.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/copper_working.before.json /tmp/copper_working.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-copper-working-smelting-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-copper-working-smelting-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-copper-working-smelting-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "copper_working",
+    "prerequisite": "smelting_basic"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Basic Smelting is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from copper_working to smelting_basic; the node is now scoped to early native copper working and annealing, which predates later extractive copper smelting.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.ancientportsantiques.com/wp-content/uploads/Documents/PLACES/Turkey/AnatoliaMetals-Yalcin2000.pdf",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Pages 1-3, especially the monometallic-period discussion: native copper working after ca. 8200 BCE at Çayönü and Aşıklı; extractive copper smelting after ca. 5000 BCE.",
+    "source_claim_summary": "Yalçın and Özbal describe early native copper objects from Çayönü and Aşıklı as worked by hammering and repeated annealing, while placing extractive copper smelting later.",
+    "source_support_rationale": "This supports copper_working as native copper working and annealing, while rejecting smelting_basic as a direct prerequisite for the first-known copper-working claim."
+  },
+  "ontology_before": "The node treated basic smelting as a historical predecessor of copper working, implying copper working began as extractive smelting.",
+  "ontology_after": "The node is scoped to native copper working and annealing, with smelting left as a separate later metallurgy capability.",
+  "invariant_preserved_or_changed": "Changed: smelting_basic is absent as a direct prerequisite for copper_working.",
+  "would_reject_if": [
+    "The node were rescoped specifically to smelted copper production.",
+    "A source showed the earliest copper working at Çayönü required copper smelting.",
+    "The graph reintroduced smelting_basic as a prerequisite for the native-copper first-known claim."
+  ],
+  "short_reason": "Early copper working used native copper and annealing; smelting is a later metallurgy capability.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/copper_working.before.json /tmp/copper_working.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-metal-casting-molds-native-copper-edge-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-metal-casting-molds-native-copper-edge-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-metal-casting-molds-native-copper-edge-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "metal_casting_molds",
+    "prerequisite": "copper_working"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Copper Working provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from metal_casting_molds to copper_working. Metal casting molds should be connected to casting practice and mold materials, not directly to the earlier native-copper-working stage.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.ancientportsantiques.com/wp-content/uploads/Documents/PLACES/Turkey/AnatoliaMetals-Yalcin2000.pdf",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Pages 1-3 separate early hammered/annealed native copper objects from later smelting, casting, and open-mold castings.",
+    "source_claim_summary": "Yalçın and Özbal describe early native copper working and later casting/open-mold metallurgy as distinct stages.",
+    "source_support_rationale": "The source supports keeping mold technology tied to casting practice rather than to native copper working as a direct prerequisite."
+  },
+  "ontology_before": "The graph made native copper working a direct enabling prerequisite for metal casting molds.",
+  "ontology_after": "Metal casting molds remain connected to casting_and_molding and clay preparation, without a direct native-copper-working prerequisite.",
+  "invariant_preserved_or_changed": "Changed: copper_working is absent as a direct prerequisite for metal_casting_molds.",
+  "would_reject_if": [
+    "The node were narrowed to the first copper casting molds and supported with a source-specific chronology.",
+    "A source showed metal casting molds specifically emerged from native copper working rather than later casting practice.",
+    "The graph reintroduced copper_working as a direct prerequisite while preserving the broad metal-casting-mold scope."
+  ],
+  "short_reason": "Metal casting molds should not directly depend on the native-copper-working node.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/copper_working.before.json /tmp/copper_working.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-copper-working-scope.json
+++ b/docs/graph-invariants/2026-06-11-copper-working-scope.json
@@ -1,0 +1,30 @@
+{
+  "id": "2026-06-11-copper-working-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "copper_working",
+      "operator": "eq",
+      "value": -8200,
+      "reason": "The node is scoped to early native copper working and annealing at Çayönü Tepesi, not a 10000 BCE placeholder."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "copper_working",
+      "prerequisite": "smelting_basic",
+      "reason": "Native copper working and annealing should not depend on later extractive copper smelting."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "casting_and_molding",
+      "prerequisite": "copper_working",
+      "reason": "The broad casting node should not directly depend on the earlier native-copper-working scope."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "metal_casting_molds",
+      "prerequisite": "copper_working",
+      "reason": "Metal casting molds should be tied to casting practice and mold materials, not directly to native copper working."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Rescoped `copper_working` from broad copper extraction/smelting to early native copper working by hammering and annealing.
- Replaced the 10000 BCE placeholder with `firstKnownDate: -8200`, `datePrecision: century`, and `region: Çayönü Tepesi, eastern Anatolia`.
- Added a source-backed scope note and node source for Yalçın & Özbal, *History of Mining and Metallurgy in Anatolia: The First Metal, Copper*.
- Removed three weak/inaccurate direct edges:
  - `smelting_basic -> copper_working`
  - `copper_working -> casting_and_molding`
  - `copper_working -> metal_casting_molds`
- Added edge-change receipts and graph invariants for the topology changes.
- Regenerated the quality snapshot.

## Old claim vs new claim

Old: copper working was described as extraction and working of copper, tied directly to `smelting_basic`, with a 10000 BCE placeholder.

New: `copper_working` covers the earlier native-copper stage: small objects made by hammering and annealing native copper before later extractive metallurgy and casting.

## Source locator

Source: https://www.ancientportsantiques.com/wp-content/uploads/Documents/PLACES/Turkey/AnatoliaMetals-Yalcin2000.pdf

Locator: pages 1-3. The source describes native copper objects at Çayönü and Aşıklı around/after ca. 8200 BCE, worked by hammering and repeated annealing. It separately places extractive copper smelting and casting later, after ca. 5000 BCE.

## Why this is better

The previous graph conflated native copper working with smelting. That reversed the early metallurgy chronology: the first-known copper working did not require extractive smelting. The new node scope matches the source and avoids making broad casting nodes depend directly on the native-copper node.

## Adversarial note

The strongest reason this correction could be incomplete is that the neighboring early-metallurgy nodes still need their own chronology pass: `casting_and_molding`, `metal_casting_molds`, `smelting_basic`, `tin_working`, and `bronze_working` still carry broad placeholder dates. This PR does not solve the whole metallurgy cluster; it keeps the copper-working claim precise and auditable.

## Validation

- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/copper_working.before.json /tmp/copper_working.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed through tests, quality, and coverage; first `source-urls` attempt hit an unrelated CableLabs timeout
- Retried `npm run source-urls`: passed, 741 unique URLs
- `npm run accuracy:risks -- --markdown --limit 24` passed

Quality snapshot after regeneration:
- Source-checked nodes: 616 / 1,660
- Nodes with node-level sources: 651 / 1,660
- Dependency edges with edge-level sources: 1,897 / 5,563
- Era-default placeholder dates: 554 / 1,660