### PR TITLE
[codex] Source-check Aurignacian flutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 625 / 1,660 (37.7%) |
-| Nodes with node-level sources | 659 / 1,660 (39.7%) |
-| Dependency edges with edge-level sources | 1,905 / 5,551 (34.3%) |
-| Era-default placeholder dates | 547 / 1,660 (33.0%) |
+| Source-checked nodes | 626 / 1,660 (37.7%) |
+| Nodes with node-level sources | 660 / 1,660 (39.8%) |
+| Dependency edges with edge-level sources | 1,906 / 5,548 (34.4%) |
+| Era-default placeholder dates | 546 / 1,660 (32.9%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -1349,51 +1349,51 @@
   },
   {
     "id": "early_musical_instruments_flutes_drums",
-    "name": "Early Musical Instruments (Flutes, Drums)",
+    "name": "Aurignacian Bone and Ivory Flutes",
     "era": "Ancient",
-    "description": "Crafting simple instruments from bone, wood, or stretched hides for ritual, communication, or entertainment.",
+    "description": "Bone and ivory flutes showing an established Upper Paleolithic musical tradition.",
     "prerequisites": [
-      "woodworking_basic",
-      "bone_tool_making",
-      "leather_working",
-      "shamanism_animism"
+      "bone_tool_making"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -35000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
-    "dependencyEdges": [
+    "region": "Hohle Fels and Geissenkloesterle caves, Swabian Jura, southwestern Germany",
+    "reviewStatus": "source_checked",
+    "scopeNote": "Covers the source-backed early Aurignacian bone and ivory flutes from southwestern Germany. It does not cover drums, hide instruments, wooden instruments, ritual interpretation, or all possible Paleolithic sound-making objects.",
+    "sources": [
       {
-        "prerequisite": "woodworking_basic",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Basic Woodworking is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
-      },
+        "title": "New flutes document the earliest musical tradition in southwestern Germany",
+        "url": "https://www.nature.com/articles/nature08169",
+        "publisher": "Nature",
+        "year": 2009,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "edge",
+          "maturity"
+        ]
+      }
+    ],
+    "dependencyEdges": [
       {
         "prerequisite": "bone_tool_making",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Bone Tool Making provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "leather_working",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Leather Working provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "shamanism_animism",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Shamanism & Animism provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "confidence": 0.76,
+        "evidence_level": "primary_source",
+        "note": "The cited flutes were made from bird bone and mammoth ivory, so bone/ivory working is an enabling material-working capability rather than proof of a broader musical prerequisite.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "New flutes document the earliest musical tradition in southwestern Germany",
+            "url": "https://www.nature.com/articles/nature08169",
+            "publisher": "Nature",
+            "year": 2009,
+            "source_type": "primary_paper",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T19:25:18.452Z",
+  "generatedAt": "2026-06-11T19:33:13.500Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 625,
+      "value": 626,
       "denominator": 1660,
-      "formatted": "625 / 1,660",
+      "formatted": "626 / 1,660",
       "note": "37.7%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 659,
+      "value": 660,
       "denominator": 1660,
-      "formatted": "659 / 1,660",
-      "note": "39.7%"
+      "formatted": "660 / 1,660",
+      "note": "39.8%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1905,
-      "denominator": 5551,
-      "formatted": "1,905 / 5,551",
-      "note": "34.3%"
+      "value": 1906,
+      "denominator": 5548,
+      "formatted": "1,906 / 5,548",
+      "note": "34.4%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 547,
+      "value": 546,
       "denominator": 1660,
-      "formatted": "547 / 1,660",
-      "note": "33.0%"
+      "formatted": "546 / 1,660",
+      "note": "32.9%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 659,
-    "sourceChecked": 625,
+    "nodesWithSources": 660,
+    "sourceChecked": 626,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 547,
+    "eraDefaultDates": 546,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5551,
-    "edgesWithSources": 1905
+    "totalEdges": 5548,
+    "edgesWithSources": 1906
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T19:25:18.452Z
+Generated: 2026-06-11T19:33:13.500Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 625 / 1,660 (37.7%) |
-| Nodes with node-level sources | 659 / 1,660 (39.7%) |
-| Dependency edges with edge-level sources | 1,905 / 5,551 (34.3%) |
-| Era-default placeholder dates | 547 / 1,660 (33.0%) |
+| Source-checked nodes | 626 / 1,660 (37.7%) |
+| Nodes with node-level sources | 660 / 1,660 (39.8%) |
+| Dependency edges with edge-level sources | 1,906 / 5,548 (34.4%) |
+| Era-default placeholder dates | 546 / 1,660 (32.9%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-aurignacian-flutes-bone-working-enabling.json
+++ b/docs/edge-change-receipts/2026-06-11-aurignacian-flutes-bone-working-enabling.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-11-aurignacian-flutes-bone-working-enabling",
+  "decision_date": "2026-06-11",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "early_musical_instruments_flutes_drums",
+    "prerequisite": "bone_tool_making"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Bone Tool Making provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.76,
+    "evidence_level": "primary_source",
+    "note": "The cited flutes were made from bird bone and mammoth ivory, so bone/ivory working is an enabling material-working capability rather than proof of a broader musical prerequisite."
+  },
+  "source_supports_edge": "partial",
+  "source_url": "https://www.nature.com/articles/nature08169",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "documents_application_use",
+    "source_locator": "Abstract: reports bone and ivory flutes from the early Aurignacian period of southwestern Germany.",
+    "source_claim_summary": "The source documents bone and ivory as the manufactured materials of the scoped flutes.",
+    "source_support_rationale": "The source supports bone/ivory material working as relevant to the flute technology, but does not make the broader bone_tool_making node a uniquely required prerequisite."
+  },
+  "invariant_preserved_or_changed": "Preserved: bone_tool_making remains an enabling edge, now source-checked and narrowed to material working.",
+  "would_reject_if": [
+    "The node were rescoped to wooden, hide, or percussion instruments rather than bone and ivory flutes.",
+    "A better upstream node for ivory/bone musical-instrument manufacture replaced bone_tool_making.",
+    "The edge were upgraded to required without source evidence that all scoped flutes depended on the broader bone_tool_making node."
+  ],
+  "short_reason": "The source-backed flutes are bone and ivory artifacts.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/early_musical_instruments_flutes_drums.before.json /tmp/early_musical_instruments_flutes_drums.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-aurignacian-flutes-leather-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-aurignacian-flutes-leather-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-aurignacian-flutes-leather-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "early_musical_instruments_flutes_drums",
+    "prerequisite": "leather_working"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Leather Working provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from early_musical_instruments_flutes_drums to leather_working. The corrected node excludes drums and stretched-hide instruments.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.nature.com/articles/nature08169",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: reports bone and ivory flutes and says they demonstrate an established musical tradition.",
+    "source_claim_summary": "The source supports flutes made of bone and ivory, not hide drums.",
+    "source_support_rationale": "Because drums and hide instruments were removed from the node scope, leather working should not remain as a direct prerequisite."
+  },
+  "ontology_before": "The graph let a flutes-and-drums label pull leather working into the prerequisites.",
+  "ontology_after": "The graph keeps the source-backed flute claim separate from unsourced hide-instrument claims.",
+  "invariant_preserved_or_changed": "Changed: leather_working is absent as a direct prerequisite for early_musical_instruments_flutes_drums.",
+  "would_reject_if": [
+    "The node were broadened again to include drums or hide instruments.",
+    "A source showed the scoped Aurignacian flutes required leather working.",
+    "The graph reintroduced leather_working without changing the node scope."
+  ],
+  "short_reason": "Bone and ivory flutes do not support a leather-working prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/early_musical_instruments_flutes_drums.before.json /tmp/early_musical_instruments_flutes_drums.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-aurignacian-flutes-shamanism-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-aurignacian-flutes-shamanism-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-aurignacian-flutes-shamanism-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "early_musical_instruments_flutes_drums",
+    "prerequisite": "shamanism_animism"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Shamanism & Animism provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from early_musical_instruments_flutes_drums to shamanism_animism. The cited source documents musical artifacts and tradition, not a ritual or animist prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.nature.com/articles/nature08169",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: reports bone and ivory flutes and an established musical tradition; it does not establish shamanism or animism as a prerequisite.",
+    "source_claim_summary": "The source supports early musical instruments without proving a ritual-religious dependency.",
+    "source_support_rationale": "Musical tradition evidence should not be converted into a direct shamanism/animism prerequisite without explicit source support."
+  },
+  "ontology_before": "The graph made a speculative religious context a direct enabler of early musical instruments.",
+  "ontology_after": "The graph models source-backed flutes without requiring a ritual or animist institution.",
+  "invariant_preserved_or_changed": "Changed: shamanism_animism is absent as a direct prerequisite for early_musical_instruments_flutes_drums.",
+  "would_reject_if": [
+    "The node were rescoped to ritual instruments with direct source evidence.",
+    "A source showed the scoped Aurignacian flutes required shamanism or animism.",
+    "The graph reintroduced the edge as more than speculative context."
+  ],
+  "short_reason": "The source supports musical artifacts, not a shamanism prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/early_musical_instruments_flutes_drums.before.json /tmp/early_musical_instruments_flutes_drums.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-aurignacian-flutes-woodworking-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-aurignacian-flutes-woodworking-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-aurignacian-flutes-woodworking-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "early_musical_instruments_flutes_drums",
+    "prerequisite": "woodworking_basic"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Basic Woodworking is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from early_musical_instruments_flutes_drums to woodworking_basic. The corrected node is scoped to bone and ivory flutes, not wooden instruments.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.nature.com/articles/nature08169",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: reports bone and ivory flutes from the early Aurignacian period of southwestern Germany.",
+    "source_claim_summary": "The source supports bone and ivory flutes, not wooden instruments.",
+    "source_support_rationale": "Because wood instruments were removed from the node scope, woodworking should not remain as a direct prerequisite."
+  },
+  "ontology_before": "The graph made basic woodworking a direct historical predecessor for a mixed flutes-and-drums node.",
+  "ontology_after": "The graph models source-backed bone and ivory flutes without a woodworking prerequisite.",
+  "invariant_preserved_or_changed": "Changed: woodworking_basic is absent as a direct prerequisite for early_musical_instruments_flutes_drums.",
+  "would_reject_if": [
+    "The node were broadened again to wooden musical instruments.",
+    "A source showed the scoped Aurignacian bone and ivory flutes required woodworking.",
+    "The graph reintroduced woodworking without changing the node scope."
+  ],
+  "short_reason": "The scoped artifacts are bone and ivory flutes, not wooden instruments.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/early_musical_instruments_flutes_drums.before.json /tmp/early_musical_instruments_flutes_drums.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-aurignacian-flutes-scope.json
+++ b/docs/graph-invariants/2026-06-11-aurignacian-flutes-scope.json
@@ -1,0 +1,37 @@
+{
+  "id": "2026-06-11-aurignacian-flutes-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "early_musical_instruments_flutes_drums",
+      "operator": "eq",
+      "value": -35000,
+      "reason": "The node is scoped to early Aurignacian bone and ivory flutes more than 35,000 calendar years old."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "early_musical_instruments_flutes_drums",
+      "prerequisite": "bone_tool_making",
+      "expected": "enabling",
+      "reason": "Bone/ivory working remains an enabling material capability for the scoped flutes."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "early_musical_instruments_flutes_drums",
+      "prerequisite": "woodworking_basic",
+      "reason": "The scoped artifacts are bone and ivory flutes, not wooden instruments."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "early_musical_instruments_flutes_drums",
+      "prerequisite": "leather_working",
+      "reason": "The scoped artifacts are flutes, not hide drums or stretched-hide instruments."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "early_musical_instruments_flutes_drums",
+      "prerequisite": "shamanism_animism",
+      "reason": "The source documents musical artifacts without proving shamanism or animism as a prerequisite."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node source-backed correction for `early_musical_instruments_flutes_drums`.

## Old Claim
`early_musical_instruments_flutes_drums` was a broad unsourced `Early Musical Instruments (Flutes, Drums)` node dated to `-10000` / `millennium`, region `Global / multiple regions`, with inferred direct prerequisites from `woodworking_basic`, `bone_tool_making`, `leather_working`, and `shamanism_animism`.

## New Claim
The node is now scoped as `Aurignacian Bone and Ivory Flutes`: bone and ivory flutes from early Aurignacian southwestern Germany, more than 35,000 calendar years old (`firstKnownDate: -35000`, `datePrecision: millennium`).

## Source
- Nature 2009, `New flutes document the earliest musical tradition in southwestern Germany`
- URL: https://www.nature.com/articles/nature08169
- Locator: abstract reports bone and ivory flutes from the early Aurignacian period of southwestern Germany and says they demonstrate an established musical tradition more than 35,000 calendar years ago.

## Edge Changes
Removed unsupported direct edges:
- `woodworking_basic -> early_musical_instruments_flutes_drums`
- `leather_working -> early_musical_instruments_flutes_drums`
- `shamanism_animism -> early_musical_instruments_flutes_drums`

Kept and source-checked:
- `bone_tool_making -> early_musical_instruments_flutes_drums` as `enabling`, with primary-source evidence tied to bird bone and mammoth ivory flute materials.

## Why Better
The old node mixed flutes, drums, wooden instruments, hide instruments, and ritual interpretation into one placeholder-era claim. The corrected node only says what the Nature paper supports. This removes three speculative prerequisites and fixes the chronology from `-10000` to `-35000`.

## Adversarial Note
The strongest reason this correction could be incomplete is that broader Paleolithic music technologies may deserve separate nodes later: drums, idiophones, wooden instruments, ritual sound objects, and disputed Middle Paleolithic candidates are intentionally excluded from this scoped correction.

## Validation
- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/early_musical_instruments_flutes_drums.before.json /tmp/early_musical_instruments_flutes_drums.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed
- `npm run accuracy:risks -- --markdown --limit 24` passed