### PR TITLE
[codex] Source-check bone tool making chronology

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 616 / 1,660 (37.1%) |
-| Nodes with node-level sources | 651 / 1,660 (39.2%) |
-| Dependency edges with edge-level sources | 1,897 / 5,563 (34.1%) |
-| Era-default placeholder dates | 554 / 1,660 (33.4%) |
+| Source-checked nodes | 617 / 1,660 (37.2%) |
+| Nodes with node-level sources | 652 / 1,660 (39.3%) |
+| Dependency edges with edge-level sources | 1,898 / 5,562 (34.1%) |
+| Era-default placeholder dates | 553 / 1,660 (33.3%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -267,33 +267,59 @@
     "id": "bone_tool_making",
     "name": "Bone Tool Making",
     "era": "Ancient",
-    "description": "Crafting tools, needles, and points from animal bones, antlers, and ivory.",
+    "description": "Crafting functional implements from animal bone, including knapped large-mammal bone tools and later awls, needles, and points.",
     "prerequisites": [
-      "stone_tool_making",
-      "hunting_gathering_basic"
+      "stone_tool_making"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -1500000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Olduvai Gorge, Tanzania",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "stone_tool_making",
         "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Stone Tool Making is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "hunting_gathering_basic",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Basic Hunting & Gathering is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "confidence": 0.72,
+        "evidence_level": "primary_source",
+        "note": "The Olduvai assemblage documents bone tools shaped by knapping, so earlier percussion-flaking traditions are a close historical predecessor rather than a generic survival context.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Systematic bone tool production at 1.5 million years ago",
+            "url": "https://www.nature.com/articles/s41586-025-08652-5",
+            "publisher": "Nature",
+            "year": 2025,
+            "source_type": "primary_paper",
+            "supports": [
+              "node",
+              "edge",
+              "maturity"
+            ]
+          }
+        ]
       }
