### PR TITLE
[codex] Source-check animal husbandry edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 617 / 1,660 (37.2%) |
+| Source-checked nodes | 618 / 1,660 (37.2%) |
 | Nodes with node-level sources | 652 / 1,660 (39.3%) |
-| Dependency edges with edge-level sources | 1,898 / 5,562 (34.1%) |
+| Dependency edges with edge-level sources | 1,900 / 5,562 (34.2%) |
 | Era-default placeholder dates | 553 / 1,660 (33.3%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -2205,37 +2205,74 @@
     "firstKnownDate": -9500,
     "datePrecision": "millennium",
     "region": "Southwest Asia and later independent pastoral regions",
-    "reviewStatus": "structurally_validated",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "animal_domestication",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Animal Domestication provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "required",
+        "confidence": 0.82,
+        "evidence_level": "review",
+        "note": "Animal husbandry is scoped to stock-keeping and livestock care, which requires domesticated or managed animals rather than wild prey alone.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Pace and process in the emergence of animal husbandry in Neolithic Southwest Asia",
+            "url": "https://www.anthropology.uw.edu.pl/08/bne-08-03.pdf",
+            "publisher": "Bioarchaeology of the Near East",
+            "year": 2014,
+            "source_type": "review",
+            "supports": [
+              "node",
+              "edge",
+              "maturity"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "agriculture",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Agriculture provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      }
-    ],
-    "sources": [
-      {
-        "title": "Animal breeding",
-        "url": "https://www.britannica.com/science/animal-breeding",
-        "publisher": "Encyclopaedia Britannica",
-        "year": 2026,
-        "source_type": "generic_overview",
-        "supports": [
-          "node"
+        "type": "common_dependency",
+        "confidence": 0.55,
+        "evidence_level": "review",
+        "note": "Early herding spread through Neolithic food-production systems, but plant agriculture is contextual rather than a strict technical prerequisite for livestock husbandry.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Pace and process in the emergence of animal husbandry in Neolithic Southwest Asia",
+            "url": "https://www.anthropology.uw.edu.pl/08/bne-08-03.pdf",
+            "publisher": "Bioarchaeology of the Near East",
+            "year": 2014,
+            "source_type": "review",
+            "supports": [
+              "node",
+              "edge",
+              "maturity"
+            ]
+          }
         ]
       }
