### PR TITLE
[codex] Source-check Paleolithic eyed needles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 627 / 1,660 (37.8%) |
-| Nodes with node-level sources | 661 / 1,660 (39.8%) |
-| Dependency edges with edge-level sources | 1,907 / 5,547 (34.4%) |
-| Era-default placeholder dates | 545 / 1,660 (32.8%) |
+| Source-checked nodes | 628 / 1,660 (37.8%) |
+| Nodes with node-level sources | 662 / 1,660 (39.9%) |
+| Dependency edges with edge-level sources | 1,909 / 5,545 (34.4%) |
+| Era-default placeholder dates | 544 / 1,660 (32.8%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -7507,42 +7507,72 @@
   },
   {
     "id": "bone_needles_tailoring",
-    "name": "Bone Needles & Tailoring",
+    "name": "Paleolithic Eyed Needles",
     "era": "Ancient",
-    "description": "Pierced bone and antler needles used to stitch fitted clothing, hides, bags, shelters, sails, and textile goods.",
+    "description": "Bone, antler, or ivory needles with eyes used for sewing thread or sinew through hides and garments.",
     "prerequisites": [
-      "advanced_stone_tools",
-      "basic_rope_making",
-      "basic_weaving_basketry"
+      "bone_tool_making",
+      "basic_rope_making"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -38000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Denisova Cave, Altai Mountains, southern Siberia",
+    "reviewStatus": "source_checked",
+    "scopeNote": "Covers source-backed Paleolithic eyed needles beginning around 40,000 cal BP at Denisova Cave. It does not cover bone awls, basketry, general tailoring, sails, shelters, or later regional needle traditions unless modeled separately.",
+    "sources": [
+      {
+        "title": "Paleolithic eyed needles and the evolution of dress",
+        "url": "https://www.science.org/doi/10.1126/sciadv.adp2887",
+        "publisher": "Science Advances",
+        "year": 2024,
+        "source_type": "review",
+        "supports": [
+          "node",
+          "edge",
+          "maturity"
+        ]
+      }
+    ],
     "dependencyEdges": [
       {
-        "prerequisite": "advanced_stone_tools",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Stone Tools is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "prerequisite": "bone_tool_making",
+        "type": "required",
+        "confidence": 0.84,
+        "evidence_level": "review",
+        "note": "The scoped technology is a bone, antler, or ivory tool form; bone-tool manufacture is therefore a direct material-method requirement.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Paleolithic eyed needles and the evolution of dress",
+            "url": "https://www.science.org/doi/10.1126/sciadv.adp2887",
+            "publisher": "Science Advances",
+            "year": 2024,
+            "source_type": "review",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "basic_rope_making",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Basic Rope Making is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "basic_weaving_basketry",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Basic Weaving and Basketry is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "type": "enabling",
+        "confidence": 0.7,
+        "evidence_level": "review",
+        "note": "Thread, sinew, or other cordage-like material enables eyed-needle sewing, but broad rope making is not a hard prerequisite for the needle artifact itself.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Paleolithic eyed needles and the evolution of dress",
+            "url": "https://www.science.org/doi/10.1126/sciadv.adp2887",
+            "publisher": "Science Advances",
+            "year": 2024,
+            "source_type": "review",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       }
     ]
   },
@@ -8530,7 +8560,6 @@
     "description": "Improved hook shapes with barbs, points, and tied lines for more reliable fishing in rivers, lakes, and coasts.",
     "prerequisites": [
       "fishing_nets_hooks",
-      "bone_needles_tailoring",
       "basic_rope_making"
     ],
     "firstKnownDate": -10000,
@@ -8544,14 +8573,6 @@
         "confidence": 0.68,
         "evidence_level": "expert_inference",
         "note": "Paleolithic Fish Hooks provide an earlier hook technology that enables later hook-shape improvements without proving a hard prerequisite.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "bone_needles_tailoring",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Bone Needles & Tailoring provides a capability that enables this technology without being the only possible path.",
         "reviewStatus": "structurally_validated"
       },
       {

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T19:40:59.267Z",
+  "generatedAt": "2026-06-11T19:47:30.518Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,30 +11,30 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 627,
+      "value": 628,
       "denominator": 1660,
-      "formatted": "627 / 1,660",
+      "formatted": "628 / 1,660",
       "note": "37.8%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 661,
+      "value": 662,
       "denominator": 1660,
-      "formatted": "661 / 1,660",
-      "note": "39.8%"
+      "formatted": "662 / 1,660",
+      "note": "39.9%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1907,
-      "denominator": 5547,
-      "formatted": "1,907 / 5,547",
+      "value": 1909,
+      "denominator": 5545,
+      "formatted": "1,909 / 5,545",
       "note": "34.4%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 545,
+      "value": 544,
       "denominator": 1660,
-      "formatted": "545 / 1,660",
+      "formatted": "544 / 1,660",
       "note": "32.8%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 661,
-    "sourceChecked": 627,
+    "nodesWithSources": 662,
+    "sourceChecked": 628,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 545,
+    "eraDefaultDates": 544,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5547,
-    "edgesWithSources": 1907
+    "totalEdges": 5545,
+    "edgesWithSources": 1909
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T19:40:59.267Z
+Generated: 2026-06-11T19:47:30.518Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 627 / 1,660 (37.8%) |
-| Nodes with node-level sources | 661 / 1,660 (39.8%) |
-| Dependency edges with edge-level sources | 1,907 / 5,547 (34.4%) |
-| Era-default placeholder dates | 545 / 1,660 (32.8%) |
+| Source-checked nodes | 628 / 1,660 (37.8%) |
+| Nodes with node-level sources | 662 / 1,660 (39.9%) |
+| Dependency edges with edge-level sources | 1,909 / 5,545 (34.4%) |
+| Era-default placeholder dates | 544 / 1,660 (32.8%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-barbed-hooks-eyed-needles-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-barbed-hooks-eyed-needles-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-barbed-hooks-eyed-needles-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "fish_hook_barbs",
+    "prerequisite": "bone_needles_tailoring"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Bone Needles & Tailoring provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from fish_hook_barbs to bone_needles_tailoring. The corrected prerequisite node is scoped to eyed sewing needles, which are not a source-backed enabler of barbed fish hooks.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.science.org/doi/10.1126/sciadv.adp2887",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Article scope: reviews eyed needles and dress; it does not connect eyed needles to fish-hook barb technology.",
+    "source_claim_summary": "The review supports eyed needles as sewing/dress technology.",
+    "source_support_rationale": "A sewing-needle source should not be used to support a fish-hook dependency."
+  },
+  "ontology_before": "The graph made bone needles and tailoring a direct enabler of barbed fish hooks.",
+  "ontology_after": "Barbed fish hooks no longer depend on eyed sewing needles.",
+  "invariant_preserved_or_changed": "Changed: bone_needles_tailoring is absent as a direct prerequisite for fish_hook_barbs.",
+  "would_reject_if": [
+    "A source showed barbed fish hooks required eyed sewing needles.",
+    "The prerequisite node were rescoped to general bone-point manufacture rather than eyed needles.",
+    "The fish_hook_barbs node were source-checked to a tradition that directly used sewing-needle technology."
+  ],
+  "short_reason": "Eyed sewing needles are not an evidenced prerequisite for barbed fish hooks.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/bone_needles_tailoring.before.json /tmp/bone_needles_tailoring.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-eyed-needles-advanced-stone-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-eyed-needles-advanced-stone-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-eyed-needles-advanced-stone-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "bone_needles_tailoring",
+    "prerequisite": "advanced_stone_tools"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Stone Tools is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from bone_needles_tailoring to advanced_stone_tools. The corrected node is scoped to eyed needles, and the direct material-method prerequisite is bone_tool_making instead of the later broad advanced_stone_tools placeholder.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.science.org/doi/10.1126/sciadv.adp2887",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Early eyed needles section: earliest eyed needles occur in northern Eurasia beginning around 40,000 cal BP at Denisova Cave.",
+    "source_claim_summary": "The review supports eyed needles as a bone/antler/ivory tool class around 40,000 cal BP.",
+    "source_support_rationale": "The reviewed technology is a bone-tool form and predates the current advanced_stone_tools placeholder date, so the broad stone-tool prerequisite is not appropriate."
+  },
+  "ontology_before": "The graph made a later broad advanced-stone-tool placeholder a direct predecessor of eyed needles.",
+  "ontology_after": "The graph uses bone_tool_making as the direct material-method prerequisite for eyed needles.",
+  "invariant_preserved_or_changed": "Changed: advanced_stone_tools is absent as a direct prerequisite for bone_needles_tailoring.",
+  "would_reject_if": [
+    "The advanced_stone_tools node were separately source-checked and redated early enough with direct needle-manufacture evidence.",
+    "The needle node were rescoped to lithic sewing tools rather than eyed bone/antler/ivory needles.",
+    "The graph lacked a bone_tool_making prerequisite for the scoped technology."
+  ],
+  "short_reason": "Eyed needles are a bone-tool class and should not depend on a later broad stone-tool placeholder.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/bone_needles_tailoring.before.json /tmp/bone_needles_tailoring.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-eyed-needles-basketry-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-eyed-needles-basketry-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-eyed-needles-basketry-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "bone_needles_tailoring",
+    "prerequisite": "basic_weaving_basketry"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Basic Weaving and Basketry is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from bone_needles_tailoring to basic_weaving_basketry. The corrected node is scoped to eyed needles for sewing, not woven or basketry technologies.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.science.org/doi/10.1126/sciadv.adp2887",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Article scope: reviews Paleolithic eyed needles and dress, not basketry or woven-container technologies.",
+    "source_claim_summary": "The review supports eyed needles as sewing technology.",
+    "source_support_rationale": "Basketry should not remain as a direct prerequisite when the node is source-locked to eyed needles rather than woven structures."
+  },
+  "ontology_before": "The graph treated basketry/weaving as a historical predecessor of bone needles and tailoring.",
+  "ontology_after": "The graph keeps eyed needles separate from basketry and woven-container technologies.",
+  "invariant_preserved_or_changed": "Changed: basic_weaving_basketry is absent as a direct prerequisite for bone_needles_tailoring.",
+  "would_reject_if": [
+    "The node were broadened to woven textiles or basketry tools.",
+    "A source showed the earliest eyed needles required basketry or weaving.",
+    "The graph reintroduced basic_weaving_basketry without changing the node scope."
+  ],
+  "short_reason": "Eyed needles are sewing tools, not basketry technology.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/bone_needles_tailoring.before.json /tmp/bone_needles_tailoring.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-eyed-needles-rope-enabling.json
+++ b/docs/edge-change-receipts/2026-06-11-eyed-needles-rope-enabling.json
@@ -1,0 +1,47 @@
+{
+  "id": "2026-06-11-eyed-needles-rope-enabling",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "bone_needles_tailoring",
+    "prerequisite": "basic_rope_making"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Basic Rope Making is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.7,
+    "evidence_level": "review",
+    "note": "Thread, sinew, or other cordage-like material enables eyed-needle sewing, but broad rope making is not a hard prerequisite for the needle artifact itself."
+  },
+  "source_supports_edge": "partial",
+  "source_url": "https://www.science.org/doi/10.1126/sciadv.adp2887",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Article scope and early-eyed-needles discussion: eyed needles are discussed as sewing tools for dress and clothing, with earliest examples around 40,000 cal BP at Denisova Cave.",
+    "source_claim_summary": "The review connects eyed needles to sewing technologies and dress rather than treating cordage as the artifact itself.",
+    "source_support_rationale": "Cordage/thread is enabling material for sewing with an eyed needle, but the review does not make broad rope-making a direct historical predecessor of the needle artifact."
+  },
+  "ontology_before": "The graph treated rope making as a historical predecessor of bone needles and tailoring.",
+  "ontology_after": "The graph treats cordage/thread as an enabling material context for source-backed eyed needles.",
+  "invariant_preserved_or_changed": "Changed: basic_rope_making edge is now enabling rather than historical_predecessor.",
+  "would_reject_if": [
+    "The node were rescoped to rope or textile production rather than eyed needles.",
+    "A source showed eyed needles derive historically from rope making rather than use thread/sinew as sewing material.",
+    "A narrower thread/sinew node replaced basic_rope_making."
+  ],
+  "short_reason": "Thread or sinew enables sewing, but rope making is not the historical predecessor of eyed needles.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/bone_needles_tailoring.before.json /tmp/bone_needles_tailoring.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-paleolithic-eyed-needles-scope.json
+++ b/docs/graph-invariants/2026-06-11-paleolithic-eyed-needles-scope.json
@@ -1,0 +1,44 @@
+{
+  "id": "2026-06-11-paleolithic-eyed-needles-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "bone_needles_tailoring",
+      "operator": "eq",
+      "value": -38000,
+      "reason": "The node is scoped to eyed needles beginning around 40,000 cal BP at Denisova Cave."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "bone_needles_tailoring",
+      "prerequisite": "bone_tool_making",
+      "expected": "required",
+      "reason": "The scoped artifacts are bone, antler, or ivory eyed needles."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "bone_needles_tailoring",
+      "prerequisite": "basic_rope_making",
+      "expected": "enabling",
+      "reason": "Thread or sinew enables sewing but is not the needle artifact itself."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "bone_needles_tailoring",
+      "prerequisite": "advanced_stone_tools",
+      "reason": "The scoped artifacts are bone-tool forms and predate the current advanced_stone_tools placeholder."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "bone_needles_tailoring",
+      "prerequisite": "basic_weaving_basketry",
+      "reason": "Eyed needles should not depend directly on basketry."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "fish_hook_barbs",
+      "prerequisite": "bone_needles_tailoring",
+      "reason": "Barbed fish hooks should not depend directly on eyed sewing needles."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node source-backed correction for `bone_needles_tailoring`, plus one direct dependent cleanup in `fish_hook_barbs`.

## Old Claim
`bone_needles_tailoring` was a broad unsourced `Bone Needles & Tailoring` node dated to `-10000` / `millennium`, region `Global / multiple regions`, with inferred prerequisites from `advanced_stone_tools`, `basic_rope_making`, and `basic_weaving_basketry`.

`fish_hook_barbs` also incorrectly depended on `bone_needles_tailoring`.

## New Claim
The node is now scoped as `Paleolithic Eyed Needles`: bone, antler, or ivory needles with eyes used for sewing thread or sinew through hides and garments, beginning around 40,000 cal BP at Denisova Cave (`firstKnownDate: -38000`, `datePrecision: millennium`).

## Source
- Science Advances 2024, `Paleolithic eyed needles and the evolution of dress`
- URL: https://www.science.org/doi/10.1126/sciadv.adp2887
- Locator: early-eyed-needles section reports the earliest eyed needles in northern Eurasia, beginning around 40,000 cal BP at Denisova Cave.

## Edge Changes
Removed unsupported/chronologically wrong direct edges:
- `advanced_stone_tools -> bone_needles_tailoring`
- `basic_weaving_basketry -> bone_needles_tailoring`
- `bone_needles_tailoring -> fish_hook_barbs`

Changed:
- `basic_rope_making -> bone_needles_tailoring`: `historical_predecessor` -> `enabling`, because thread/sinew enables sewing but rope making is not the historical predecessor of the needle artifact.

Added source-backed direct edge:
- `bone_tool_making -> bone_needles_tailoring` as `required`, because the scoped artifacts are bone/antler/ivory tools.

## Why Better
The old node mixed eyed needles, tailoring, sails, shelters, basketry, and broad stone-tool context into one placeholder-era claim. The new node is source-locked to a specific artifact class and fixes the chronology from `-10000` to `-38000`.

## Adversarial Note
The strongest reason this could be incomplete is that broader clothing technologies, bone awls, pierced-hide technologies, and regional needle traditions deserve separate source-checked nodes. This PR deliberately keeps the correction narrow.

## Validation
- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/bone_needles_tailoring.before.json /tmp/bone_needles_tailoring.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed
- `npm run accuracy:risks -- --markdown --limit 24` passed