### PR TITLE
[codex] Source-check basic shelter chronology

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 619 / 1,660 (37.3%) |
-| Nodes with node-level sources | 653 / 1,660 (39.3%) |
-| Dependency edges with edge-level sources | 1,901 / 5,561 (34.2%) |
-| Era-default placeholder dates | 552 / 1,660 (33.3%) |
+| Source-checked nodes | 620 / 1,660 (37.3%) |
+| Nodes with node-level sources | 654 / 1,660 (39.4%) |
+| Dependency edges with edge-level sources | 1,902 / 5,560 (34.2%) |
+| Era-default placeholder dates | 551 / 1,660 (33.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -378,33 +378,59 @@
     "id": "basic_shelter",
     "name": "Basic Shelter",
     "era": "Ancient",
-    "description": "Construction of rudimentary shelters like lean-tos from wood, bone, and hides for protection from elements.",
+    "description": "Construction of simple brushwood, branch, hide, or bone shelters for protection from weather and repeated camp use.",
     "prerequisites": [
-      "woodworking_basic",
-      "bone_tool_making"
+      "woodworking_basic"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -21000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Ohalo II, Sea of Galilee, Israel",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "woodworking_basic",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Basic Woodworking is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "bone_tool_making",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Bone Tool Making provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "confidence": 0.66,
+        "evidence_level": "primary_source",
+        "note": "The Ohalo II shelter evidence comes from brush huts made with plant stems and branch material; wood handling enabled this shelter form but does not make formal woodworking a universal hard prerequisite.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Stone Age hut in Israel yields world's oldest evidence of bedding",
+            "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC404215/",
+            "publisher": "Proceedings of the National Academy of Sciences",
+            "year": 2004,
+            "source_type": "primary_paper",
+            "supports": [
+              "node",
+              "edge",
+              "maturity"
+            ]
+          }
+        ]
       }
