### PR TITLE
[codex] Source-check stone grinding slabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 618 / 1,660 (37.2%) |
-| Nodes with node-level sources | 652 / 1,660 (39.3%) |
-| Dependency edges with edge-level sources | 1,900 / 5,562 (34.2%) |
-| Era-default placeholder dates | 553 / 1,660 (33.3%) |
+| Source-checked nodes | 619 / 1,660 (37.3%) |
+| Nodes with node-level sources | 653 / 1,660 (39.3%) |
+| Dependency edges with edge-level sources | 1,901 / 5,561 (34.2%) |
+| Era-default placeholder dates | 552 / 1,660 (33.3%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -9358,33 +9358,61 @@
     "id": "stone_grinding_slabs",
     "name": "Stone Grinding Slabs",
     "era": "Ancient",
-    "description": "Flat grinding stones for processing grains, seeds, pigments, medicines, and mineral powders.",
+    "description": "Flat stone implements used to grind wild cereals, seeds, pigments, medicines, and mineral powders.",
     "prerequisites": [
-      "stone_tool_making",
-      "plant_domestication"
+      "stone_tool_making"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -21000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Ohalo II, Sea of Galilee, Israel",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "stone_tool_making",
         "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Stone Tool Making is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "plant_domestication",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Plant Domestication provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "confidence": 0.72,
+        "evidence_level": "primary_source",
+        "note": "The Ohalo II grinding stone is a modified stone implement used for processing wild cereals, so earlier stone toolmaking is the relevant material predecessor.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "New evidence for the processing of wild cereal grains at Ohalo II, a 23 000-year-old campsite on the shore of the Sea of Galilee, Israel",
+            "url": "https://cris.haifa.ac.il/en/publications/new-evidence-for-the-processing-of-wild-cereal-grains-at-ohalo-ii/",
+            "publisher": "Antiquity / University of Haifa CRIS",
+            "year": 2012,
+            "source_type": "primary_paper",
+            "supports": [
+              "node",
+              "edge",
+              "maturity"
+            ]
+          }
+        ]
       }
