### PR TITLE
[codex] Source-check Paleolithic fish hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 622 / 1,660 (37.5%) |
-| Nodes with node-level sources | 656 / 1,660 (39.5%) |
-| Dependency edges with edge-level sources | 1,903 / 5,558 (34.2%) |
-| Era-default placeholder dates | 550 / 1,660 (33.1%) |
+| Source-checked nodes | 623 / 1,660 (37.5%) |
+| Nodes with node-level sources | 657 / 1,660 (39.6%) |
+| Dependency edges with edge-level sources | 1,903 / 5,552 (34.3%) |
+| Era-default placeholder dates | 549 / 1,660 (33.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -1284,35 +1284,29 @@
   },
   {
     "id": "fishing_nets_hooks",
-    "name": "Fishing Nets & Hooks",
+    "name": "Paleolithic Fish Hooks",
     "era": "Ancient",
-    "description": "Crafting hooks from bone or wood and nets from fiber for efficient fishing.",
-    "prerequisites": [
-      "bone_tool_making",
-      "basic_weaving_basketry"
-    ],
-    "firstKnownDate": -10000,
+    "description": "Single-piece shell fishhooks used as part of Late Pleistocene maritime subsistence.",
+    "prerequisites": [],
+    "firstKnownDate": -21000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
-    "dependencyEdges": [
+    "region": "Sakitari Cave, Okinawa Island, Japan",
+    "reviewStatus": "source_checked",
+    "scopeNote": "Covers source-backed single-piece shell fishhooks from Sakitari Cave. It does not cover fishing nets, weirs, traps, spears, gigs, net sinkers, or later barbed-hook variants unless those are modeled by separate nodes.",
+    "sources": [
       {
-        "prerequisite": "bone_tool_making",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Bone Tool Making provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "basic_weaving_basketry",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Basic Weaving and Basketry is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "title": "Advanced maritime adaptation in the western Pacific coastal region extends back to 35,000-30,000 years before present",
+        "url": "https://www.pnas.org/doi/10.1073/pnas.1607857113",
+        "publisher": "Proceedings of the National Academy of Sciences",
+        "year": 2016,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       }
-    ]
+    ],
+    "dependencyEdges": []
   },
   {
     "id": "early_musical_instruments_flutes_drums",
@@ -6321,7 +6315,6 @@
     "era": "Ancient",
     "description": "Fixed structures of stone, reeds, stakes, or nets that guided fish into harvestable enclosures with low daily labor.",
     "prerequisites": [
-      "fishing_nets_hooks",
       "woodworking_basic",
       "basic_rope_making"
     ],
@@ -6330,14 +6323,6 @@
     "region": "Global / multiple regions",
     "reviewStatus": "structurally_validated",
     "dependencyEdges": [
-      {
-        "prerequisite": "fishing_nets_hooks",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Fishing Nets & Hooks provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
       {
         "prerequisite": "woodworking_basic",
         "type": "historical_predecessor",
@@ -8501,7 +8486,7 @@
         "type": "enabling",
         "confidence": 0.68,
         "evidence_level": "expert_inference",
-        "note": "Fishing Nets & Hooks provides a capability that enables this technology without being the only possible path.",
+        "note": "Paleolithic Fish Hooks provide an earlier hook technology that enables later hook-shape improvements without proving a hard prerequisite.",
         "reviewStatus": "structurally_validated"
       },
       {
@@ -8528,7 +8513,6 @@
     "era": "Ancient",
     "description": "Stone, clay, or ceramic weights attached to nets to control depth and shape during fishing.",
     "prerequisites": [
-      "fishing_nets_hooks",
       "pottery",
       "portable_scales"
     ],
@@ -8537,14 +8521,6 @@
     "region": "Global / multiple regions",
     "reviewStatus": "structurally_validated",
     "dependencyEdges": [
-      {
-        "prerequisite": "fishing_nets_hooks",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Fishing Nets & Hooks provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
       {
         "prerequisite": "pottery",
         "type": "enabling",
@@ -9021,7 +8997,6 @@
     "era": "Ancient",
     "description": "Barbed spears, multi-pronged gigs, and night-fishing tools for shallow water and river harvests.",
     "prerequisites": [
-      "fishing_nets_hooks",
       "archery",
       "fire_control"
     ],
@@ -9030,14 +9005,6 @@
     "region": "Global / multiple regions",
     "reviewStatus": "structurally_validated",
     "dependencyEdges": [
-      {
-        "prerequisite": "fishing_nets_hooks",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Fishing Nets & Hooks provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
       {
         "prerequisite": "archery",
         "type": "enabling",
@@ -9354,7 +9321,6 @@
     "era": "Ancient",
     "description": "Stone, brush, and stake barriers that guided fish into traps in rivers, tidal flats, and lakes.",
     "prerequisites": [
-      "fishing_nets_hooks",
       "basic_rope_making"
     ],
     "firstKnownDate": -10000,
@@ -9362,14 +9328,6 @@
     "region": "Global / multiple regions",
     "reviewStatus": "structurally_validated",
     "dependencyEdges": [
-      {
-        "prerequisite": "fishing_nets_hooks",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Fishing Nets & Hooks provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
       {
         "prerequisite": "basic_rope_making",
         "type": "historical_predecessor",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T19:02:14.942Z",
+  "generatedAt": "2026-06-11T19:13:13.366Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,30 +11,30 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 622,
+      "value": 623,
       "denominator": 1660,
-      "formatted": "622 / 1,660",
+      "formatted": "623 / 1,660",
       "note": "37.5%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 656,
+      "value": 657,
       "denominator": 1660,
-      "formatted": "656 / 1,660",
-      "note": "39.5%"
+      "formatted": "657 / 1,660",
+      "note": "39.6%"
     },
     {
       "label": "Dependency edges with edge-level sources",
       "value": 1903,
-      "denominator": 5558,
-      "formatted": "1,903 / 5,558",
-      "note": "34.2%"
+      "denominator": 5552,
+      "formatted": "1,903 / 5,552",
+      "note": "34.3%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 550,
+      "value": 549,
       "denominator": 1660,
-      "formatted": "550 / 1,660",
+      "formatted": "549 / 1,660",
       "note": "33.1%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 656,
-    "sourceChecked": 622,
+    "nodesWithSources": 657,
+    "sourceChecked": 623,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 550,
+    "eraDefaultDates": 549,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5558,
+    "totalEdges": 5552,
     "edgesWithSources": 1903
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T19:02:14.942Z
+Generated: 2026-06-11T19:13:13.366Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 622 / 1,660 (37.5%) |
-| Nodes with node-level sources | 656 / 1,660 (39.5%) |
-| Dependency edges with edge-level sources | 1,903 / 5,558 (34.2%) |
-| Era-default placeholder dates | 550 / 1,660 (33.1%) |
+| Source-checked nodes | 623 / 1,660 (37.5%) |
+| Nodes with node-level sources | 657 / 1,660 (39.6%) |
+| Dependency edges with edge-level sources | 1,903 / 5,552 (34.3%) |
+| Era-default placeholder dates | 549 / 1,660 (33.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-fish-weirs-and-traps-hooks-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-fish-weirs-and-traps-hooks-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-fish-weirs-and-traps-hooks-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "fish_weirs_and_traps",
+    "prerequisite": "fishing_nets_hooks"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Fishing Nets & Hooks provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from fish_weirs_and_traps to fishing_nets_hooks. The prerequisite node is now scoped to shell fishhooks, which are not a prerequisite for fixed weirs or traps.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.pnas.org/doi/10.1073/pnas.1607857113",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: reports seashell artifacts including fishhooks at Sakitari Cave; it does not present weir or trap construction as derived from fishhook technology.",
+    "source_claim_summary": "The source supports early fishhooks, not a general fishing-structure prerequisite.",
+    "source_support_rationale": "After scope correction, a fishhook node should not be used as the direct enabler for fixed weirs and traps."
+  },
+  "ontology_before": "The graph made a broad nets-and-hooks node a direct enabler of weirs and traps.",
+  "ontology_after": "Fish weirs and traps retain their own woodworking and rope context without depending on fishhooks.",
+  "invariant_preserved_or_changed": "Changed: fishing_nets_hooks is absent as a direct prerequisite for fish_weirs_and_traps.",
+  "would_reject_if": [
+    "A source showed fish weirs or traps required prior fishhook technology.",
+    "The fishhook node were broadened again to include nets, weirs, or traps.",
+    "The graph reintroduced the edge without source-backed edge evidence."
+  ],
+  "short_reason": "Fishhooks are not a prerequisite for fixed fish weirs and traps.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/fishing_nets_hooks.before.json /tmp/fishing_nets_hooks.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-fish-weirs-hooks-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-fish-weirs-hooks-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-fish-weirs-hooks-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "fish_weirs",
+    "prerequisite": "fishing_nets_hooks"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Fishing Nets & Hooks provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from fish_weirs to fishing_nets_hooks. The corrected prerequisite node represents shell fishhooks, not weir construction.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.pnas.org/doi/10.1073/pnas.1607857113",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract and seashell-artifact report: supports shell fishhooks as artifacts at Sakitari Cave.",
+    "source_claim_summary": "The source supports fishhook technology only.",
+    "source_support_rationale": "A source-backed shell-fishhook node should not be a direct prerequisite for fish-weir technology."
+  },
+  "ontology_before": "The graph let a mixed nets-and-hooks node stand upstream of fish weirs.",
+  "ontology_after": "Fish weirs no longer depend on fishhooks as a direct upstream technology.",
+  "invariant_preserved_or_changed": "Changed: fishing_nets_hooks is absent as a direct prerequisite for fish_weirs.",
+  "would_reject_if": [
+    "A source showed fish weirs required prior fishhook technology.",
+    "The graph changed the prerequisite node back into a broad fishing-net/weir node.",
+    "The edge returned without edge-level evidence."
+  ],
+  "short_reason": "Fishhooks are not a direct prerequisite for fish weirs.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/fishing_nets_hooks.before.json /tmp/fishing_nets_hooks.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-fishing-spears-hooks-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-fishing-spears-hooks-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-fishing-spears-hooks-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "fishing_spear_gigs",
+    "prerequisite": "fishing_nets_hooks"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Fishing Nets & Hooks provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from fishing_spear_gigs to fishing_nets_hooks. The corrected prerequisite node is shell fishhooks, not spear or gig technology.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.pnas.org/doi/10.1073/pnas.1607857113",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Seashell artifact discussion: supports shell fishhooks at Sakitari Cave, not spear or gig manufacture.",
+    "source_claim_summary": "The source supports early fishhooks, not a dependency from hooks to fishing spears.",
+    "source_support_rationale": "Fishing spears and gigs are separate capture technologies and should not inherit a hook prerequisite from an old mixed node."
+  },
+  "ontology_before": "The graph made broad fishing nets and hooks a direct enabler of fishing spears and gigs.",
+  "ontology_after": "Fishing spears and gigs no longer depend directly on fishhook technology.",
+  "invariant_preserved_or_changed": "Changed: fishing_nets_hooks is absent as a direct prerequisite for fishing_spear_gigs.",
+  "would_reject_if": [
+    "A source showed fishing spear or gig technology required prior fishhooks.",
+    "The fishhook node were broadened to include spears or gigs.",
+    "The edge returned without edge-level evidence."
+  ],
+  "short_reason": "Fishhooks are not a direct prerequisite for fishing spears or gigs.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/fishing_nets_hooks.before.json /tmp/fishing_nets_hooks.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-net-sinker-hooks-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-net-sinker-hooks-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-net-sinker-hooks-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "net_sinker_weights",
+    "prerequisite": "fishing_nets_hooks"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Fishing Nets & Hooks provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from net_sinker_weights to fishing_nets_hooks. The corrected prerequisite node is shell fishhooks, not net technology.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.pnas.org/doi/10.1073/pnas.1607857113",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract and seashell-artifact discussion: reports shell fishhooks, not nets or sinker weights.",
+    "source_claim_summary": "The source supports early shell fishhooks and does not support nets being part of this node.",
+    "source_support_rationale": "Because nets were removed from the node scope, net sinker weights should not depend on the fishhook node."
+  },
+  "ontology_before": "The graph used a mixed nets-and-hooks node as an enabler for net sinker weights.",
+  "ontology_after": "Net sinker weights no longer depend directly on shell fishhook technology.",
+  "invariant_preserved_or_changed": "Changed: fishing_nets_hooks is absent as a direct prerequisite for net_sinker_weights.",
+  "would_reject_if": [
+    "The source-backed node were broadened again to include fishing nets.",
+    "A source showed net sinker weights required prior fishhook technology.",
+    "The edge returned without source-backed edge evidence."
+  ],
+  "short_reason": "Shell fishhooks are not net sinker technology.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/fishing_nets_hooks.before.json /tmp/fishing_nets_hooks.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-paleolithic-fish-hooks-bone-tool-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-paleolithic-fish-hooks-bone-tool-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-paleolithic-fish-hooks-bone-tool-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "fishing_nets_hooks",
+    "prerequisite": "bone_tool_making"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Bone Tool Making provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from fishing_nets_hooks to bone_tool_making. The node is now scoped to single-piece shell fishhooks at Sakitari Cave, not bone hooks.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.pnas.org/doi/10.1073/pnas.1607857113",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Seashell artifacts section and abstract: reports single-piece fishhooks made of Trochus shell from a layer dated to 23,000 cal BP at Sakitari Cave.",
+    "source_claim_summary": "The earliest source-backed claim for this node is shell fishhook manufacture at Sakitari Cave.",
+    "source_support_rationale": "Because the scoped artifacts are shell fishhooks, bone-tool making is not a direct prerequisite for the corrected node."
+  },
+  "ontology_before": "The graph modeled a broad nets-and-hooks node as enabled by bone-tool making.",
+  "ontology_after": "The graph models source-backed Paleolithic shell fishhooks without requiring bone-tool making.",
+  "invariant_preserved_or_changed": "Changed: bone_tool_making is absent as a direct prerequisite for fishing_nets_hooks.",
+  "would_reject_if": [
+    "The node were respecified as bone fishhooks rather than shell fishhooks.",
+    "A source showed that Sakitari shell fishhooks required bone-tool manufacturing.",
+    "The graph reintroduced bone_tool_making as a direct prerequisite without changing the node scope."
+  ],
+  "short_reason": "Sakitari fishhooks are shell artifacts, not bone hooks.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/fishing_nets_hooks.before.json /tmp/fishing_nets_hooks.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-paleolithic-fish-hooks-weaving-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-paleolithic-fish-hooks-weaving-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-paleolithic-fish-hooks-weaving-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "fishing_nets_hooks",
+    "prerequisite": "basic_weaving_basketry"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Basic Weaving and Basketry is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from fishing_nets_hooks to basic_weaving_basketry. The corrected node covers shell fishhooks, not fiber nets.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.pnas.org/doi/10.1073/pnas.1607857113",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract and seashell-artifact discussion: identifies formally shaped seashell artifacts including the world's oldest fishhooks at Sakitari Cave.",
+    "source_claim_summary": "The source supports shell fishhooks as a maritime technology; it does not support a combined nets-and-hooks technology.",
+    "source_support_rationale": "Because nets were removed from the node scope, weaving/basketry should not remain as a direct prerequisite."
+  },
+  "ontology_before": "The graph combined nets and hooks, which made weaving appear relevant to the whole node.",
+  "ontology_after": "The graph separates the source-backed fishhook claim from unsourced net technology.",
+  "invariant_preserved_or_changed": "Changed: basic_weaving_basketry is absent as a direct prerequisite for fishing_nets_hooks.",
+  "would_reject_if": [
+    "The node were broadened again to include fiber nets.",
+    "A source directly tied the scoped Sakitari fishhooks to net or basketry manufacture.",
+    "The graph reintroduced basic_weaving_basketry as a direct prerequisite without changing the node scope."
+  ],
+  "short_reason": "The source-backed node is shell fishhooks, not nets.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/fishing_nets_hooks.before.json /tmp/fishing_nets_hooks.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-paleolithic-fish-hooks-scope.json
+++ b/docs/graph-invariants/2026-06-11-paleolithic-fish-hooks-scope.json
@@ -1,0 +1,48 @@
+{
+  "id": "2026-06-11-paleolithic-fish-hooks-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "fishing_nets_hooks",
+      "operator": "eq",
+      "value": -21000,
+      "reason": "The node is scoped to Sakitari Cave shell fishhooks from a layer dated to about 23,000 cal BP."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "fishing_nets_hooks",
+      "prerequisite": "bone_tool_making",
+      "reason": "The scoped artifacts are shell fishhooks, not bone hooks."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "fishing_nets_hooks",
+      "prerequisite": "basic_weaving_basketry",
+      "reason": "The scoped node excludes nets and therefore should not depend on weaving or basketry."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "fish_weirs_and_traps",
+      "prerequisite": "fishing_nets_hooks",
+      "reason": "Fixed fish weirs and traps should not depend directly on shell fishhooks."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "fish_weirs",
+      "prerequisite": "fishing_nets_hooks",
+      "reason": "Fish weirs should not depend directly on shell fishhooks."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "fishing_spear_gigs",
+      "prerequisite": "fishing_nets_hooks",
+      "reason": "Fishing spears and gigs should not depend directly on shell fishhooks."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "net_sinker_weights",
+      "prerequisite": "fishing_nets_hooks",
+      "reason": "Net sinker weights should not depend directly on shell fishhooks."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node source-backed correction for `fishing_nets_hooks`, plus direct topology cleanup caused by the corrected scope.

## Old Claim
`fishing_nets_hooks` was a broad unsourced `Fishing Nets & Hooks` node dated to `-10000` / `millennium`, region `Global / multiple regions`, with inferred dependencies on `bone_tool_making` and `basic_weaving_basketry`.

It also acted as an inferred enabler for `fish_weirs`, `fish_weirs_and_traps`, `fishing_spear_gigs`, and `net_sinker_weights`.

## New Claim
`fishing_nets_hooks` is now scoped as `Paleolithic Fish Hooks`: source-backed single-piece shell fishhooks from Sakitari Cave, Okinawa Island, Japan, dated to about 23,000 cal BP (`firstKnownDate: -21000`, `datePrecision: millennium`).

## Source
- Fujita et al. 2016, PNAS, `Advanced maritime adaptation in the western Pacific coastal region extends back to 35,000-30,000 years before present`
- URL: https://www.pnas.org/doi/10.1073/pnas.1607857113
- Locator: abstract / seashell-artifact discussion reports Sakitari Cave seashell artifacts including the world's oldest fishhooks, with single-piece Trochus shell fishhooks from a layer dated to 23,000 cal BP.

## Edge Changes
Removed unsupported direct edges:
- `bone_tool_making -> fishing_nets_hooks`
- `basic_weaving_basketry -> fishing_nets_hooks`
- `fishing_nets_hooks -> fish_weirs`
- `fishing_nets_hooks -> fish_weirs_and_traps`
- `fishing_nets_hooks -> fishing_spear_gigs`
- `fishing_nets_hooks -> net_sinker_weights`

Kept `fishing_nets_hooks -> fish_hook_barbs` as a weak enabling edge for later hook-form improvements, with its note updated to match the new scope.

## Why Better
The old node mixed nets, hooks, weirs, spears, and sinkers under one placeholder-era claim. The new node only says what the source supports: Paleolithic shell fishhooks at Sakitari Cave. That removes misleading topology where shell hooks appeared to enable fixed weirs, spears/gigs, or net sinker weights.

## Adversarial Note
The strongest reason this correction could be incomplete is that other early fishing technologies still need their own source checks. This PR intentionally does not date or source `fish_weirs`, `fish_weirs_and_traps`, `fishing_spear_gigs`, or `net_sinker_weights`; it only prevents the corrected fishhook node from laundering those technologies.

## Validation
- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/fishing_nets_hooks.before.json /tmp/fishing_nets_hooks.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed
- `npm run accuracy:risks -- --markdown --limit 24` passed