### PR TITLE
[codex] Source-check Upper Paleolithic grinding stones

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 628 / 1,660 (37.8%) |
-| Nodes with node-level sources | 662 / 1,660 (39.9%) |
-| Dependency edges with edge-level sources | 1,909 / 5,545 (34.4%) |
-| Era-default placeholder dates | 544 / 1,660 (32.8%) |
+| Source-checked nodes | 629 / 1,660 (37.9%) |
+| Nodes with node-level sources | 663 / 1,660 (39.9%) |
+| Dependency edges with edge-level sources | 1,910 / 5,544 (34.5%) |
+| Era-default placeholder dates | 543 / 1,660 (32.7%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -1640,33 +1640,51 @@
   },
   {
     "id": "grinding_stones_querns",
-    "name": "Grinding Stones & Querns",
+    "name": "Upper Paleolithic Grinding Stones",
     "era": "Ancient",
-    "description": "Using hand-operated stones (saddle stones, querns) to mill grain into flour.",
+    "description": "Hand-operated grinding stones used to process wild plants into starch-rich flour-like foods.",
     "prerequisites": [
-      "plant_domestication",
-      "advanced_stone_tools"
+      "stone_tool_making"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -28000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Bilancino II, Kostenki 16-Uglyanka, and Pavlov VI, Europe",
+    "reviewStatus": "source_checked",
+    "scopeNote": "Covers source-backed Upper Paleolithic grinding stones with starch residues from wild plants around 30,000 years ago. It does not cover rotary querns, domesticated-grain milling, later agricultural quern traditions, or every grinding-stone use such as ochre processing.",
+    "sources": [
+      {
+        "title": "Thirty thousand-year-old evidence of plant food processing",
+        "url": "https://www.pnas.org/doi/10.1073/pnas.1006993107",
+        "publisher": "Proceedings of the National Academy of Sciences",
+        "year": 2010,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "edge",
+          "maturity"
+        ]
+      }
+    ],
     "dependencyEdges": [
       {
-        "prerequisite": "plant_domestication",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Plant Domestication provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "advanced_stone_tools",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Stone Tools is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "prerequisite": "stone_tool_making",
+        "type": "required",
+        "confidence": 0.86,
+        "evidence_level": "primary_source",
+        "note": "The scoped technology is a manufactured stone grinding-tool class; stone-tool making is the direct material-method prerequisite.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Thirty thousand-year-old evidence of plant food processing",
+            "url": "https://www.pnas.org/doi/10.1073/pnas.1006993107",
+            "publisher": "Proceedings of the National Academy of Sciences",
+            "year": 2010,
+            "source_type": "primary_paper",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T19:47:30.518Z",
+  "generatedAt": "2026-06-11T19:55:17.500Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 628,
+      "value": 629,
       "denominator": 1660,
-      "formatted": "628 / 1,660",
-      "note": "37.8%"
+      "formatted": "629 / 1,660",
+      "note": "37.9%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 662,
+      "value": 663,
       "denominator": 1660,
-      "formatted": "662 / 1,660",
+      "formatted": "663 / 1,660",
       "note": "39.9%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1909,
-      "denominator": 5545,
-      "formatted": "1,909 / 5,545",
-      "note": "34.4%"
+      "value": 1910,
+      "denominator": 5544,
+      "formatted": "1,910 / 5,544",
+      "note": "34.5%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 544,
+      "value": 543,
       "denominator": 1660,
-      "formatted": "544 / 1,660",
-      "note": "32.8%"
+      "formatted": "543 / 1,660",
+      "note": "32.7%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 662,
-    "sourceChecked": 628,
+    "nodesWithSources": 663,
+    "sourceChecked": 629,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 544,
+    "eraDefaultDates": 543,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5545,
-    "edgesWithSources": 1909
+    "totalEdges": 5544,
+    "edgesWithSources": 1910
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T19:47:30.518Z
+Generated: 2026-06-11T19:55:17.500Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 628 / 1,660 (37.8%) |
-| Nodes with node-level sources | 662 / 1,660 (39.9%) |
-| Dependency edges with edge-level sources | 1,909 / 5,545 (34.4%) |
-| Era-default placeholder dates | 544 / 1,660 (32.8%) |
+| Source-checked nodes | 629 / 1,660 (37.9%) |
+| Nodes with node-level sources | 663 / 1,660 (39.9%) |
+| Dependency edges with edge-level sources | 1,910 / 5,544 (34.5%) |
+| Era-default placeholder dates | 543 / 1,660 (32.7%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-grinding-stones-advanced-stone-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-grinding-stones-advanced-stone-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-grinding-stones-advanced-stone-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "grinding_stones_querns",
+    "prerequisite": "advanced_stone_tools"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Stone Tools is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from grinding_stones_querns to advanced_stone_tools. The corrected node uses stone_tool_making as the direct material-method prerequisite instead of the later broad advanced_stone_tools placeholder.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.pnas.org/doi/10.1073/pnas.1006993107",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: reports starch grains on grinding tools from Mid-Upper Paleolithic sites across Europe.",
+    "source_claim_summary": "The source supports a stone grinding-tool technology around 30,000 years ago.",
+    "source_support_rationale": "The direct prerequisite should be the broader stone-tool-making capability rather than a later placeholder advanced-stone-tool node."
+  },
+  "ontology_before": "The graph made a later advanced-stone-tool placeholder a direct predecessor of grinding stones.",
+  "ontology_after": "The graph uses stone_tool_making as the direct material-method prerequisite for source-backed grinding tools.",
+  "invariant_preserved_or_changed": "Changed: advanced_stone_tools is absent as a direct prerequisite for grinding_stones_querns.",
+  "would_reject_if": [
+    "The advanced_stone_tools node were source-checked and redated early enough with direct grinding-tool evidence.",
+    "The grinding-stones node were rescoped to a later agricultural stone-tool tradition.",
+    "The graph lacked a direct stone-tool-making prerequisite for the scoped grinding stones."
+  ],
+  "short_reason": "Stone-tool making is the direct prerequisite; advanced_stone_tools is a later placeholder.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/grinding_stones_querns.before.json /tmp/grinding_stones_querns.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-grinding-stones-plant-domestication-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-grinding-stones-plant-domestication-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-grinding-stones-plant-domestication-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "grinding_stones_querns",
+    "prerequisite": "plant_domestication"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Plant Domestication provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from grinding_stones_querns to plant_domestication. The corrected node is scoped to Upper Paleolithic wild-plant processing around 30,000 years ago, long before domesticated crops.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.pnas.org/doi/10.1073/pnas.1006993107",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: reports starch grains from various wild plants on grinding tools at three Mid-Upper Paleolithic sites across Europe.",
+    "source_claim_summary": "The source supports grinding-tool use for wild-plant food processing around 30,000 years ago.",
+    "source_support_rationale": "Because the scoped evidence is wild-plant processing before agriculture, plant domestication is not a prerequisite."
+  },
+  "ontology_before": "The graph made grinding stones and querns directly dependent on plant domestication.",
+  "ontology_after": "The graph models Upper Paleolithic wild-plant grinding as preceding domesticated-crop agriculture.",
+  "invariant_preserved_or_changed": "Changed: plant_domestication is absent as a direct prerequisite for grinding_stones_querns.",
+  "would_reject_if": [
+    "The node were rescoped to agricultural rotary querns or domesticated-grain milling.",
+    "A source showed the scoped Upper Paleolithic grinding tools required domesticated plants.",
+    "The graph reintroduced plant_domestication without changing the node scope."
+  ],
+  "short_reason": "Wild-plant grinding predates plant domestication.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/grinding_stones_querns.before.json /tmp/grinding_stones_querns.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-upper-paleolithic-grinding-stones-scope.json
+++ b/docs/graph-invariants/2026-06-11-upper-paleolithic-grinding-stones-scope.json
@@ -1,0 +1,31 @@
+{
+  "id": "2026-06-11-upper-paleolithic-grinding-stones-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "grinding_stones_querns",
+      "operator": "eq",
+      "value": -28000,
+      "reason": "The node is scoped to 30,000-year-old Upper Paleolithic grinding stones with wild-plant starch residues."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "grinding_stones_querns",
+      "prerequisite": "stone_tool_making",
+      "expected": "required",
+      "reason": "The scoped artifacts are manufactured stone grinding tools."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "grinding_stones_querns",
+      "prerequisite": "plant_domestication",
+      "reason": "Wild-plant grinding predates domesticated-crop agriculture."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "grinding_stones_querns",
+      "prerequisite": "advanced_stone_tools",
+      "reason": "The direct prerequisite is stone_tool_making, not the later broad advanced_stone_tools placeholder."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node source-backed correction for `grinding_stones_querns`.

## Old Claim
`grinding_stones_querns` was a broad unsourced `Grinding Stones & Querns` node dated to `-10000` / `millennium`, region `Global / multiple regions`, with inferred prerequisites from `plant_domestication` and `advanced_stone_tools`.

## New Claim
The node is now scoped as `Upper Paleolithic Grinding Stones`: hand-operated grinding stones used to process wild plants into starch-rich flour-like foods at about 30,000 years ago (`firstKnownDate: -28000`, `datePrecision: millennium`).

## Source
- PNAS 2010, `Thirty thousand-year-old evidence of plant food processing`
- URL: https://www.pnas.org/doi/10.1073/pnas.1006993107
- Locator: abstract reports starch grains from various wild plants on grinding tools at three Mid-Upper Paleolithic sites across Europe.

## Edge Changes
Removed unsupported/chronologically misleading direct edges:
- `plant_domestication -> grinding_stones_querns`
- `advanced_stone_tools -> grinding_stones_querns`

Added source-backed direct edge:
- `stone_tool_making -> grinding_stones_querns` as `required`, because the scoped artifacts are manufactured stone grinding tools.

## Why Better
The old graph implied grinding stones required domesticated crops. The source-backed evidence is explicitly wild-plant processing around 30,000 years ago, so the plant-domestication edge was wrong for this scoped node.

## Adversarial Note
The strongest reason this could be incomplete is that later agricultural querns and rotary querns deserve their own source-checked nodes. This PR deliberately narrows the existing node to Upper Paleolithic wild-plant grinding evidence.

## Validation
- `npm run edge-receipts` passed
- `npm run graph-invariants` passed
- `npm run node-snapshot-diff -- /tmp/grinding_stones_querns.before.json /tmp/grinding_stones_querns.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed through local checks; initial URL audit hit unrelated transient IEEE/ETHW timeouts
- `npm run source-urls` rerun passed for 753 unique URLs
- `npm run accuracy:risks -- --markdown --limit 24` passed