### PR TITLE
[codex] Source-check KP1 hafted stone-point spears

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 629 / 1,660 (37.9%) |
-| Nodes with node-level sources | 663 / 1,660 (39.9%) |
-| Dependency edges with edge-level sources | 1,910 / 5,544 (34.5%) |
-| Era-default placeholder dates | 543 / 1,660 (32.7%) |
+| Source-checked nodes | 630 / 1,660 (38.0%) |
+| Nodes with node-level sources | 664 / 1,660 (40.0%) |
+| Dependency edges with edge-level sources | 1,911 / 5,540 (34.5%) |
+| Era-default placeholder dates | 542 / 1,660 (32.7%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -863,60 +863,52 @@
   },
   {
     "id": "composite_tools",
-    "name": "Composite Tools",
+    "name": "Hafted Stone-Point Spears",
     "era": "Ancient",
-    "description": "Combining different materials like stone, bone, and wood (e.g., hafting axe heads, spears) using bindings and adhesives.",
+    "description": "Stone points hafted to spear shafts, forming early multicomponent hunting tools.",
     "prerequisites": [
-      "advanced_stone_tools",
-      "bone_tool_making",
-      "woodworking_basic",
-      "basic_rope_making",
-      "natural_adhesives"
+      "stone_tool_making"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -500000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Kathu Pan 1, Northern Cape, South Africa",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
-        "prerequisite": "advanced_stone_tools",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Stone Tools is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
-      },
+        "prerequisite": "stone_tool_making",
+        "type": "required",
+        "confidence": 0.86,
+        "evidence_level": "primary_source",
+        "note": "The KP1 claim is specifically about stone points manufactured as spear tips, so stone-tool production is the direct material prerequisite for this scoped composite-tool node.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Evidence for Early Hafted Hunting Technology",
+            "url": "https://www.science.org/doi/10.1126/science.1227608",
+            "publisher": "Science",
+            "year": 2012,
+            "source_type": "primary_paper",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
+      }
+    ],
+    "scopeNote": "Scoped to the Kathu Pan 1 evidence for hafted stone-point spears around 500 ka. This does not claim direct preservation of the wooden shaft, adhesive, binding, later handled axes, or every later composite-tool tradition.",
+    "maturity": "established",
+    "sources": [
       {
-        "prerequisite": "bone_tool_making",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Bone Tool Making provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "woodworking_basic",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Basic Woodworking is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "basic_rope_making",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Basic Rope Making is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "natural_adhesives",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Natural Adhesives provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "title": "Evidence for Early Hafted Hunting Technology",
+        "url": "https://www.science.org/doi/10.1126/science.1227608",
+        "publisher": "Science",
+        "year": 2012,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "edge",
+          "maturity"
+        ]
       }
     ]
   },

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T19:55:17.500Z",
+  "generatedAt": "2026-06-11T20:05:29.280Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,30 +11,30 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 629,
+      "value": 630,
       "denominator": 1660,
-      "formatted": "629 / 1,660",
-      "note": "37.9%"
+      "formatted": "630 / 1,660",
+      "note": "38.0%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 663,
+      "value": 664,
       "denominator": 1660,
-      "formatted": "663 / 1,660",
-      "note": "39.9%"
+      "formatted": "664 / 1,660",
+      "note": "40.0%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1910,
-      "denominator": 5544,
-      "formatted": "1,910 / 5,544",
+      "value": 1911,
+      "denominator": 5540,
+      "formatted": "1,911 / 5,540",
       "note": "34.5%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 543,
+      "value": 542,
       "denominator": 1660,
-      "formatted": "543 / 1,660",
+      "formatted": "542 / 1,660",
       "note": "32.7%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 663,
