### PR TITLE
[codex] Source-check predomestication granaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 621 / 1,660 (37.4%) |
-| Nodes with node-level sources | 655 / 1,660 (39.5%) |
-| Dependency edges with edge-level sources | 1,903 / 5,559 (34.2%) |
+| Source-checked nodes | 622 / 1,660 (37.5%) |
+| Nodes with node-level sources | 656 / 1,660 (39.5%) |
+| Dependency edges with edge-level sources | 1,903 / 5,558 (34.2%) |
 | Era-default placeholder dates | 550 / 1,660 (33.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -9502,26 +9502,38 @@
   },
   {
     "id": "basketry_granaries",
-    "name": "Basketry Granaries",
+    "name": "Predomestication Granaries",
     "era": "Ancient",
-    "description": "Woven storage bins and lined baskets that protected seed grain and dried foods from damp and pests.",
-    "prerequisites": [
-      "agriculture"
+    "description": "Purpose-built granaries with raised or suspended floors for storing wild cereals and protecting stored foods from damp and rodents.",
+    "prerequisites": [],
+    "firstKnownDate": -9300,
+    "datePrecision": "century",
+    "region": "Dhra', Jordan Valley",
+    "reviewStatus": "source_checked",
+    "dependencyEdges": [],
+    "fields": [
+      "Agriculture & Food Systems",
+      "Civil Engineering & Built Environment"
     ],
-    "firstKnownDate": -9000,
-    "datePrecision": "millennium",
-    "region": "Early farming settlements",
-    "reviewStatus": "structurally_validated",
-    "dependencyEdges": [
+    "fieldLanes": {
+      "Agriculture & Food Systems": "Foundations",
+      "Civil Engineering & Built Environment": "Buildings & Urban Systems"
+    },
+    "maturity": "established",
+    "sources": [
       {
-        "prerequisite": "agriculture",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Agriculture provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "title": "Evidence for food storage and predomestication granaries 11,000 years ago in the Jordan Valley",
+        "url": "https://www.pnas.org/doi/10.1073/pnas.0812764106",
+        "publisher": "Proceedings of the National Academy of Sciences",
+        "year": 2009,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       }
-    ]
+    ],
+    "scopeNote": "Covers the source-backed Dhra' predomestication granary structures, not generic woven baskets or later household grain bins. The source places these storage systems before domesticated plants and large sedentary communities."
   },
   {
     "id": "hide_tent_frames",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T18:55:12.452Z",
+  "generatedAt": "2026-06-11T19:02:14.942Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,23 +11,23 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 621,
+      "value": 622,
       "denominator": 1660,
-      "formatted": "621 / 1,660",
-      "note": "37.4%"
+      "formatted": "622 / 1,660",
+      "note": "37.5%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 655,
+      "value": 656,
       "denominator": 1660,
-      "formatted": "655 / 1,660",
+      "formatted": "656 / 1,660",
       "note": "39.5%"
     },
     {
       "label": "Dependency edges with edge-level sources",
       "value": 1903,
-      "denominator": 5559,
-      "formatted": "1,903 / 5,559",
+      "denominator": 5558,
+      "formatted": "1,903 / 5,558",
       "note": "34.2%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 655,
-    "sourceChecked": 621,
+    "nodesWithSources": 656,
+    "sourceChecked": 622,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 550,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5559,
+    "totalEdges": 5558,
     "edgesWithSources": 1903
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,15 +1,15 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T18:55:12.452Z
+Generated: 2026-06-11T19:02:14.942Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 621 / 1,660 (37.4%) |
-| Nodes with node-level sources | 655 / 1,660 (39.5%) |
-| Dependency edges with edge-level sources | 1,903 / 5,559 (34.2%) |
+| Source-checked nodes | 622 / 1,660 (37.5%) |
+| Nodes with node-level sources | 656 / 1,660 (39.5%) |
+| Dependency edges with edge-level sources | 1,903 / 5,558 (34.2%) |
 | Era-default placeholder dates | 550 / 1,660 (33.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-predomestication-granaries-agriculture-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-predomestication-granaries-agriculture-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-predomestication-granaries-agriculture-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "basketry_granaries",
+    "prerequisite": "agriculture"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Agriculture provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from basketry_granaries to agriculture. The node is now scoped to predomestication granaries at Dhra', where the cited source explicitly argues food storage preceded plant domestication and large sedentary communities.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.pnas.org/doi/10.1073/pnas.0812764106",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: reports sophisticated purpose-built granaries in a predomestication context ca. 11,300-11,175 cal BP at Dhra', with suspended floors for air circulation and rodent protection.",
+    "source_claim_summary": "The source supports purpose-built granaries before domesticated plants and large-scale sedentary communities.",
+    "source_support_rationale": "Because the source-backed granaries are predomestication storage systems, agriculture should not be a direct prerequisite for this node."
+  },
+  "ontology_before": "The graph modeled early granaries as enabled by agriculture and described them as basketry storage bins.",
+  "ontology_after": "The graph models source-backed predomestication granary structures as a food-storage technology preceding domesticated crop agriculture.",
+  "invariant_preserved_or_changed": "Changed: agriculture is absent as a direct prerequisite for basketry_granaries.",
+  "would_reject_if": [
+    "The node were narrowed back to later agricultural household grain bins.",
+    "A source showed the Dhra' granaries required domesticated crop agriculture.",
+    "The graph reintroduced agriculture as a direct prerequisite without changing the node scope."
+  ],
+  "short_reason": "Dhra' granaries are predomestication storage structures, not products of domesticated-crop agriculture.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/basketry_granaries.before.json /tmp/basketry_granaries.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-predomestication-granaries-scope.json
+++ b/docs/graph-invariants/2026-06-11-predomestication-granaries-scope.json
@@ -1,0 +1,18 @@
+{
+  "id": "2026-06-11-predomestication-granaries-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "basketry_granaries",
+      "operator": "eq",
+      "value": -9300,
+      "reason": "The node is scoped to Dhra' predomestication granaries dated around 11,300-11,175 cal BP."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "basketry_granaries",
+      "prerequisite": "agriculture",
+      "reason": "The source-backed granaries predate domesticated crop agriculture and should not depend on the agriculture node."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Rescoped `basketry_granaries` from generic woven storage bins to source-backed predomestication granary structures.
- Renamed display text to `Predomestication Granaries` while preserving the existing node id.
- Replaced the rough 9000 BCE millennium date with `firstKnownDate: -9300`, `datePrecision: century`, and `region: Dhra', Jordan Valley`.
- Added a primary PNAS source and marked the node `source_checked`.
- Removed the unsupported `agriculture -> basketry_granaries` edge.
- Added an edge-change receipt and graph invariant.
- Regenerated quality snapshots.

## Old claim vs new claim

Old: the node described woven basketry bins in early farming settlements and depended on agriculture.

New: the node describes purpose-built Dhra' granary structures with raised or suspended floors for storing wild cereals and protecting stores from damp and rodents. The source explicitly frames these as predomestication storage systems, so agriculture is not a direct prerequisite.

## Source locator

Source: https://www.pnas.org/doi/10.1073/pnas.0812764106

Locator: abstract. The source reports sophisticated purpose-built granaries in a predomestication context around 11,300-11,175 cal BP at Dhra', with suspended floors for air circulation and rodent protection.

## Why this is better

The previous graph inverted the dependency story: it made agriculture enable granaries, while the source argues storage systems helped precede later domesticated-plant agriculture and sedentary communities.

## Adversarial note

The strongest reason this could be incomplete is the existing node id `basketry_granaries`: it now preserves compatibility but no longer matches the improved display name perfectly. A later schema migration could rename the id if downstream consumers can tolerate it.

## Validation

- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/basketry_granaries.before.json /tmp/basketry_granaries.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed
- `npm run source-urls` passed, 746 unique URLs
- `npm run accuracy:risks -- --markdown --limit 24` passed

Quality snapshot after regeneration:
- Source-checked nodes: 622 / 1,660
- Nodes with node-level sources: 656 / 1,660
- Dependency edges with edge-level sources: 1,903 / 5,558
- Era-default placeholder dates: 550 / 1,660