-    ]
+    ],
+    "fields": [
+      "Agriculture & Food Systems",
+      "Materials Science & Manufacturing"
+    ],
+    "fieldLanes": {
+      "Agriculture & Food Systems": "Foundations",
+      "Materials Science & Manufacturing": "Foundations"
+    },
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "New evidence for the processing of wild cereal grains at Ohalo II, a 23 000-year-old campsite on the shore of the Sea of Galilee, Israel",
+        "url": "https://cris.haifa.ac.il/en/publications/new-evidence-for-the-processing-of-wild-cereal-grains-at-ohalo-ii/",
+        "publisher": "Antiquity / University of Haifa CRIS",
+        "year": 2012,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "scopeNote": "Covers flat grinding stones used for wild plant and material processing. The first-known date is pinned to wild-cereal processing at Ohalo II and should not be made dependent on later plant domestication."
   },
   {
     "id": "mortar_pestle_food_processing",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T18:30:24.447Z",
+  "generatedAt": "2026-06-11T18:36:01.909Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,30 +11,30 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 618,
+      "value": 619,
       "denominator": 1660,
-      "formatted": "618 / 1,660",
-      "note": "37.2%"
+      "formatted": "619 / 1,660",
+      "note": "37.3%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 652,
+      "value": 653,
       "denominator": 1660,
-      "formatted": "652 / 1,660",
+      "formatted": "653 / 1,660",
       "note": "39.3%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1900,
-      "denominator": 5562,
-      "formatted": "1,900 / 5,562",
+      "value": 1901,
+      "denominator": 5561,
+      "formatted": "1,901 / 5,561",
       "note": "34.2%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 553,
+      "value": 552,
       "denominator": 1660,
-      "formatted": "553 / 1,660",
+      "formatted": "552 / 1,660",
       "note": "33.3%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 652,
-    "sourceChecked": 618,
+    "nodesWithSources": 653,
+    "sourceChecked": 619,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 553,
+    "eraDefaultDates": 552,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5562,
-    "edgesWithSources": 1900
+    "totalEdges": 5561,
+    "edgesWithSources": 1901
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T18:30:24.447Z
+Generated: 2026-06-11T18:36:01.909Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 618 / 1,660 (37.2%) |
-| Nodes with node-level sources | 652 / 1,660 (39.3%) |
-| Dependency edges with edge-level sources | 1,900 / 5,562 (34.2%) |
-| Era-default placeholder dates | 553 / 1,660 (33.3%) |
+| Source-checked nodes | 619 / 1,660 (37.3%) |
+| Nodes with node-level sources | 653 / 1,660 (39.3%) |
+| Dependency edges with edge-level sources | 1,901 / 5,561 (34.2%) |
+| Era-default placeholder dates | 552 / 1,660 (33.3%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-stone-grinding-plant-domestication-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-stone-grinding-plant-domestication-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-stone-grinding-plant-domestication-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "stone_grinding_slabs",
+    "prerequisite": "plant_domestication"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Plant Domestication provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from stone_grinding_slabs to plant_domestication. The source-backed first-known claim is wild-cereal processing at Ohalo II, long before domesticated crops.",
+  "source_supports_edge": "no",
+  "source_url": "https://cris.haifa.ac.il/en/publications/new-evidence-for-the-processing-of-wild-cereal-grains-at-ohalo-ii/",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: documents routine processing of wild cereals, including wheat, barley, and oats, around 23,000 years ago at Ohalo II.",
+    "source_claim_summary": "The paper supports grinding-stone use for wild cereals at a hunter-gatherer site that predates Neolithic plant domestication.",
+    "source_support_rationale": "Because the documented grinding use involved wild cereals, plant domestication is not a prerequisite for the scoped stone-grinding-slab technology."
+  },
+  "ontology_before": "The graph made plant domestication a direct enabler of stone grinding slabs, implying grinding slabs emerged from domesticated crop processing.",
+  "ontology_after": "Stone grinding slabs are scoped to wild-cereal and material processing, with plant domestication left as a later agricultural context rather than a prerequisite.",
+  "invariant_preserved_or_changed": "Changed: plant_domestication is absent as a direct prerequisite for stone_grinding_slabs.",
+  "would_reject_if": [
+    "The node were narrowed to grinding slabs specifically for domesticated crop agriculture.",
+    "A source showed the earliest scoped grinding slabs required domesticated plants.",
+    "The graph reintroduced plant_domestication as a direct prerequisite without changing the node scope."
+  ],
+  "short_reason": "Wild-cereal grinding at Ohalo II predates plant domestication.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/stone_grinding_slabs.before.json /tmp/stone_grinding_slabs.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-stone-grinding-slabs-scope.json
+++ b/docs/graph-invariants/2026-06-11-stone-grinding-slabs-scope.json
@@ -1,0 +1,18 @@
+{
+  "id": "2026-06-11-stone-grinding-slabs-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "stone_grinding_slabs",
+      "operator": "eq",
+      "value": -21000,
+      "reason": "The node is scoped to wild-cereal grinding at the 23,000-year-old Ohalo II site."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "stone_grinding_slabs",
+      "prerequisite": "plant_domestication",
+      "reason": "Wild-cereal grinding predates plant domestication and should not depend on it."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Rescoped `stone_grinding_slabs` to flat stone implements used for wild cereal and material processing.
- Replaced the 10000 BCE placeholder with `firstKnownDate: -21000`, `datePrecision: millennium`, and `region: Ohalo II, Sea of Galilee, Israel`.
- Added a primary Antiquity source via University of Haifa CRIS.
- Strengthened `stone_tool_making -> stone_grinding_slabs` with primary-source edge evidence.
- Removed `plant_domestication -> stone_grinding_slabs`, because the source-backed use predates domesticated crops.
- Added an edge-change receipt and graph invariant.
- Regenerated quality snapshots.

## Old claim vs new claim

Old: stone grinding slabs were a 10000 BCE placeholder and depended on plant domestication.

New: stone grinding slabs are pinned to Ohalo II evidence for routine wild-cereal processing around 23,000 years ago, before Neolithic domestication.

## Source locator

Source: https://cris.haifa.ac.il/en/publications/new-evidence-for-the-processing-of-wild-cereal-grains-at-ohalo-ii/

Locator: abstract. The source states that the Ohalo II stone was used for routine processing of wild cereals, including wheat, barley, and oats, around 23,000 years ago.

## Why this is better

The previous edge made grinding slabs look like a domesticated-crop technology. The Ohalo II evidence shows the opposite: wild-cereal grinding predates plant domestication, so the plant-domestication prerequisite was misleading.

## Adversarial note

The strongest reason this could be incomplete is that `mortar_pestle_food_processing` still has its own 10000 BCE placeholder and should receive a separate source-check pass. This PR only corrects flat stone grinding slabs.

## Validation

- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/stone_grinding_slabs.before.json /tmp/stone_grinding_slabs.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed
- `npm run accuracy:risks -- --markdown --limit 24` passed

Quality snapshot after regeneration:
- Source-checked nodes: 619 / 1,660
- Nodes with node-level sources: 653 / 1,660
- Dependency edges with edge-level sources: 1,901 / 5,561
- Era-default placeholder dates: 552 / 1,660