-    "sourceChecked": 629,
+    "nodesWithSources": 664,
+    "sourceChecked": 630,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 543,
+    "eraDefaultDates": 542,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5544,
-    "edgesWithSources": 1910
+    "totalEdges": 5540,
+    "edgesWithSources": 1911
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T19:55:17.500Z
+Generated: 2026-06-11T20:05:29.280Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 629 / 1,660 (37.9%) |
-| Nodes with node-level sources | 663 / 1,660 (39.9%) |
-| Dependency edges with edge-level sources | 1,910 / 5,544 (34.5%) |
-| Era-default placeholder dates | 543 / 1,660 (32.7%) |
+| Source-checked nodes | 630 / 1,660 (38.0%) |
+| Nodes with node-level sources | 664 / 1,660 (40.0%) |
+| Dependency edges with edge-level sources | 1,911 / 5,540 (34.5%) |
+| Era-default placeholder dates | 542 / 1,660 (32.7%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-composite-tools-adhesives-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-composite-tools-adhesives-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-composite-tools-adhesives-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "composite_tools",
+    "prerequisite": "natural_adhesives"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Natural Adhesives provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from composite_tools to natural_adhesives. The current adhesive node is anchored to later birch-tar evidence and the KP1 source does not make adhesive production a demonstrated prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.science.org/doi/10.1126/science.1227608",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract and report scope: the source identifies hafted stone points at KP1 but does not document adhesive residues or adhesive production.",
+    "source_claim_summary": "The source supports hafting but not a direct dependency on the later birch-tar adhesive technology represented by natural_adhesives.",
+    "source_support_rationale": "Adhesives are plausible for some hafting traditions, but this edge would overclaim the KP1 evidence and introduce a later prerequisite."
+  },
+  "ontology_before": "The graph treated later Paleolithic birch-tar adhesive evidence as an enabler for all composite tools.",
+  "ontology_after": "The graph avoids making adhesive production a prerequisite for the earlier KP1 hafted stone-point scope.",
+  "invariant_preserved_or_changed": "Changed: natural_adhesives is absent as a direct prerequisite for composite_tools.",
+  "would_reject_if": [
+    "A source documented adhesive residue or adhesive production directly associated with KP1 hafted stone points.",
+    "The node were rescoped to a later adhesive-hafted composite technology.",
+    "The natural_adhesives node were replaced by a source-backed 500 ka adhesive technology."
+  ],
+  "short_reason": "The KP1 source supports hafting, not an adhesive-production prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/composite_tools.before.json /tmp/composite_tools.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-composite-tools-advanced-stone-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-composite-tools-advanced-stone-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-composite-tools-advanced-stone-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "composite_tools",
+    "prerequisite": "advanced_stone_tools"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Stone Tools is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from composite_tools to advanced_stone_tools. The corrected node is scoped to KP1 hafted stone-point spears and uses stone_tool_making as the direct material-method prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.science.org/doi/10.1126/science.1227608",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: reports about 500,000-year-old stone points from Kathu Pan 1 functioning as spear tips and describes early humans manufacturing hafted multicomponent tools.",
+    "source_claim_summary": "The source supports a much earlier hafted stone-point spear technology at Kathu Pan 1 than the existing broad advanced_stone_tools placeholder chronology.",
+    "source_support_rationale": "The scoped technology should depend on stone-tool production itself rather than a later unsourced broad advanced-stone-tool node."
+  },
+  "ontology_before": "The graph routed composite-tool technology through an unsourced advanced-stone-tool placeholder with the same late Neolithic date.",
+  "ontology_after": "The graph anchors the scoped hafted spear-point node directly to source-checked stone_tool_making.",
+  "invariant_preserved_or_changed": "Changed: advanced_stone_tools is absent as a direct prerequisite for composite_tools.",
+  "would_reject_if": [
+    "The advanced_stone_tools node were source-checked and explicitly scoped to KP1 hafted stone points.",
+    "The composite_tools node were broadened back to a late general composite-tool bundle.",
+    "The graph lacked a direct stone-tool-making prerequisite for the scoped KP1 spear points."
+  ],
+  "short_reason": "The KP1 source supports stone points directly, not a later advanced_stone_tools placeholder.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/composite_tools.before.json /tmp/composite_tools.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-composite-tools-bone-tools-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-composite-tools-bone-tools-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-composite-tools-bone-tools-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "composite_tools",
+    "prerequisite": "bone_tool_making"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Bone Tool Making provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from composite_tools to bone_tool_making. The corrected node is scoped to hafted stone-point spears, not bone implements or mixed stone-bone tools.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.science.org/doi/10.1126/science.1227608",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract and report scope: the evidence concerns stone points from Kathu Pan 1 functioning as spear tips.",
+    "source_claim_summary": "The source supports hafted stone-point spears and does not describe bone tool manufacture as a direct precondition.",
+    "source_support_rationale": "Bone tools may be relevant to other composite-tool traditions, but they are not supported as a direct dependency for the KP1 stone-point scope."
+  },
+  "ontology_before": "The graph treated bone-tool making as an enabling dependency for a broad composite-tools bundle.",
+  "ontology_after": "The graph keeps the node scoped to stone-point spears and removes unsupported bone-tool dependency leakage.",
+  "invariant_preserved_or_changed": "Changed: bone_tool_making is absent as a direct prerequisite for composite_tools.",
+  "would_reject_if": [
+    "A source showed KP1 hafted spear-point manufacture required bone tools.",
+    "The node were split to a separate composite bone-tool technology.",
+    "The source locator changed to a composite-tool tradition where bone tools are central."
+  ],
+  "short_reason": "The source-backed scope is stone-point hafting, not bone-tool manufacture.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/composite_tools.before.json /tmp/composite_tools.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-composite-tools-rope-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-composite-tools-rope-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-composite-tools-rope-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "composite_tools",
+    "prerequisite": "basic_rope_making"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Basic Rope Making is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from composite_tools to basic_rope_making. The current rope node is much later than the KP1 hafted spear evidence and is not shown by the KP1 source.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.science.org/doi/10.1126/science.1227608",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: describes KP1 stone points as hafted spear tips around 500,000 years ago, without evidence for preserved cordage or rope.",
+    "source_claim_summary": "The source supports hafted stone points long before the current direct evidence for cordage represented by basic_rope_making.",
+    "source_support_rationale": "A later cordage node cannot be a historical predecessor for the earlier KP1 claim unless a separate earlier binding technology is source-checked."
+  },
+  "ontology_before": "The graph made later source-checked cordage a predecessor of a broad composite-tools node.",
+  "ontology_after": "The graph removes the later cordage dependency from the earlier KP1 hafted spear-point scope.",
+  "invariant_preserved_or_changed": "Changed: basic_rope_making is absent as a direct prerequisite for composite_tools.",
+  "would_reject_if": [
+    "A source documented 500 ka binding cordage as part of the KP1 technology.",
+    "The basic_rope_making node were replaced by an earlier source-backed binding technology.",
+    "The composite_tools node were rescoped to a later cord-bound composite artifact."
+  ],
+  "short_reason": "Later cordage evidence should not be a prerequisite for 500 ka hafted stone points.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/composite_tools.before.json /tmp/composite_tools.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-composite-tools-woodworking-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-composite-tools-woodworking-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-composite-tools-woodworking-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "composite_tools",
+    "prerequisite": "woodworking_basic"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Basic Woodworking is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from composite_tools to woodworking_basic. The current woodworking_basic node is anchored to later preserved wooden artifacts and should not be used as a hard predecessor for the earlier KP1 hafting claim.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.science.org/doi/10.1126/science.1227608",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "supports_chronology",
+    "source_locator": "Abstract and article context: KP1 stone points functioned as spear tips; the source supports hafting but not preservation of the wooden shaft at KP1.",
+    "source_claim_summary": "The source supports hafted stone points but does not prove that the existing later-dated woodworking_basic graph node is an earlier prerequisite.",
+    "source_support_rationale": "Keeping a direct dependency on the current woodworking_basic node would create a later-prerequisite problem and overstate what the KP1 source directly preserves."
+  },
+  "ontology_before": "The graph treated a later source-checked woodworking node as a predecessor of a broad 10,000 BCE composite-tools placeholder.",
+  "ontology_after": "The graph avoids making the later woodworking_basic node a prerequisite for the earlier KP1 hafted stone-point claim.",
+  "invariant_preserved_or_changed": "Changed: woodworking_basic is absent as a direct prerequisite for composite_tools.",
+  "would_reject_if": [
+    "woodworking_basic were redated or split to an earlier source-backed wooden-shaft preparation node.",
+    "A KP1 source directly documented preserved or confidently reconstructed wooden shaft manufacture as the graph prerequisite.",
+    "The composite_tools node were rescoped to later composite implements with preserved wooden handles."
+  ],
+  "short_reason": "The source supports hafting but not the later woodworking_basic node as a direct prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/composite_tools.before.json /tmp/composite_tools.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-hafted-stone-point-spears-scope.json
+++ b/docs/graph-invariants/2026-06-11-hafted-stone-point-spears-scope.json
@@ -1,0 +1,49 @@
+{
+  "id": "2026-06-11-hafted-stone-point-spears-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "composite_tools",
+      "operator": "eq",
+      "value": -500000,
+      "reason": "The node is scoped to about 500,000-year-old hafted stone-point spears from Kathu Pan 1."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "composite_tools",
+      "prerequisite": "stone_tool_making",
+      "expected": "required",
+      "reason": "The scoped artifacts are manufactured stone points used as spear tips."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "composite_tools",
+      "prerequisite": "advanced_stone_tools",
+      "reason": "The source-backed KP1 stone-point scope should not depend on the later broad advanced_stone_tools placeholder."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "composite_tools",
+      "prerequisite": "bone_tool_making",
+      "reason": "The KP1 source documents stone-point spear tips, not bone-tool manufacture as a direct prerequisite."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "composite_tools",
+      "prerequisite": "basic_rope_making",
+      "reason": "The current cordage node is later than the KP1 hafting claim and is not documented by the source."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "composite_tools",
+      "prerequisite": "natural_adhesives",
+      "reason": "The KP1 source supports hafting but does not document adhesive production as a prerequisite."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "composite_tools",
+      "prerequisite": "woodworking_basic",
+      "reason": "The current woodworking_basic node is later-dated and should not be used as a direct prerequisite for the earlier KP1 claim."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node source-backed correction for `composite_tools`.

## Old Claim
`composite_tools` was a broad unsourced `Composite Tools` node dated to `-10000` / `millennium`, region `Global / multiple regions`, with inferred prerequisites from `advanced_stone_tools`, `bone_tool_making`, `woodworking_basic`, `basic_rope_making`, and `natural_adhesives`.

## New Claim
The node is now scoped as `Hafted Stone-Point Spears`: stone points hafted to spear shafts, forming early multicomponent hunting tools at Kathu Pan 1 around 500,000 years ago (`firstKnownDate: -500000`, `datePrecision: millennium`).

## Source
- Science 2012, `Evidence for Early Hafted Hunting Technology`
- URL: https://www.science.org/doi/10.1126/science.1227608
- Locator: abstract/report scope describes ~500,000-year-old KP1 stone points functioning as spear tips and identifies them as hafted multicomponent tools.

## Edge Changes
Removed unsupported or chronologically misleading direct edges:
- `advanced_stone_tools -> composite_tools`
- `bone_tool_making -> composite_tools`
- `woodworking_basic -> composite_tools`
- `basic_rope_making -> composite_tools`
- `natural_adhesives -> composite_tools`

Added source-backed direct edge:
- `stone_tool_making -> composite_tools` as `required`, because the scoped artifacts are manufactured stone points used as spear tips.

## Why Better
The old graph made a foundational early composite-tool technology depend on later or unsupported inferred nodes, including rope and adhesive nodes with much later source-backed dates. The new scope is narrower and source-backed.

## Adversarial Note
The strongest reason this could be incomplete is that hafting also implies a shaft and attachment method. The existing `woodworking_basic`, `basic_rope_making`, and `natural_adhesives` nodes are not source-backed early enough for KP1, so this PR avoids treating them as direct prerequisites until an earlier source-backed shaft/binding/adhesive node is added or those nodes are split.

## Validation
- `npm run node-snapshot-diff -- /tmp/composite_tools.before.json /tmp/composite_tools.after.json --require-behavior-change` passed
- `npm run agent:check -- --run` passed through tests, quality, and coverage; first source URL audit had unrelated timeout on an existing Science Museum plastics URL
- `npm run source-urls` rerun passed for 754 unique URLs
- `npm run accuracy:risks -- --markdown --limit 24` passed

## Snapshot Delta
- Source-checked nodes: 630 / 1,660 (38.0%)
- Nodes with node-level sources: 664 / 1,660 (40.0%)
- Era-default placeholder dates: 542 / 1,660 (32.7%)
- Dependency edges with edge-level sources: 1,911 / 5,540 (34.5%)