### PR TITLE
[codex] Source-check Contrebandiers hide working

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 626 / 1,660 (37.7%) |
-| Nodes with node-level sources | 660 / 1,660 (39.8%) |
-| Dependency edges with edge-level sources | 1,906 / 5,548 (34.4%) |
-| Era-default placeholder dates | 546 / 1,660 (32.9%) |
+| Source-checked nodes | 627 / 1,660 (37.8%) |
+| Nodes with node-level sources | 661 / 1,660 (39.8%) |
+| Dependency edges with edge-level sources | 1,907 / 5,547 (34.4%) |
+| Era-default placeholder dates | 545 / 1,660 (32.8%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -1182,33 +1182,51 @@
   },
   {
     "id": "hide_processing",
-    "name": "Hide Processing",
+    "name": "Contrebandiers Leather and Fur Working",
     "era": "Ancient",
-    "description": "The basic craft of scraping and preparing animal hides for use as simple clothing, shelter covers, or containers.",
+    "description": "Bone-tool working of animal hides and pelts for leather and fur production.",
     "prerequisites": [
-      "advanced_hunting_gathering",
-      "advanced_stone_tools"
+      "bone_tool_making"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -118000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Contrebandiers Cave, Atlantic Coast, Morocco",
+    "reviewStatus": "source_checked",
+    "scopeNote": "Covers source-backed bone tools from Contrebandiers Cave that were likely used for leather and fur working in 120,000-90,000-year-old deposits. It does not claim all hide processing, tanning, sewn clothing, or later leatherworking traditions.",
+    "sources": [
+      {
+        "title": "A worked bone assemblage from 120,000-90,000 year old deposits at Contrebandiers Cave, Atlantic Coast, Morocco",
+        "url": "https://doi.org/10.1016/j.isci.2021.102988",
+        "publisher": "iScience",
+        "year": 2021,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "edge",
+          "maturity"
+        ]
+      }
+    ],
     "dependencyEdges": [
       {
-        "prerequisite": "advanced_hunting_gathering",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Hunting & Gathering provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "advanced_stone_tools",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Stone Tools is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "prerequisite": "bone_tool_making",
+        "type": "required",
+        "confidence": 0.88,
+        "evidence_level": "primary_source",
+        "note": "The scoped technology is defined by worked bone tools used for leather and fur working in the Contrebandiers assemblage.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "A worked bone assemblage from 120,000-90,000 year old deposits at Contrebandiers Cave, Atlantic Coast, Morocco",
+            "url": "https://doi.org/10.1016/j.isci.2021.102988",
+            "publisher": "iScience",
+            "year": 2021,
+            "source_type": "primary_paper",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T19:33:13.500Z",
+  "generatedAt": "2026-06-11T19:40:59.267Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 626,
+      "value": 627,
       "denominator": 1660,
-      "formatted": "626 / 1,660",
-      "note": "37.7%"
+      "formatted": "627 / 1,660",
+      "note": "37.8%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 660,
+      "value": 661,
       "denominator": 1660,
-      "formatted": "660 / 1,660",
+      "formatted": "661 / 1,660",
       "note": "39.8%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1906,
-      "denominator": 5548,
-      "formatted": "1,906 / 5,548",
+      "value": 1907,
+      "denominator": 5547,
+      "formatted": "1,907 / 5,547",
       "note": "34.4%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 546,
+      "value": 545,
       "denominator": 1660,
-      "formatted": "546 / 1,660",
-      "note": "32.9%"
+      "formatted": "545 / 1,660",
+      "note": "32.8%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 660,
-    "sourceChecked": 626,
+    "nodesWithSources": 661,
+    "sourceChecked": 627,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 546,
+    "eraDefaultDates": 545,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5548,
-    "edgesWithSources": 1906
+    "totalEdges": 5547,
+    "edgesWithSources": 1907
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T19:33:13.500Z
+Generated: 2026-06-11T19:40:59.267Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 626 / 1,660 (37.7%) |
-| Nodes with node-level sources | 660 / 1,660 (39.8%) |
-| Dependency edges with edge-level sources | 1,906 / 5,548 (34.4%) |
-| Era-default placeholder dates | 546 / 1,660 (32.9%) |
+| Source-checked nodes | 627 / 1,660 (37.8%) |
+| Nodes with node-level sources | 661 / 1,660 (39.8%) |
+| Dependency edges with edge-level sources | 1,907 / 5,547 (34.4%) |
+| Era-default placeholder dates | 545 / 1,660 (32.8%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-contrebandiers-hide-advanced-hunting-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-contrebandiers-hide-advanced-hunting-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-contrebandiers-hide-advanced-hunting-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "hide_processing",
+    "prerequisite": "advanced_hunting_gathering"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Hunting & Gathering provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from hide_processing to advanced_hunting_gathering. The corrected node is scoped to worked bone tools for leather and fur production in 120,000-90,000-year-old deposits, which predates the current advanced_hunting_gathering node date.",
+  "source_supports_edge": "no",
+  "source_url": "https://doi.org/10.1016/j.isci.2021.102988",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Highlights and summary: bone tools from Contrebandiers Cave are dated to 120,000-90,000 years ago and were likely used for leather and fur working; carnivore bones show skinning for fur removal.",
+    "source_claim_summary": "The source supports early bone-tool leather and fur working at Contrebandiers Cave.",
+    "source_support_rationale": "The source gives a much earlier scoped technology than the advanced_hunting_gathering placeholder and does not require that graph node as a prerequisite."
+  },
+  "ontology_before": "The graph modeled hide processing as downstream of a later broad advanced hunting-and-gathering placeholder.",
+  "ontology_after": "The graph models a source-backed bone-tool hide-working technology without a chronologically invalid advanced-hunting prerequisite.",
+  "invariant_preserved_or_changed": "Changed: advanced_hunting_gathering is absent as a direct prerequisite for hide_processing.",
+  "would_reject_if": [
+    "The advanced_hunting_gathering node were separately source-checked and redated early enough with direct evidence for this technology.",
+    "A source showed Contrebandiers leather and fur working required the broader advanced_hunting_gathering node.",
+    "The hide_processing node were broadened again to general subsistence hide use."
+  ],
+  "short_reason": "The source-backed hide-working claim predates the placeholder advanced_hunting_gathering node.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/hide_processing.before.json /tmp/hide_processing.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-contrebandiers-hide-stone-tools-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-contrebandiers-hide-stone-tools-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-contrebandiers-hide-stone-tools-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "hide_processing",
+    "prerequisite": "advanced_stone_tools"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Stone Tools is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from hide_processing to advanced_stone_tools. The corrected node is scoped to worked bone tools for leather and fur production, so the direct prerequisite is bone_tool_making instead of the later broad advanced_stone_tools node.",
+  "source_supports_edge": "no",
+  "source_url": "https://doi.org/10.1016/j.isci.2021.102988",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Highlights and summary: describes a bone tool tradition from Contrebandiers Cave, dated between 120,000 and 90,000 years ago, produced for activities including likely leather and fur working.",
+    "source_claim_summary": "The source supports worked bone tools as the relevant material technology.",
+    "source_support_rationale": "The scoped claim should depend on bone-tool manufacture rather than a later, broad advanced-stone-tool placeholder."
+  },
+  "ontology_before": "The graph treated advanced stone tools as the direct predecessor of hide processing.",
+  "ontology_after": "The graph uses bone_tool_making as the direct prerequisite for the source-backed bone-tool hide-working claim.",
+  "invariant_preserved_or_changed": "Changed: advanced_stone_tools is absent as a direct prerequisite for hide_processing.",
+  "would_reject_if": [
+    "The node were rescoped to stone end-scraper hide processing rather than worked bone tools.",
+    "A source showed the Contrebandiers hide-working bone tools required the current advanced_stone_tools node.",
+    "The graph lacked a bone_tool_making prerequisite for the scoped technology."
+  ],
+  "short_reason": "The source-backed technology is worked bone hide-working tools, not a broad stone-tool prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/hide_processing.before.json /tmp/hide_processing.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-contrebandiers-hide-working-scope.json
+++ b/docs/graph-invariants/2026-06-11-contrebandiers-hide-working-scope.json
@@ -1,0 +1,31 @@
+{
+  "id": "2026-06-11-contrebandiers-hide-working-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "hide_processing",
+      "operator": "eq",
+      "value": -118000,
+      "reason": "The node is scoped to Contrebandiers Cave worked bone tools in 120,000-90,000-year-old deposits."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "hide_processing",
+      "prerequisite": "bone_tool_making",
+      "expected": "required",
+      "reason": "The scoped technology is defined by worked bone tools used for leather and fur working."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "hide_processing",
+      "prerequisite": "advanced_hunting_gathering",
+      "reason": "The source-backed claim predates the current advanced_hunting_gathering node and does not require it."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "hide_processing",
+      "prerequisite": "advanced_stone_tools",
+      "reason": "The scoped claim uses worked bone tools, not the later broad advanced_stone_tools node."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node source-backed correction for `hide_processing`.

## Old Claim
`hide_processing` was a broad unsourced `Hide Processing` node dated to `-10000` / `millennium`, region `Global / multiple regions`, with inferred prerequisites from `advanced_hunting_gathering` and `advanced_stone_tools`.

## New Claim
The node is now scoped as `Contrebandiers Leather and Fur Working`: worked bone tools used for leather and fur production in 120,000-90,000-year-old deposits at Contrebandiers Cave, Atlantic Coast, Morocco (`firstKnownDate: -118000`, `datePrecision: millennium`).

## Source
- iScience 2021, `A worked bone assemblage from 120,000-90,000 year old deposits at Contrebandiers Cave, Atlantic Coast, Morocco`
- URL: https://doi.org/10.1016/j.isci.2021.102988
- Locator: highlights and summary report bone tools from Contrebandiers Cave dated to 120,000-90,000 years ago, likely used for leather and fur working, with carnivore bones showing skinning for fur removal.

## Edge Changes
Removed unsupported/chronologically wrong direct edges:
- `advanced_hunting_gathering -> hide_processing`
- `advanced_stone_tools -> hide_processing`

Added source-backed direct edge:
- `bone_tool_making -> hide_processing` as `required`, because the scoped technology is defined by worked bone tools.

## Why Better
The old node was a generic placeholder and would become temporally invalid once dated correctly. The correction uses the primary paper's exact scope and moves the direct prerequisite to the material technology actually documented by the source.

## Adversarial Note
The strongest reason this could be incomplete is that general hide processing and stone end-scraper hide working are broader than this node now claims. Those should be modeled separately if kept; this PR only source-checks the Contrebandiers bone-tool leather/fur-working evidence.

## Validation
- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/hide_processing.before.json /tmp/hide_processing.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed
- `npm run accuracy:risks -- --markdown --limit 24` passed