### PR TITLE
[codex] Source-check submerged stone fish weir

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 623 / 1,660 (37.5%) |
-| Nodes with node-level sources | 657 / 1,660 (39.6%) |
-| Dependency edges with edge-level sources | 1,903 / 5,552 (34.3%) |
-| Era-default placeholder dates | 549 / 1,660 (33.1%) |
+| Source-checked nodes | 624 / 1,660 (37.6%) |
+| Nodes with node-level sources | 658 / 1,660 (39.6%) |
+| Dependency edges with edge-level sources | 1,903 / 5,551 (34.3%) |
+| Era-default placeholder dates | 548 / 1,660 (33.0%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -9317,26 +9317,29 @@
   },
   {
     "id": "fish_weirs",
-    "name": "Fish Weirs",
+    "name": "Submerged Stone Fish Weir",
     "era": "Ancient",
-    "description": "Stone, brush, and stake barriers that guided fish into traps in rivers, tidal flats, and lakes.",
-    "prerequisites": [
-      "basic_rope_making"
-    ],
-    "firstKnownDate": -10000,
+    "description": "Low stone tidal-trap walls positioned so fish pass over them at high tide and are trapped as the tide recedes.",
+    "prerequisites": [],
+    "firstKnownDate": -9150,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
-    "dependencyEdges": [
+    "region": "Shakan Bay, Prince of Wales Island, Southeast Alaska",
+    "reviewStatus": "source_checked",
+    "scopeNote": "Covers the source-backed submerged stone fish weir confirmed at Shakan Bay and dated by sea-level reconstruction to about 11,100 years ago. It does not generalize to wooden stake weirs, basket traps, brush traps, or later regional fish-weir traditions.",
+    "sources": [
       {
-        "prerequisite": "basic_rope_making",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Basic Rope Making is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "title": "Scientists Discover Ancient Underwater Fish Weir in Southeast Alaska",
+        "url": "https://oceanexplorer.noaa.gov/expedition-feature/22sunfish-features-fish-weir/",
+        "publisher": "NOAA Ocean Exploration",
+        "year": 2022,
+        "source_type": "official_agency",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       }
-    ]
+    ],
+    "dependencyEdges": []
   },
   {
     "id": "stone_grinding_slabs",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T19:13:13.366Z",
+  "generatedAt": "2026-06-11T19:18:32.622Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 623,
+      "value": 624,
       "denominator": 1660,
-      "formatted": "623 / 1,660",
-      "note": "37.5%"
+      "formatted": "624 / 1,660",
+      "note": "37.6%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 657,
+      "value": 658,
       "denominator": 1660,
-      "formatted": "657 / 1,660",
+      "formatted": "658 / 1,660",
       "note": "39.6%"
     },
     {
       "label": "Dependency edges with edge-level sources",
       "value": 1903,
-      "denominator": 5552,
-      "formatted": "1,903 / 5,552",
+      "denominator": 5551,
+      "formatted": "1,903 / 5,551",
       "note": "34.3%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 549,
+      "value": 548,
       "denominator": 1660,
-      "formatted": "549 / 1,660",
-      "note": "33.1%"
+      "formatted": "548 / 1,660",
+      "note": "33.0%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 657,
-    "sourceChecked": 623,
+    "nodesWithSources": 658,
+    "sourceChecked": 624,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 549,
+    "eraDefaultDates": 548,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5552,
+    "totalEdges": 5551,
     "edgesWithSources": 1903
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T19:13:13.366Z
+Generated: 2026-06-11T19:18:32.622Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 623 / 1,660 (37.5%) |
-| Nodes with node-level sources | 657 / 1,660 (39.6%) |
-| Dependency edges with edge-level sources | 1,903 / 5,552 (34.3%) |
-| Era-default placeholder dates | 549 / 1,660 (33.1%) |
+| Source-checked nodes | 624 / 1,660 (37.6%) |
+| Nodes with node-level sources | 658 / 1,660 (39.6%) |
+| Dependency edges with edge-level sources | 1,903 / 5,551 (34.3%) |
+| Era-default placeholder dates | 548 / 1,660 (33.0%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-stone-fish-weir-rope-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-stone-fish-weir-rope-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-stone-fish-weir-rope-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "fish_weirs",
+    "prerequisite": "basic_rope_making"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Basic Rope Making is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from fish_weirs to basic_rope_making. The node is now scoped to a submerged stone tidal fish weir, not rope, net, basket, or wooden-stake trap construction.",
+  "source_supports_edge": "no",
+  "source_url": "https://oceanexplorer.noaa.gov/expedition-feature/22sunfish-features-fish-weir/",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "NOAA feature, lines describing low arced stone walls across gullies, an 11,100-year age from sea-level reconstruction, and confirmation of the Shakan Bay structure as a stone weir.",
+    "source_claim_summary": "The source supports a stone tidal fish trap made from stacked boulders at Shakan Bay.",
+    "source_support_rationale": "Because the corrected node covers stone wall fish-weir construction, rope making is not a direct prerequisite."
+  },
+  "ontology_before": "The graph modeled fish weirs as directly dependent on basic rope making, implying fiber or lashing as a prerequisite.",
+  "ontology_after": "The graph models a source-backed stone fish weir without a rope prerequisite.",
+  "invariant_preserved_or_changed": "Changed: basic_rope_making is absent as a direct prerequisite for fish_weirs.",
+  "would_reject_if": [
+    "The node were broadened to basket traps, net traps, or lashed wooden-stake weirs.",
+    "A source showed the Shakan Bay stone weir required rope making.",
+    "The graph reintroduced basic_rope_making as a direct prerequisite without changing the node scope."
+  ],
+  "short_reason": "The source-backed Shakan Bay weir is a stone tidal trap, not a rope-built trap.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/fish_weirs.before.json /tmp/fish_weirs.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-stone-fish-weir-scope.json
+++ b/docs/graph-invariants/2026-06-11-stone-fish-weir-scope.json
@@ -1,0 +1,18 @@
+{
+  "id": "2026-06-11-stone-fish-weir-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "fish_weirs",
+      "operator": "eq",
+      "value": -9150,
+      "reason": "The node is scoped to the Shakan Bay submerged stone fish weir, estimated at about 11,100 years ago from sea-level reconstruction."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "fish_weirs",
+      "prerequisite": "basic_rope_making",
+      "reason": "The scoped stone tidal fish trap should not depend directly on rope making."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node source-backed correction for `fish_weirs`.

## Old Claim
`fish_weirs` was a broad unsourced `Fish Weirs` node dated to `-10000` / `millennium`, region `Global / multiple regions`, with an inferred `basic_rope_making` historical-predecessor edge.

## New Claim
`fish_weirs` is now scoped as `Submerged Stone Fish Weir`: low stone tidal-trap walls at Shakan Bay, Prince of Wales Island, Southeast Alaska, estimated at about 11,100 years ago from sea-level reconstruction (`firstKnownDate: -9150`, `datePrecision: millennium`).

## Source
- NOAA Ocean Exploration, `Scientists Discover Ancient Underwater Fish Weir in Southeast Alaska`
- URL: https://oceanexplorer.noaa.gov/expedition-feature/22sunfish-features-fish-weir/
- Locator: NOAA describes a Shakan Bay stone fish trap confirmed by underwater exploration, low arced stone walls across gullies, and an approximate 11,100-year age based on sea-level reconstruction.

## Edge Change
Removed unsupported direct edge:
- `basic_rope_making -> fish_weirs`

## Why Better
The old node generalized several kinds of fish-weir technology and implied rope/fiber construction. The source-backed case is a stone tidal trap, so rope making is not a direct prerequisite for the corrected node.

## Adversarial Note
This is an official-agency report, not a peer-reviewed primary archaeological paper. It is adequate to remove the rope prerequisite and replace a placeholder claim, but the node should be revisited if a primary publication gives a tighter date, uncertainty range, or alternative interpretation.

## Validation
- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/fish_weirs.before.json /tmp/fish_weirs.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed
- `npm run accuracy:risks -- --markdown --limit 24` passed