### PR TITLE
[codex] Source-check mortar pestle food processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 620 / 1,660 (37.3%) |
-| Nodes with node-level sources | 654 / 1,660 (39.4%) |
-| Dependency edges with edge-level sources | 1,902 / 5,560 (34.2%) |
-| Era-default placeholder dates | 551 / 1,660 (33.2%) |
+| Source-checked nodes | 621 / 1,660 (37.4%) |
+| Nodes with node-level sources | 655 / 1,660 (39.5%) |
+| Dependency edges with edge-level sources | 1,903 / 5,559 (34.2%) |
+| Era-default placeholder dates | 550 / 1,660 (33.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -9444,33 +9444,61 @@
     "id": "mortar_pestle_food_processing",
     "name": "Mortar & Pestle Food Processing",
     "era": "Ancient",
-    "description": "Paired pounding tools for grinding cereals, spices, medicines, pigments, and pastes at household scale.",
+    "description": "Stone mortar-and-pounding food processing for crushing, cooking, storing, and fermenting wild plant foods and cereals.",
     "prerequisites": [
-      "stone_grinding_slabs",
-      "pottery"
+      "stone_grinding_slabs"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -11000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Raqefet Cave, Mount Carmel, Israel",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "stone_grinding_slabs",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Stone Grinding Slabs provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "pottery",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Pottery provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "historical_predecessor",
+        "confidence": 0.66,
+        "evidence_level": "primary_source",
+        "note": "Earlier flat grinding stones show wild-plant grinding traditions; Raqefet Cave documents later bedrock and boulder mortars for pounding, cooking, storing, and fermenting plant foods.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Fermented beverage and food storage in 13,000 y-old stone mortars at Raqefet Cave, Israel",
+            "url": "https://archaeology.stanford.edu/publications/fermented-beverage-and-food-storage-13000-y-old-stone-mortars-raqefet-cave-israel",
+            "publisher": "Journal of Archaeological Science: Reports / Stanford Archaeology",
+            "year": 2018,
+            "source_type": "primary_paper",
+            "supports": [
+              "node",
+              "edge",
+              "maturity"
+            ]
+          }
+        ]
       }