-    ]
+    ],
+    "fields": [
+      "Agriculture & Food Systems"
+    ],
+    "fieldLanes": {
+      "Agriculture & Food Systems": "Foundations"
+    },
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "Pace and process in the emergence of animal husbandry in Neolithic Southwest Asia",
+        "url": "https://www.anthropology.uw.edu.pl/08/bne-08-03.pdf",
+        "publisher": "Bioarchaeology of the Near East",
+        "year": 2014,
+        "source_type": "review",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "scopeNote": "Covers early stock-keeping and livestock husbandry emerging from Southwest Asian domestication systems and later spreading into other pastoral regions. It should not imply that crop agriculture is always a hard prerequisite for livestock herding."
   },
   {
     "id": "pastoralism",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T18:17:10.187Z",
+  "generatedAt": "2026-06-11T18:30:24.447Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,9 +11,9 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 617,
+      "value": 618,
       "denominator": 1660,
-      "formatted": "617 / 1,660",
+      "formatted": "618 / 1,660",
       "note": "37.2%"
     },
     {
@@ -25,10 +25,10 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1898,
+      "value": 1900,
       "denominator": 5562,
-      "formatted": "1,898 / 5,562",
-      "note": "34.1%"
+      "formatted": "1,900 / 5,562",
+      "note": "34.2%"
     },
     {
       "label": "Era-default placeholder dates",
@@ -55,13 +55,13 @@
   "riskReportTotals": {
     "technologies": 1660,
     "nodesWithSources": 652,
-    "sourceChecked": 617,
+    "sourceChecked": 618,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 553,
     "sourceCheckedEraDefaultDates": 0,
     "totalEdges": 5562,
-    "edgesWithSources": 1898
+    "edgesWithSources": 1900
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,15 +1,15 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T18:17:10.187Z
+Generated: 2026-06-11T18:30:24.447Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 617 / 1,660 (37.2%) |
+| Source-checked nodes | 618 / 1,660 (37.2%) |
 | Nodes with node-level sources | 652 / 1,660 (39.3%) |
-| Dependency edges with edge-level sources | 1,898 / 5,562 (34.1%) |
+| Dependency edges with edge-level sources | 1,900 / 5,562 (34.2%) |
 | Era-default placeholder dates | 553 / 1,660 (33.3%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-animal-husbandry-agriculture-common.json
+++ b/docs/edge-change-receipts/2026-06-11-animal-husbandry-agriculture-common.json
@@ -1,0 +1,47 @@
+{
+  "id": "2026-06-11-animal-husbandry-agriculture-common",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "animal_husbandry",
+    "prerequisite": "agriculture"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Agriculture provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "common_dependency",
+    "confidence": 0.55,
+    "evidence_level": "review",
+    "note": "Early herding spread through Neolithic food-production systems, but plant agriculture is contextual rather than a strict technical prerequisite for livestock husbandry."
+  },
+  "source_supports_edge": "partial",
+  "source_url": "https://www.anthropology.uw.edu.pl/08/bne-08-03.pdf",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Abstract and introduction: reviews the emergence of Southwest Asian animal husbandry within Neolithic farming expansion while emphasizing a multi-century, regionally varied process.",
+    "source_claim_summary": "The source supports a historical association between early herding and Neolithic food-production systems, but not a hard technical dependency on crop farming.",
+    "source_support_rationale": "The relation is best modeled as contextual/common dependency rather than enabling or required."
+  },
+  "ontology_before": "The graph made agriculture look like a direct enabler for livestock husbandry.",
+  "ontology_after": "The graph preserves the Neolithic food-production context while avoiding a hard dependency from husbandry to crop agriculture.",
+  "invariant_preserved_or_changed": "Changed: agriculture -> animal_husbandry is common_dependency.",
+  "would_reject_if": [
+    "The node were narrowed to mixed crop-livestock farming rather than animal husbandry generally.",
+    "A source showed crop agriculture was technically required for the scoped husbandry practice.",
+    "The graph promoted agriculture back to enabling or required without narrowing the node scope."
+  ],
+  "short_reason": "Agriculture is contextual for early husbandry, not a universal hard prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/animal_husbandry.before.json /tmp/animal_husbandry.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-animal-husbandry-domestication-required.json
+++ b/docs/edge-change-receipts/2026-06-11-animal-husbandry-domestication-required.json
@@ -1,0 +1,47 @@
+{
+  "id": "2026-06-11-animal-husbandry-domestication-required",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "animal_husbandry",
+    "prerequisite": "animal_domestication"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Animal Domestication provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.82,
+    "evidence_level": "review",
+    "note": "Animal husbandry is scoped to stock-keeping and livestock care, which requires domesticated or managed animals rather than wild prey alone."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.anthropology.uw.edu.pl/08/bne-08-03.pdf",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "demonstrates_method_dependency",
+    "source_locator": "Abstract and introduction: discusses sheep, goats, cattle, and pigs being domesticated in Southwest Asia and forming an integrated barnyard complex that fueled Neolithic expansion.",
+    "source_claim_summary": "The review treats animal husbandry as stock-keeping/herding rooted in the domestication of livestock taxa.",
+    "source_support_rationale": "Domesticated or managed animals are intrinsic to the scoped husbandry practice, so the edge is stronger than a generic enabling relation."
+  },
+  "ontology_before": "The graph treated animal domestication as merely enabling animal husbandry.",
+  "ontology_after": "The graph treats animal domestication as a required prerequisite for livestock husbandry and stock-keeping.",
+  "invariant_preserved_or_changed": "Changed: animal_domestication -> animal_husbandry is required.",
+  "would_reject_if": [
+    "The node were rescoped to general human-animal interaction rather than livestock husbandry.",
+    "A source showed the scoped husbandry practice was performed on unmanaged wild animals.",
+    "The graph demoted animal_domestication without changing the animal_husbandry scope."
+  ],
+  "short_reason": "Livestock husbandry requires managed/domesticated animals.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/animal_husbandry.before.json /tmp/animal_husbandry.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-animal-husbandry-scope.json
+++ b/docs/graph-invariants/2026-06-11-animal-husbandry-scope.json
@@ -1,0 +1,19 @@
+{
+  "id": "2026-06-11-animal-husbandry-scope",
+  "checks": [
+    {
+      "type": "edge_type",
+      "dependent": "animal_husbandry",
+      "prerequisite": "animal_domestication",
+      "expected": "required",
+      "reason": "Livestock husbandry requires managed or domesticated animals."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "animal_husbandry",
+      "prerequisite": "agriculture",
+      "expected": "common_dependency",
+      "reason": "Crop agriculture is early Neolithic context for stock-keeping, not a universal technical prerequisite."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Replaced the generic Britannica animal-breeding source on `animal_husbandry` with Arbuckle, *Pace and process in the emergence of animal husbandry in Neolithic Southwest Asia*.
- Marked `animal_husbandry` as `source_checked` and added a scope note.
- Added Agriculture & Food field metadata using an existing valid lane.
- Retyped and sourced both direct incoming edges:
  - `animal_domestication -> animal_husbandry`: `required`, review evidence.
  - `agriculture -> animal_husbandry`: `common_dependency`, review evidence.
- Added edge-change receipts and graph invariants for both edge semantics.
- Regenerated quality snapshots.

## Old claim vs new claim

Old: animal husbandry used a generic overview source and treated both animal domestication and agriculture as generic enabling prerequisites.

New: animal husbandry is scoped to early stock-keeping/livestock care in Southwest Asian domestication systems. Domestication is required for that scope; crop agriculture is historical Neolithic context, not a universal hard prerequisite.

## Source locator

Source: https://www.anthropology.uw.edu.pl/08/bne-08-03.pdf

Locator: abstract and introduction. The review discusses Southwest Asian sheep, goats, cattle, and pigs being domesticated and the emergence of an integrated barnyard complex over a regionally varied Neolithic process.

## Why this is better

This removes a weak generic overview source from a foundational agriculture node and makes the edge semantics visible: livestock husbandry depends on domesticated/managed animals, while crop agriculture should not be modeled as a hard prerequisite for all husbandry.

## Adversarial note

The strongest reason this could be incomplete is that `animal_domestication` itself still deserves a separate source-check pass. This PR only corrects `animal_husbandry` and its direct incoming edge semantics.

## Validation

- `npm test` passed
- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/animal_husbandry.before.json /tmp/animal_husbandry.after.json --require-behavior-change` passed
- `npm run quality` passed
- `npm run coverage` passed
- `npm run source-urls` passed, 742 unique URLs
- `npm run accuracy:risks -- --markdown --limit 24` passed

Quality snapshot after regeneration:
- Source-checked nodes: 618 / 1,660
- Nodes with node-level sources: 652 / 1,660
- Dependency edges with edge-level sources: 1,900 / 5,562
- Era-default placeholder dates: 553 / 1,660