-    ]
+    ],
+    "fields": [
+      "Civil Engineering & Built Environment"
+    ],
+    "fieldLanes": {
+      "Civil Engineering & Built Environment": "Foundations & Surveying"
+    },
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "Stone Age hut in Israel yields world's oldest evidence of bedding",
+        "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC404215/",
+        "publisher": "Proceedings of the National Academy of Sciences",
+        "year": 2004,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "scopeNote": "Covers simple constructed shelters, with the first-known date pinned to brush-hut floors and bedding at Ohalo II. Later hide tents, bone-frame shelters, and permanent dwellings should keep their own narrower dates."
   },
   {
     "id": "pigment_creation",

--- a/data/classical.json
+++ b/data/classical.json
@@ -1637,8 +1637,8 @@
       },
       {
         "title": "Vitruvius: The Ten Books on Architecture",
-        "url": "https://www.gutenberg.org/files/20239/20239-h/20239-h.htm",
-        "publisher": "Project Gutenberg / Harvard University Press translation",
+        "url": "https://penelope.uchicago.edu/Thayer/E/Roman/Texts/Vitruvius/1%2A.html",
+        "publisher": "LacusCurtius / University of Chicago",
         "year": 1914,
         "source_type": "textbook",
         "supports": [
@@ -1675,8 +1675,8 @@
         "sources": [
           {
             "title": "Vitruvius: The Ten Books on Architecture",
-            "url": "https://www.gutenberg.org/files/20239/20239-h/20239-h.htm",
-            "publisher": "Project Gutenberg / Harvard University Press translation",
+            "url": "https://penelope.uchicago.edu/Thayer/E/Roman/Texts/Vitruvius/1%2A.html",
+            "publisher": "LacusCurtius / University of Chicago",
             "year": 1914,
             "source_type": "textbook",
             "supports": [

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T18:36:01.909Z",
+  "generatedAt": "2026-06-11T18:48:44.972Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 619,
+      "value": 620,
       "denominator": 1660,
-      "formatted": "619 / 1,660",
+      "formatted": "620 / 1,660",
       "note": "37.3%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 653,
+      "value": 654,
       "denominator": 1660,
-      "formatted": "653 / 1,660",
-      "note": "39.3%"
+      "formatted": "654 / 1,660",
+      "note": "39.4%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1901,
-      "denominator": 5561,
-      "formatted": "1,901 / 5,561",
+      "value": 1902,
+      "denominator": 5560,
+      "formatted": "1,902 / 5,560",
       "note": "34.2%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 552,
+      "value": 551,
       "denominator": 1660,
-      "formatted": "552 / 1,660",
-      "note": "33.3%"
+      "formatted": "551 / 1,660",
+      "note": "33.2%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 653,
-    "sourceChecked": 619,
+    "nodesWithSources": 654,
+    "sourceChecked": 620,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 552,
+    "eraDefaultDates": 551,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5561,
-    "edgesWithSources": 1901
+    "totalEdges": 5560,
+    "edgesWithSources": 1902
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T18:36:01.909Z
+Generated: 2026-06-11T18:48:44.972Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 619 / 1,660 (37.3%) |
-| Nodes with node-level sources | 653 / 1,660 (39.3%) |
-| Dependency edges with edge-level sources | 1,901 / 5,561 (34.2%) |
-| Era-default placeholder dates | 552 / 1,660 (33.3%) |
+| Source-checked nodes | 620 / 1,660 (37.3%) |
+| Nodes with node-level sources | 654 / 1,660 (39.4%) |
+| Dependency edges with edge-level sources | 1,902 / 5,560 (34.2%) |
+| Era-default placeholder dates | 551 / 1,660 (33.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-basic-shelter-bone-tool-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-basic-shelter-bone-tool-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-basic-shelter-bone-tool-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "basic_shelter",
+    "prerequisite": "bone_tool_making"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Bone Tool Making provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from basic_shelter to bone_tool_making. The Ohalo II brush-hut source supports constructed plant/brush shelters, not bone tools as a direct prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC404215/",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract and site description: reports bedding on a brush-hut floor at Ohalo II; it does not identify bone tools as necessary for the shelter claim.",
+    "source_claim_summary": "The source supports brush-hut shelter evidence without supporting bone-tool making as a direct dependency.",
+    "source_support_rationale": "Bone tools may appear in some later shelter traditions, but they are not required by the source-backed basic shelter scope."
+  },
+  "ontology_before": "The graph made bone tool making a direct enabling prerequisite for basic shelter.",
+  "ontology_after": "The source-backed basic shelter scope does not depend directly on bone tool making.",
+  "invariant_preserved_or_changed": "Changed: bone_tool_making is absent as a direct prerequisite for basic_shelter.",
+  "would_reject_if": [
+    "The node were narrowed to bone-frame shelters or another shelter class that directly requires bone tools.",
+    "A source showed the Ohalo II brush huts required bone-tool manufacturing.",
+    "The graph reintroduced bone_tool_making as a direct prerequisite without changing the shelter scope."
+  ],
+  "short_reason": "Bone tool making is not supported as a direct prerequisite for source-backed basic shelter.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/basic_shelter.before.json /tmp/basic_shelter.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-basic-shelter-woodworking-enabling.json
+++ b/docs/edge-change-receipts/2026-06-11-basic-shelter-woodworking-enabling.json
@@ -1,0 +1,47 @@
+{
+  "id": "2026-06-11-basic-shelter-woodworking-enabling",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "basic_shelter",
+    "prerequisite": "woodworking_basic"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Basic Woodworking is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.66,
+    "evidence_level": "primary_source",
+    "note": "The Ohalo II shelter evidence comes from brush huts made with plant stems and branch material; wood handling enabled this shelter form but does not make formal woodworking a universal hard prerequisite."
+  },
+  "source_supports_edge": "partial",
+  "source_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC404215/",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "documents_application_use",
+    "source_locator": "Abstract and site description: reports grass bedding exposed on a brush-hut floor at the 23,000-year-old Ohalo II fisher-hunter-gatherer camp.",
+    "source_claim_summary": "The source documents constructed brush huts and bedding at Ohalo II, supporting wood/plant handling as an enabling capability for this shelter form.",
+    "source_support_rationale": "The source supports wood/plant material use in shelter construction, but it does not prove formal woodworking is a hard prerequisite for every simple shelter."
+  },
+  "ontology_before": "The edge treated basic woodworking as a generic historical predecessor for basic shelter.",
+  "ontology_after": "The edge now treats wood handling as an enabling capability for the source-backed brush-hut shelter scope.",
+  "invariant_preserved_or_changed": "Changed: woodworking_basic -> basic_shelter is enabling.",
+  "would_reject_if": [
+    "The node were narrowed to a shelter type that does not use wood, brush, stems, or branch material.",
+    "A source showed the Ohalo II brush huts required a different prerequisite technology instead of wood/plant material handling.",
+    "The graph promoted woodworking_basic to required without evidence that formal woodworking is universal for basic shelter."
+  ],
+  "short_reason": "Ohalo II brush huts support wood/plant handling as enabling, not a hard universal prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/basic_shelter.before.json /tmp/basic_shelter.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-basic-shelter-scope.json
+++ b/docs/graph-invariants/2026-06-11-basic-shelter-scope.json
@@ -1,0 +1,25 @@
+{
+  "id": "2026-06-11-basic-shelter-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "basic_shelter",
+      "operator": "eq",
+      "value": -21000,
+      "reason": "The node is scoped to source-backed brush-hut shelter evidence from the 23,000-year-old Ohalo II site."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "basic_shelter",
+      "prerequisite": "woodworking_basic",
+      "expected": "enabling",
+      "reason": "Wood and brush handling enable the Ohalo II shelter form but are not modeled as a hard universal prerequisite."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "basic_shelter",
+      "prerequisite": "bone_tool_making",
+      "reason": "The source-backed brush-hut claim does not require bone tool making."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Rescoped `basic_shelter` to simple constructed shelters, anchored to Ohalo II brush huts and bedding.
- Replaced the 10000 BCE placeholder with `firstKnownDate: -21000`, `datePrecision: millennium`, and `region: Ohalo II, Sea of Galilee, Israel`.
- Added a primary PNAS source and marked the node `source_checked`.
- Retyped `woodworking_basic -> basic_shelter` from `historical_predecessor` to `enabling`, with edge-level source evidence.
- Removed the unsupported `bone_tool_making -> basic_shelter` edge.
- Added two edge-change receipts and a graph invariant.
- Replaced the slow Project Gutenberg file URL on `construction` with a faster University of Chicago/LacusCurtius Vitruvius mirror for the same source claim.
- Regenerated quality snapshots.

## Old claim vs new claim

Old: basic shelter was a 10000 BCE placeholder with weak edges from woodworking and bone-tool making.

New: basic shelter is pinned to source-backed Ohalo II brush-hut evidence around 23,000 BP. Wood/plant material handling is an enabling capability; bone-tool making is not a direct prerequisite for this scope.

## Source locator

Basic shelter source: https://pmc.ncbi.nlm.nih.gov/articles/PMC404215/

Locator: abstract and site description. The paper reports grass bedding exposed on a brush-hut floor at the 23,000-year-old Ohalo II fisher-hunter-gatherer camp.

Vitruvius URL maintenance source: https://penelope.uchicago.edu/Thayer/E/Roman/Texts/Vitruvius/1%2A.html

## Why this is better

The previous shelter claim was both too late and too generic. Ohalo II gives a concrete archaeological anchor for simple constructed shelters, and the dependency graph no longer implies bone-tool making is necessary for that shelter class.

## Adversarial note

The strongest reason this could be incomplete is that downstream shelter nodes still need separate chronology passes: `hide_tent_frames`, `simple_windbreak_shelters`, `village_settlements`, and `wattle_and_daub` are not corrected here.

## Validation

- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/basic_shelter.before.json /tmp/basic_shelter.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed
- `npm run source-urls` passed, 744 unique URLs
- `npm run accuracy:risks -- --markdown --limit 24` passed

Quality snapshot after regeneration:
- Source-checked nodes: 620 / 1,660
- Nodes with node-level sources: 654 / 1,660
- Dependency edges with edge-level sources: 1,902 / 5,560
- Era-default placeholder dates: 551 / 1,660