### PR TITLE
[codex] Source-check early animal domestication

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 630 / 1,660 (38.0%) |
-| Nodes with node-level sources | 664 / 1,660 (40.0%) |
-| Dependency edges with edge-level sources | 1,911 / 5,540 (34.5%) |
-| Era-default placeholder dates | 542 / 1,660 (32.7%) |
+| Source-checked nodes | 631 / 1,660 (38.0%) |
+| Nodes with node-level sources | 665 / 1,660 (40.1%) |
+| Dependency edges with edge-level sources | 1,911 / 5,537 (34.5%) |
+| Era-default placeholder dates | 541 / 1,660 (32.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -1133,42 +1133,28 @@
   },
   {
     "id": "animal_domestication",
-    "name": "Animal Domestication",
+    "name": "Early Animal Domestication",
     "era": "Ancient",
-    "description": "Taming and selective breeding of animals (e.g., dogs, goats, sheep) for food, labor, or companionship.",
-    "prerequisites": [
-      "advanced_hunting_gathering",
-      "trapping",
-      "tribalism"
-    ],
-    "firstKnownDate": -10000,
+    "description": "Long-term human control and breeding of animal populations, beginning with wolf/dog domestication and later expanding to livestock.",
+    "prerequisites": [],
+    "firstKnownDate": -15000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
-    "dependencyEdges": [
+    "region": "Europe and Asia hunter-gatherer contexts; later Near East livestock domestication",
+    "reviewStatus": "source_checked",
+    "dependencyEdges": [],
+    "scopeNote": "First-known date is anchored to Late Glacial wolf/dog domestication around 17-15 kyr BP. The node remains broad enough to cover later Neolithic livestock domestication, but it does not model trapping, tribal organization, or any single hunting practice as a hard prerequisite.",
+    "maturity": "established",
+    "sources": [
       {
-        "prerequisite": "advanced_hunting_gathering",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Hunting & Gathering provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "trapping",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Trapping provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "tribalism",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Tribalism provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "title": "The origins of animal domestication and husbandry: A major change in the history of humanity and the biosphere",
+        "url": "https://comptes-rendus.academie-sciences.fr/biologies/articles/10.1016/j.crvi.2010.12.009/",
+        "publisher": "Comptes Rendus Biologies",
+        "year": 2011,
+        "source_type": "review",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       }
     ]
   },

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T20:05:29.280Z",
+  "generatedAt": "2026-06-11T20:13:53.365Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 630,
+      "value": 631,
       "denominator": 1660,
-      "formatted": "630 / 1,660",
+      "formatted": "631 / 1,660",
       "note": "38.0%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 664,
+      "value": 665,
       "denominator": 1660,
-      "formatted": "664 / 1,660",
-      "note": "40.0%"
+      "formatted": "665 / 1,660",
+      "note": "40.1%"
     },
     {
       "label": "Dependency edges with edge-level sources",
       "value": 1911,
-      "denominator": 5540,
-      "formatted": "1,911 / 5,540",
+      "denominator": 5537,
+      "formatted": "1,911 / 5,537",
       "note": "34.5%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 542,
+      "value": 541,
       "denominator": 1660,
-      "formatted": "542 / 1,660",
-      "note": "32.7%"
+      "formatted": "541 / 1,660",
+      "note": "32.6%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 664,
-    "sourceChecked": 630,
+    "nodesWithSources": 665,
+    "sourceChecked": 631,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 542,
+    "eraDefaultDates": 541,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5540,
+    "totalEdges": 5537,
     "edgesWithSources": 1911
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T20:05:29.280Z
+Generated: 2026-06-11T20:13:53.365Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 630 / 1,660 (38.0%) |
-| Nodes with node-level sources | 664 / 1,660 (40.0%) |
-| Dependency edges with edge-level sources | 1,911 / 5,540 (34.5%) |
-| Era-default placeholder dates | 542 / 1,660 (32.7%) |
+| Source-checked nodes | 631 / 1,660 (38.0%) |
+| Nodes with node-level sources | 665 / 1,660 (40.1%) |
+| Dependency edges with edge-level sources | 1,911 / 5,537 (34.5%) |
+| Era-default placeholder dates | 541 / 1,660 (32.6%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-animal-domestication-advanced-hunting-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-animal-domestication-advanced-hunting-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-animal-domestication-advanced-hunting-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "animal_domestication",
+    "prerequisite": "advanced_hunting_gathering"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Hunting & Gathering provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from animal_domestication to advanced_hunting_gathering. The corrected node is anchored to Late Glacial wolf/dog domestication, while advanced_hunting_gathering is a later unsourced placeholder.",
+  "source_supports_edge": "no",
+  "source_url": "https://comptes-rendus.academie-sciences.fr/biologies/articles/10.1016/j.crvi.2010.12.009/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Introduction: wolves are described as the first known domesticated species, domesticated around 17-15 kyr BP by European and Asian hunter-gatherers.",
+    "source_claim_summary": "The review supports a Late Glacial wolf/dog domestication chronology before the current advanced_hunting_gathering placeholder date.",
+    "source_support_rationale": "Hunter-gatherer context is not equivalent to the graph's later advanced_hunting_gathering node and should not be modeled as a direct prerequisite."
+  },
+  "ontology_before": "The graph made early animal domestication depend on a later broad advanced-hunting placeholder.",
+  "ontology_after": "The graph treats early animal domestication as a source-backed node without laundering hunter-gatherer context into a prerequisite edge.",
+  "invariant_preserved_or_changed": "Changed: advanced_hunting_gathering is absent as a direct prerequisite for animal_domestication.",
+  "would_reject_if": [
+    "advanced_hunting_gathering were source-checked and redated before Late Glacial wolf/dog domestication.",
+    "A source showed animal domestication required the specific graph concept represented by advanced_hunting_gathering.",
+    "The animal_domestication node were rescoped to a later specialist hunting-management technology."
+  ],
+  "short_reason": "Advanced hunting context is not a source-backed direct prerequisite for early animal domestication.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/animal_domestication.before.json /tmp/animal_domestication.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-animal-domestication-trapping-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-animal-domestication-trapping-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-animal-domestication-trapping-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "animal_domestication",
+    "prerequisite": "trapping"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Trapping provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from animal_domestication to trapping. Trapping may be one animal-capture practice, but the review does not identify it as a direct prerequisite for domestication.",
+  "source_supports_edge": "no",
+  "source_url": "https://comptes-rendus.academie-sciences.fr/biologies/articles/10.1016/j.crvi.2010.12.009/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Conceptual section: domestication is discussed as human control over reproduction and animal populations, not as a trapping technology.",
+    "source_claim_summary": "The review frames domestication around control, breeding, and changing human-animal relations rather than a necessary trapping prerequisite.",
+    "source_support_rationale": "A capture method is contextual and species-specific; retaining it would overstate a weak inferred edge as graph topology."
+  },
+  "ontology_before": "The graph modeled trapping as a direct enabler of all early animal domestication.",
+  "ontology_after": "The graph leaves animal domestication without a direct trapping prerequisite unless a narrower species-specific source supports one.",
+  "invariant_preserved_or_changed": "Changed: trapping is absent as a direct prerequisite for animal_domestication.",
+  "would_reject_if": [
+    "A source showed the scoped first domestication event required trapping as a demonstrated method.",
+    "The node were split to a specific captive-management or trapping-based domestication technique.",
+    "The graph added a narrower source-backed animal-capture node with a supported edge."
+  ],
+  "short_reason": "Trapping is not source-backed as a direct prerequisite for the broad animal-domestication node.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/animal_domestication.before.json /tmp/animal_domestication.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-animal-domestication-tribalism-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-animal-domestication-tribalism-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-animal-domestication-tribalism-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "animal_domestication",
+    "prerequisite": "tribalism"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Tribalism provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from animal_domestication to tribalism. The source discusses human societies and domestication but does not support tribalism as a technical dependency.",
+  "source_supports_edge": "no",
+  "source_url": "https://comptes-rendus.academie-sciences.fr/biologies/articles/10.1016/j.crvi.2010.12.009/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract and conceptual sections: the paper emphasizes human-society dynamics and reproductive control, not tribalism as a prerequisite technology.",
+    "source_claim_summary": "The review supports animal domestication as a socio-biological process without making tribal organization a direct technological dependency.",
+    "source_support_rationale": "Social context should not be converted into a hard or enabling graph edge when the source does not identify that specific institution."
+  },
+  "ontology_before": "The graph modeled tribalism as a direct enabler of animal domestication.",
+  "ontology_after": "The graph removes unsupported social-institution dependency from the direct technology prerequisites.",
+  "invariant_preserved_or_changed": "Changed: tribalism is absent as a direct prerequisite for animal_domestication.",
+  "would_reject_if": [
+    "A source explicitly tied the scoped domestication event to the graph's tribalism node as a necessary institution.",
+    "The node were rescoped to a specific social-management institution rather than animal domestication.",
+    "A narrower, source-backed institutional dependency were added with clear absence-breaks logic."
+  ],
+  "short_reason": "Tribalism is unsupported as a direct technology dependency for early animal domestication.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/animal_domestication.before.json /tmp/animal_domestication.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-early-animal-domestication-scope.json
+++ b/docs/graph-invariants/2026-06-11-early-animal-domestication-scope.json
@@ -1,0 +1,30 @@
+{
+  "id": "2026-06-11-early-animal-domestication-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "animal_domestication",
+      "operator": "eq",
+      "value": -15000,
+      "reason": "The node is anchored to Late Glacial wolf/dog domestication around 17-15 kyr BP."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "animal_domestication",
+      "prerequisite": "advanced_hunting_gathering",
+      "reason": "Hunter-gatherer context should not be represented by the later advanced_hunting_gathering placeholder as a direct prerequisite."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "animal_domestication",
+      "prerequisite": "trapping",
+      "reason": "Trapping is not source-backed as a direct prerequisite for the broad early animal-domestication process."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "animal_domestication",
+      "prerequisite": "tribalism",
+      "reason": "Social context is not enough to model tribalism as a direct technology dependency."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node source-backed correction for `animal_domestication`.

## Old Claim
`animal_domestication` was a broad unsourced `Animal Domestication` node dated to `-10000` / `millennium`, region `Global / multiple regions`, with inferred direct prerequisites from `advanced_hunting_gathering`, `trapping`, and `tribalism`.

## New Claim
The node is now scoped as `Early Animal Domestication`: long-term human control and breeding of animal populations, beginning with wolf/dog domestication and later expanding to livestock. It is anchored to Late Glacial wolf/dog domestication around 17-15 kyr BP (`firstKnownDate: -15000`, `datePrecision: millennium`).

## Source
- Jean-Denis Vigne, `The origins of animal domestication and husbandry: A major change in the history of humanity and the biosphere`, Comptes Rendus Biologies, 2011
- URL: https://comptes-rendus.academie-sciences.fr/biologies/articles/10.1016/j.crvi.2010.12.009/
- Locator: introduction states wolves are the first known domesticated species and places this around 17-15 kyr BP; later sections discuss Neolithic animal domestication and husbandry.

## Edge Changes
Removed unsupported direct edges:
- `advanced_hunting_gathering -> animal_domestication`
- `trapping -> animal_domestication`
- `tribalism -> animal_domestication`

No replacement direct prerequisite was added. The source supports domestication as a socio-biological process involving human control and breeding, but does not make one specific hunting practice, trapping method, or social institution a direct technology prerequisite.

## Why Better
The old graph turned context into prerequisites and used a Neolithic-era placeholder date. The new scope separates source-backed chronology from weak inferred social or hunting edges.

## Adversarial Note
The strongest reason this could be incomplete is that domestication is broad and species-specific. Dog domestication, goat/sheep domestication, and later livestock husbandry may deserve narrower nodes. This PR only fixes the existing broad node by anchoring it to a review source and removing unsupported direct dependencies.

## Validation
- `npm run node-snapshot-diff -- /tmp/animal_domestication.before.json /tmp/animal_domestication.after.json --require-behavior-change` passed
- `npm run edge-receipts` passed
- `npm run graph-invariants && npm run invariant-coverage` passed
- `npm run agent:check -- --run` passed
- `npm run accuracy:risks -- --markdown --limit 24` passed

## Snapshot Delta
- Source-checked nodes: 631 / 1,660 (38.0%)
- Nodes with node-level sources: 665 / 1,660 (40.1%)
- Era-default placeholder dates: 541 / 1,660 (32.6%)
- Dependency edges with edge-level sources: 1,911 / 5,537 (34.5%)