-    ]
+    ],
+    "fields": [
+      "Agriculture & Food Systems",
+      "Materials Science & Manufacturing"
+    ],
+    "fieldLanes": {
+      "Agriculture & Food Systems": "Foundations",
+      "Materials Science & Manufacturing": "Foundations"
+    },
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "Fermented beverage and food storage in 13,000 y-old stone mortars at Raqefet Cave, Israel",
+        "url": "https://archaeology.stanford.edu/publications/fermented-beverage-and-food-storage-13000-y-old-stone-mortars-raqefet-cave-israel",
+        "publisher": "Journal of Archaeological Science: Reports / Stanford Archaeology",
+        "year": 2018,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "scopeNote": "Covers stone mortars and pounding/grinding food processing, with the first-known date pinned to Natufian Raqefet Cave mortars. It should not imply pottery was required, and it does not cover all earlier flat grinding stones."
   },
   {
     "id": "basketry_granaries",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T18:48:44.972Z",
+  "generatedAt": "2026-06-11T18:55:12.452Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 620,
+      "value": 621,
       "denominator": 1660,
-      "formatted": "620 / 1,660",
-      "note": "37.3%"
+      "formatted": "621 / 1,660",
+      "note": "37.4%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 654,
+      "value": 655,
       "denominator": 1660,
-      "formatted": "654 / 1,660",
-      "note": "39.4%"
+      "formatted": "655 / 1,660",
+      "note": "39.5%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1902,
-      "denominator": 5560,
-      "formatted": "1,902 / 5,560",
+      "value": 1903,
+      "denominator": 5559,
+      "formatted": "1,903 / 5,559",
       "note": "34.2%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 551,
+      "value": 550,
       "denominator": 1660,
-      "formatted": "551 / 1,660",
-      "note": "33.2%"
+      "formatted": "550 / 1,660",
+      "note": "33.1%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 654,
-    "sourceChecked": 620,
+    "nodesWithSources": 655,
+    "sourceChecked": 621,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 551,
+    "eraDefaultDates": 550,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5560,
-    "edgesWithSources": 1902
+    "totalEdges": 5559,
+    "edgesWithSources": 1903
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T18:48:44.972Z
+Generated: 2026-06-11T18:55:12.452Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 620 / 1,660 (37.3%) |
-| Nodes with node-level sources | 654 / 1,660 (39.4%) |
-| Dependency edges with edge-level sources | 1,902 / 5,560 (34.2%) |
-| Era-default placeholder dates | 551 / 1,660 (33.2%) |
+| Source-checked nodes | 621 / 1,660 (37.4%) |
+| Nodes with node-level sources | 655 / 1,660 (39.5%) |
+| Dependency edges with edge-level sources | 1,903 / 5,559 (34.2%) |
+| Era-default placeholder dates | 550 / 1,660 (33.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-mortar-pestle-pottery-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-mortar-pestle-pottery-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-mortar-pestle-pottery-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "mortar_pestle_food_processing",
+    "prerequisite": "pottery"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Pottery provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from mortar_pestle_food_processing to pottery. The Raqefet Cave source documents stone mortars that predate ceramic-dependent food processing.",
+  "source_supports_edge": "no",
+  "source_url": "https://archaeology.stanford.edu/publications/fermented-beverage-and-food-storage-13000-y-old-stone-mortars-raqefet-cave-israel",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Publication summary: 13,000-year-old stone mortars were used for plant-food storage, pounding, cooking, and fermentation at Raqefet Cave.",
+    "source_claim_summary": "The source supports stone-mortar food processing without requiring pottery.",
+    "source_support_rationale": "A ceramic prerequisite would be anachronistic or at least unsupported for the scoped stone-mortar claim."
+  },
+  "ontology_before": "The graph made pottery a direct enabling prerequisite for mortar-and-pestle food processing.",
+  "ontology_after": "The source-backed mortar-and-pestle node no longer depends on pottery.",
+  "invariant_preserved_or_changed": "Changed: pottery is absent as a direct prerequisite for mortar_pestle_food_processing.",
+  "would_reject_if": [
+    "The node were narrowed to ceramic mortar-and-pestle vessels rather than stone mortars.",
+    "A source showed the Raqefet Cave stone mortars required pottery.",
+    "The graph reintroduced pottery as a direct prerequisite without narrowing the node scope."
+  ],
+  "short_reason": "Stone mortars do not require pottery.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/mortar_pestle_food_processing.before.json /tmp/mortar_pestle_food_processing.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-mortar-pestle-stone-grinding-predecessor.json
+++ b/docs/edge-change-receipts/2026-06-11-mortar-pestle-stone-grinding-predecessor.json
@@ -1,0 +1,47 @@
+{
+  "id": "2026-06-11-mortar-pestle-stone-grinding-predecessor",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "mortar_pestle_food_processing",
+    "prerequisite": "stone_grinding_slabs"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Stone Grinding Slabs provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.66,
+    "evidence_level": "primary_source",
+    "note": "Earlier flat grinding stones show wild-plant grinding traditions; Raqefet Cave documents later bedrock and boulder mortars for pounding, cooking, storing, and fermenting plant foods."
+  },
+  "source_supports_edge": "partial",
+  "source_url": "https://archaeology.stanford.edu/publications/fermented-beverage-and-food-storage-13000-y-old-stone-mortars-raqefet-cave-israel",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "supports_chronology",
+    "source_locator": "Publication summary: reports 13,000-year-old stone mortars at Raqefet Cave used for plant-food storage, pounding, cooking, and cereal-based beer production.",
+    "source_claim_summary": "The source supports Natufian stone-mortar processing as a later, more specific food-processing practice than earlier flat grinding stones.",
+    "source_support_rationale": "The source supports chronology and functional continuity in stone plant-processing tools, not a hard dependency from flat slabs to mortars."
+  },
+  "ontology_before": "The graph treated flat grinding slabs as a direct enabling prerequisite for mortar-and-pestle food processing.",
+  "ontology_after": "The graph treats flat grinding slabs as an earlier historical predecessor to later source-backed stone mortar food processing.",
+  "invariant_preserved_or_changed": "Changed: stone_grinding_slabs -> mortar_pestle_food_processing is historical_predecessor.",
+  "would_reject_if": [
+    "The node were narrowed to a technical mortar design proven to require flat grinding slabs.",
+    "A source showed stone grinding slabs directly enabled the Raqefet mortar technology rather than preceding it historically.",
+    "The graph promoted the edge back to enabling or required without method-level evidence."
+  ],
+  "short_reason": "Flat grinding stones are better modeled as historical predecessors, not direct enablers.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/mortar_pestle_food_processing.before.json /tmp/mortar_pestle_food_processing.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-mortar-pestle-scope.json
+++ b/docs/graph-invariants/2026-06-11-mortar-pestle-scope.json
@@ -1,0 +1,25 @@
+{
+  "id": "2026-06-11-mortar-pestle-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "mortar_pestle_food_processing",
+      "operator": "eq",
+      "value": -11000,
+      "reason": "The node is scoped to 13,000-year-old Natufian stone mortars at Raqefet Cave."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "mortar_pestle_food_processing",
+      "prerequisite": "stone_grinding_slabs",
+      "expected": "historical_predecessor",
+      "reason": "Earlier flat grinding stones are a historical predecessor, not a direct hard prerequisite."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "mortar_pestle_food_processing",
+      "prerequisite": "pottery",
+      "reason": "Stone mortar food processing should not depend on pottery."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Rescoped `mortar_pestle_food_processing` to stone mortar-and-pounding food processing, anchored to Natufian Raqefet Cave mortars.
- Replaced the 10000 BCE placeholder with `firstKnownDate: -11000`, `datePrecision: millennium`, and `region: Raqefet Cave, Mount Carmel, Israel`.
- Added a primary source and marked the node `source_checked`.
- Retyped `stone_grinding_slabs -> mortar_pestle_food_processing` from `enabling` to `historical_predecessor`, with edge-level source evidence.
- Removed the unsupported `pottery -> mortar_pestle_food_processing` edge.
- Added two edge-change receipts and a graph invariant.
- Regenerated quality snapshots.

## Old claim vs new claim

Old: mortar/pestle processing was an unsourced 10000 BCE placeholder and depended on pottery.

New: mortar/pestle processing is pinned to 13,000-year-old stone mortars at Raqefet Cave. Earlier flat grinding stones are modeled as historical predecessors; pottery is not required for the scoped stone-mortar claim.

## Source locator

Source: https://archaeology.stanford.edu/publications/fermented-beverage-and-food-storage-13000-y-old-stone-mortars-raqefet-cave-israel

Locator: publication summary. The source reports 13,000-year-old stone mortars at Raqefet Cave used for plant-food storage, pounding, cooking, and cereal-based beer production.

## Why this is better

The previous graph made a ceramic prerequisite look necessary for a stone-mortar technology. The source supports the opposite: stone mortars are the relevant artifact class, and flat grinding stones are better represented as earlier plant-processing predecessors than as direct enablers.

## Adversarial note

The strongest reason this could be incomplete is scope breadth: the node name says “Mortar & Pestle,” while the source specifically supports mortars and pounding/grinding food processing. Later ceramic or household mortar/pestle traditions should keep separate narrower dates if modeled.

## Validation

- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/mortar_pestle_food_processing.before.json /tmp/mortar_pestle_food_processing.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed
- `npm run source-urls` passed, 745 unique URLs
- `npm run accuracy:risks -- --markdown --limit 24` passed

Quality snapshot after regeneration:
- Source-checked nodes: 621 / 1,660
- Nodes with node-level sources: 655 / 1,660
- Dependency edges with edge-level sources: 1,903 / 5,559
- Era-default placeholder dates: 550 / 1,660