### PR TITLE
[codex] Source-check Paleolithic birch tar adhesive

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 624 / 1,660 (37.6%) |
-| Nodes with node-level sources | 658 / 1,660 (39.6%) |
-| Dependency edges with edge-level sources | 1,903 / 5,551 (34.3%) |
-| Era-default placeholder dates | 548 / 1,660 (33.0%) |
+| Source-checked nodes | 625 / 1,660 (37.7%) |
+| Nodes with node-level sources | 659 / 1,660 (39.7%) |
+| Dependency edges with edge-level sources | 1,905 / 5,551 (34.3%) |
+| Era-default placeholder dates | 547 / 1,660 (33.0%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -716,33 +716,72 @@
   },
   {
     "id": "natural_adhesives",
-    "name": "Natural Adhesives",
+    "name": "Paleolithic Birch Tar Adhesive",
     "era": "Ancient",
-    "description": "Processing materials like birch bark tar or pine resin to create glues for hafting tools and waterproofing.",
+    "description": "Intentional production of birch bark tar used as a hafting adhesive for stone tools.",
     "prerequisites": [
       "fire_control",
       "foraging_and_botany"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -188000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Campitello Quarry, Italy",
+    "reviewStatus": "source_checked",
+    "scopeNote": "Covers source-backed birch bark tar adhesive, currently described as the oldest known adhesive substance, dating to at least about 190,000 years ago at Campitello Quarry. It does not cover every natural gum, resin, pitch, waterproofing compound, or later ceramic-era tar-production method.",
+    "sources": [
+      {
+        "title": "Identifying Palaeolithic birch tar production techniques: challenges from an experimental biomolecular approach",
+        "url": "https://www.nature.com/articles/s41598-023-41898-5",
+        "publisher": "Scientific Reports",
+        "year": 2023,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "edge",
+          "maturity"
+        ]
+      }
+    ],
     "dependencyEdges": [
       {
         "prerequisite": "fire_control",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Fire Control is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "type": "required",
+        "confidence": 0.93,
+        "evidence_level": "primary_source",
+        "note": "Birch bark tar must be intentionally manufactured by heating bark; the cited paper states that all production methods require knowledge of fire to transform bark into tar.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Identifying Palaeolithic birch tar production techniques: challenges from an experimental biomolecular approach",
+            "url": "https://www.nature.com/articles/s41598-023-41898-5",
+            "publisher": "Scientific Reports",
+            "year": 2023,
+            "source_type": "primary_paper",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "foraging_and_botany",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Foraging & Botany provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "confidence": 0.74,
+        "evidence_level": "primary_source",
+        "note": "The scoped adhesive depends on selecting birch bark as the raw plant material; this is a material-selection enabler rather than a hard botanical-science prerequisite.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Identifying Palaeolithic birch tar production techniques: challenges from an experimental biomolecular approach",
+            "url": "https://www.nature.com/articles/s41598-023-41898-5",
+            "publisher": "Scientific Reports",
+            "year": 2023,
+            "source_type": "primary_paper",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T19:18:32.622Z",
+  "generatedAt": "2026-06-11T19:25:18.452Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,30 +11,30 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 624,
+      "value": 625,
       "denominator": 1660,
-      "formatted": "624 / 1,660",
-      "note": "37.6%"
+      "formatted": "625 / 1,660",
+      "note": "37.7%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 658,
+      "value": 659,
       "denominator": 1660,
-      "formatted": "658 / 1,660",
-      "note": "39.6%"
+      "formatted": "659 / 1,660",
+      "note": "39.7%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1903,
+      "value": 1905,
       "denominator": 5551,
-      "formatted": "1,903 / 5,551",
+      "formatted": "1,905 / 5,551",
       "note": "34.3%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 548,
+      "value": 547,
       "denominator": 1660,
-      "formatted": "548 / 1,660",
+      "formatted": "547 / 1,660",
       "note": "33.0%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 658,
-    "sourceChecked": 624,
+    "nodesWithSources": 659,
+    "sourceChecked": 625,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 548,
+    "eraDefaultDates": 547,
     "sourceCheckedEraDefaultDates": 0,
     "totalEdges": 5551,
-    "edgesWithSources": 1903
+    "edgesWithSources": 1905
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T19:18:32.622Z
+Generated: 2026-06-11T19:25:18.452Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 624 / 1,660 (37.6%) |
-| Nodes with node-level sources | 658 / 1,660 (39.6%) |
-| Dependency edges with edge-level sources | 1,903 / 5,551 (34.3%) |
-| Era-default placeholder dates | 548 / 1,660 (33.0%) |
+| Source-checked nodes | 625 / 1,660 (37.7%) |
+| Nodes with node-level sources | 659 / 1,660 (39.7%) |
+| Dependency edges with edge-level sources | 1,905 / 5,551 (34.3%) |
+| Era-default placeholder dates | 547 / 1,660 (33.0%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-birch-tar-fire-required.json
+++ b/docs/edge-change-receipts/2026-06-11-birch-tar-fire-required.json
@@ -1,0 +1,47 @@
+{
+  "id": "2026-06-11-birch-tar-fire-required",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "natural_adhesives",
+    "prerequisite": "fire_control"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Fire Control is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.93,
+    "evidence_level": "primary_source",
+    "note": "Birch bark tar must be intentionally manufactured by heating bark; the cited paper states that all production methods require knowledge of fire to transform bark into tar."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.nature.com/articles/s41598-023-41898-5",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "demonstrates_method_dependency",
+    "source_locator": "Introduction: birch bark tar must be intentionally manufactured; all methods require knowledge about using fire to transform white bark into sticky black tar.",
+    "source_claim_summary": "The paper directly links birch tar production to fire-mediated transformation of birch bark.",
+    "source_support_rationale": "Because the node is scoped to manufactured birch bark tar adhesive, fire is a method requirement rather than only historical background."
+  },
+  "ontology_before": "The graph treated fire control as a broad historical predecessor for natural adhesives.",
+  "ontology_after": "The graph treats fire as required for the scoped birch-tar manufacturing process.",
+  "invariant_preserved_or_changed": "Changed: fire_control edge is now required and source-checked.",
+  "would_reject_if": [
+    "The node were broadened to naturally exuded gums or resins collected without thermal processing.",
+    "A source showed Campitello birch tar formed naturally without deliberate heating.",
+    "The edge were retyped as merely historical without changing the node scope."
+  ],
+  "short_reason": "Manufactured birch bark tar requires fire-mediated heating.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/natural_adhesives.before.json /tmp/natural_adhesives.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-birch-tar-plant-selection-enabling.json
+++ b/docs/edge-change-receipts/2026-06-11-birch-tar-plant-selection-enabling.json
@@ -1,0 +1,47 @@
+{
+  "id": "2026-06-11-birch-tar-plant-selection-enabling",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "natural_adhesives",
+    "prerequisite": "foraging_and_botany"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Foraging & Botany provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.74,
+    "evidence_level": "primary_source",
+    "note": "The scoped adhesive depends on selecting birch bark as the raw plant material; this is a material-selection enabler rather than a hard botanical-science prerequisite."
+  },
+  "source_supports_edge": "partial",
+  "source_url": "https://www.nature.com/articles/s41598-023-41898-5",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Introduction and materials discussion: birch bark tar uses birch bark as the raw material and relies on identifying production methods for that material.",
+    "source_claim_summary": "The paper supports birch bark as the raw material for the scoped adhesive.",
+    "source_support_rationale": "The source supports plant-material selection, but not a strict dependency on formal botany; the edge therefore remains enabling."
+  },
+  "ontology_before": "The graph used a generic foraging-and-botany enabler edge without source support.",
+  "ontology_after": "The graph keeps a weaker enabling edge tied to plant raw-material selection.",
+  "invariant_preserved_or_changed": "Preserved: foraging_and_botany remains an enabling edge, now with a narrower note and source-backed rationale.",
+  "would_reject_if": [
+    "The node were narrowed to lab-produced tar where field plant selection is irrelevant.",
+    "A better upstream node for raw-material selection replaced foraging_and_botany.",
+    "The edge were made required without direct source support for a formal botanical prerequisite."
+  ],
+  "short_reason": "Birch bark selection is relevant context, but not a hard prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/natural_adhesives.before.json /tmp/natural_adhesives.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-birch-tar-adhesive-scope.json
+++ b/docs/graph-invariants/2026-06-11-birch-tar-adhesive-scope.json
@@ -1,0 +1,26 @@
+{
+  "id": "2026-06-11-birch-tar-adhesive-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "natural_adhesives",
+      "operator": "eq",
+      "value": -188000,
+      "reason": "The node is scoped to birch bark tar adhesive dating to at least about 190,000 years ago at Campitello Quarry."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "natural_adhesives",
+      "prerequisite": "fire_control",
+      "expected": "required",
+      "reason": "Manufactured birch bark tar requires fire-mediated heating of bark."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "natural_adhesives",
+      "prerequisite": "foraging_and_botany",
+      "expected": "enabling",
+      "reason": "Plant raw-material selection is enabling context, not a hard formal-botany prerequisite."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node source-backed correction for `natural_adhesives`.

## Old Claim
`natural_adhesives` was a broad unsourced `Natural Adhesives` node dated to `-10000` / `millennium`, region `Global / multiple regions`, with inferred edges from `fire_control` and `foraging_and_botany`.

## New Claim
`natural_adhesives` is now scoped as `Paleolithic Birch Tar Adhesive`: intentional production of birch bark tar used as a hafting adhesive, with an earliest supported claim at Campitello Quarry, Italy, dating to at least about 190,000 years ago (`firstKnownDate: -188000`, `datePrecision: millennium`).

## Source
- Scientific Reports 2023, `Identifying Palaeolithic birch tar production techniques: challenges from an experimental biomolecular approach`
- URL: https://www.nature.com/articles/s41598-023-41898-5
- Locator: introduction describes birch bark tar as intentionally manufactured, the oldest known adhesive substance, dating to at least 190,000 years ago at Campitello Quarry; also states all production methods require knowledge about using fire to transform bark into tar.

## Edge Changes
- `fire_control -> natural_adhesives`: `historical_predecessor` / expert inference -> `required` / primary-source supported.
- `foraging_and_botany -> natural_adhesives`: kept as `enabling`, but source-checked and narrowed to birch-bark raw material selection rather than a hard botanical-science prerequisite.

## Why Better
The previous node was a broad placeholder for many adhesive materials. This PR narrows it to a specific source-backed Paleolithic adhesive and fixes a large chronology error: `-10000` became `-188000` for the scoped birch-tar technology.

## Adversarial Note
The strongest reason this could be incomplete is that `natural_adhesives` used to cover broader gums, resins, pitch, and waterproofing compounds. This PR intentionally scope-locks the existing node rather than adding separate nodes for those other adhesive traditions.

## Validation
- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/natural_adhesives.before.json /tmp/natural_adhesives.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed
- `npm run accuracy:risks -- --markdown --limit 24` passed