-    ]
+    ],
+    "fields": [
+      "Materials Science & Manufacturing"
+    ],
+    "fieldLanes": {
+      "Materials Science & Manufacturing": "Foundations"
+    },
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "Systematic bone tool production at 1.5 million years ago",
+        "url": "https://www.nature.com/articles/s41586-025-08652-5",
+        "publisher": "Nature",
+        "year": 2025,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "scopeNote": "Covers deliberate production of bone implements as a material technology. The first-known date is pinned to knapped large-mammal bone tools at Olduvai; later formal awls, needles, and antler/ivory industries should keep their own more specific dates."
   },
   {
     "id": "woodworking_basic",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T18:09:58.096Z",
+  "generatedAt": "2026-06-11T18:17:10.187Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 616,
+      "value": 617,
       "denominator": 1660,
-      "formatted": "616 / 1,660",
-      "note": "37.1%"
+      "formatted": "617 / 1,660",
+      "note": "37.2%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 651,
+      "value": 652,
       "denominator": 1660,
-      "formatted": "651 / 1,660",
-      "note": "39.2%"
+      "formatted": "652 / 1,660",
+      "note": "39.3%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1897,
-      "denominator": 5563,
-      "formatted": "1,897 / 5,563",
+      "value": 1898,
+      "denominator": 5562,
+      "formatted": "1,898 / 5,562",
       "note": "34.1%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 554,
+      "value": 553,
       "denominator": 1660,
-      "formatted": "554 / 1,660",
-      "note": "33.4%"
+      "formatted": "553 / 1,660",
+      "note": "33.3%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 651,
-    "sourceChecked": 616,
+    "nodesWithSources": 652,
+    "sourceChecked": 617,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 554,
+    "eraDefaultDates": 553,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5563,
-    "edgesWithSources": 1897
+    "totalEdges": 5562,
+    "edgesWithSources": 1898
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T18:09:58.096Z
+Generated: 2026-06-11T18:17:10.187Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 616 / 1,660 (37.1%) |
-| Nodes with node-level sources | 651 / 1,660 (39.2%) |
-| Dependency edges with edge-level sources | 1,897 / 5,563 (34.1%) |
-| Era-default placeholder dates | 554 / 1,660 (33.4%) |
+| Source-checked nodes | 617 / 1,660 (37.2%) |
+| Nodes with node-level sources | 652 / 1,660 (39.3%) |
+| Dependency edges with edge-level sources | 1,898 / 5,562 (34.1%) |
+| Era-default placeholder dates | 553 / 1,660 (33.3%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-bone-tool-making-hunting-edge-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-bone-tool-making-hunting-edge-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-bone-tool-making-hunting-edge-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "bone_tool_making",
+    "prerequisite": "hunting_gathering_basic"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Basic Hunting & Gathering is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from bone_tool_making to hunting_gathering_basic. The source-backed first-known claim is a knapped-bone manufacturing assemblage, not a claim that generalized hunting-and-gathering practice is a direct prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.nature.com/articles/s41586-025-08652-5",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract and main paper: documents an Olduvai Gorge assemblage of bone tools shaped by knapping in a single horizon dated to 1.5 Ma.",
+    "source_claim_summary": "The paper supports systematic bone-tool production through knapping of large-mammal limb bone fragments at Olduvai, without making generalized hunting-gathering systems a direct prerequisite.",
+    "source_support_rationale": "The source points to transferred knapping/manufacturing practice, so stone toolmaking is the relevant predecessor while hunting_gathering_basic is only broad context."
+  },
+  "ontology_before": "The graph treated generalized hunting-and-gathering as a direct historical predecessor of bone tool making.",
+  "ontology_after": "Bone tool making is scoped to a manufacturing practice whose relevant predecessor is percussion-flaking/stone-tool craft, not broad subsistence organization.",
+  "invariant_preserved_or_changed": "Changed: hunting_gathering_basic is absent as a direct prerequisite for bone_tool_making.",
+  "would_reject_if": [
+    "A source showed the first scoped bone-tool assemblage required an organized hunting-and-gathering technology rather than available animal bone and knapping practice.",
+    "The node were narrowed to a later hunter-gatherer bone-point or needle industry with a different source-backed dependency.",
+    "The graph reintroduced hunting_gathering_basic as a direct prerequisite without changing the node scope."
+  ],
+  "short_reason": "The first-known bone-tool claim is manufacturing-specific, not a generic subsistence dependency.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/bone_tool_making.before.json /tmp/bone_tool_making.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-bone-tool-making-scope.json
+++ b/docs/graph-invariants/2026-06-11-bone-tool-making-scope.json
@@ -1,0 +1,18 @@
+{
+  "id": "2026-06-11-bone-tool-making-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "bone_tool_making",
+      "operator": "eq",
+      "value": -1500000,
+      "reason": "The node is scoped to systematic knapped bone-tool production documented at Olduvai Gorge around 1.5 Ma."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "bone_tool_making",
+      "prerequisite": "hunting_gathering_basic",
+      "reason": "Generalized hunting-and-gathering is broad context, not a direct prerequisite for the source-backed knapped-bone-tool claim."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Rescoped `bone_tool_making` to deliberate production of bone implements, including the documented Olduvai knapped large-mammal bone tools.
- Replaced the 10000 BCE placeholder with `firstKnownDate: -1500000`, `datePrecision: millennium`, and `region: Olduvai Gorge, Tanzania`.
- Added a primary Nature source and marked the node `source_checked`.
- Strengthened the `stone_tool_making -> bone_tool_making` edge with primary-source evidence and an edge-level source.
- Removed the weak `hunting_gathering_basic -> bone_tool_making` contextual edge.
- Added an edge-change receipt and graph invariant.
- Regenerated the quality snapshot.

## Old claim vs new claim

Old: bone tool making was a broad, unsourced 10000 BCE placeholder tied to generalized hunting/gathering.

New: bone tool making is pinned to a 1.5 Ma Olduvai Gorge assemblage of bone tools shaped by knapping, with later formal awls/needles left as later examples under the broader material tradition.

## Source locator

Source: https://www.nature.com/articles/s41586-025-08652-5

Locator: abstract and main paper. The paper documents an assemblage of bone tools shaped by knapping in a single Olduvai Gorge horizon dated to 1.5 Ma.

## Why this is better

The previous node was off by roughly 1.49 million years and made a generic subsistence system look like a direct prerequisite. The new version pins the date, region, and edge semantics to a primary source.

## Adversarial note

The strongest reason this could be wrong is scope breadth: later awls, needles, antler tools, and ivory industries have distinct chronologies. The scope note explicitly keeps those later formal traditions from being laundered into the 1.5 Ma claim.

## Validation

- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/bone_tool_making.before.json /tmp/bone_tool_making.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed
- `npm run accuracy:risks -- --markdown --limit 24` passed

Quality snapshot after regeneration:
- Source-checked nodes: 617 / 1,660
- Nodes with node-level sources: 652 / 1,660
- Dependency edges with edge-level sources: 1,898 / 5,562
- Era-default placeholder dates: 553 / 1,660