### PR TITLE
[codex] Source-check Song gunpowder weapons cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 631 / 1,660 (38.0%) |
-| Nodes with node-level sources | 665 / 1,660 (40.1%) |
-| Dependency edges with edge-level sources | 1,911 / 5,537 (34.5%) |
-| Era-default placeholder dates | 541 / 1,660 (32.6%) |
+| Source-checked nodes | 634 / 1,660 (38.2%) |
+| Nodes with node-level sources | 668 / 1,660 (40.2%) |
+| Dependency edges with edge-level sources | 1,913 / 5,531 (34.6%) |
+| Era-default placeholder dates | 538 / 1,660 (32.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/medieval.json
+++ b/data/medieval.json
@@ -960,42 +960,28 @@
   },
   {
     "id": "gunpowder",
-    "name": "Gunpowder",
+    "name": "Song Gunpowder Formula",
     "era": "Medieval",
-    "description": "Explosive mixture of sulfur, charcoal, and potassium nitrate (saltpeter) used in early firearms and cannons.",
-    "prerequisites": [
-      "mining",
-      "basic_chemistry",
-      "alchemy"
-    ],
-    "firstKnownDate": 500,
-    "datePrecision": "century",
-    "region": "Afro-Eurasia and other medieval societies",
-    "reviewStatus": "structurally_validated",
-    "dependencyEdges": [
+    "description": "Recorded black-powder formula using saltpeter, sulfur, and charcoal for Song military incendiaries, bombs, and fire arrows.",
+    "prerequisites": [],
+    "firstKnownDate": 1044,
+    "datePrecision": "exact",
+    "region": "Song China",
+    "reviewStatus": "source_checked",
+    "dependencyEdges": [],
+    "scopeNote": "Anchored to the Wujing zongyao record of true gunpowder formulas in 1044 CE. This covers documented black-powder formulae and early military incendiary use, not later handguns, cannons, smokeless powder, or the full global diffusion of gunpowder weapons.",
+    "maturity": "established",
+    "sources": [
       {
-        "prerequisite": "mining",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Mining provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "basic_chemistry",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Basic Chemistry is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "alchemy",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Alchemy provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "title": "Gunpowder - Song Dynasty China",
+        "url": "https://afe.easia.columbia.edu/songdynasty-module/tech-gunpowder.html",
+        "publisher": "Asia for Educators, Columbia University",
+        "year": 2026,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       }
     ]
   },
@@ -3193,26 +3179,36 @@
     "id": "cannons",
     "name": "Cannons",
     "era": "Medieval",
-    "description": "Early, large-caliber artillery pieces utilizing gunpowder to fire stone or iron projectiles, challenging the dominance of traditional fortifications.",
+    "description": "Early gunpowder artillery pieces, including bombards and other cannon-like guns for siege and field warfare.",
     "prerequisites": [
       "gunpowder",
       "bronze_working",
-      "iron_working",
-      "construction",
-      "blast_furnace"
+      "iron_working"
     ],
-    "firstKnownDate": 500,
+    "firstKnownDate": 1300,
     "datePrecision": "century",
-    "region": "Afro-Eurasia and other medieval societies",
-    "reviewStatus": "structurally_validated",
+    "region": "China and Europe",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "gunpowder",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Gunpowder provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "required",
+        "confidence": 0.9,
+        "evidence_level": "textbook",
+        "note": "Early cannon were gunpowder artillery: the propellant is a direct operating prerequisite for the scoped technology.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Military technology - The gunpowder revolution, c. 1300-1650",
+            "url": "https://www.britannica.com/technology/military-technology/The-gunpowder-revolution-c-1300-1650",
+            "publisher": "Encyclopaedia Britannica",
+            "year": 2026,
+            "source_type": "textbook",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "bronze_working",
@@ -3229,55 +3225,69 @@
         "evidence_level": "expert_inference",
         "note": "Iron Working provides a capability that enables this technology without being the only possible path.",
         "reviewStatus": "structurally_validated"
+      }
+    ],
+    "scopeNote": "Scoped to early gunpowder artillery during the c. 1300-1650 gunpowder revolution. This does not claim every later cannon type, explosive-shell artillery, or modern artillery system.",
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "Military technology - The gunpowder revolution, c. 1300-1650",
+        "url": "https://www.britannica.com/technology/military-technology/The-gunpowder-revolution-c-1300-1650",
+        "publisher": "Encyclopaedia Britannica",
+        "year": 2026,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "edge",
+          "maturity"
+        ]
       },
       {
-        "prerequisite": "construction",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Construction provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "blast_furnace",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Blast Furnace provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "title": "Military technology - Early use of artillery",
+        "url": "https://www.britannica.com/technology/military-technology/Early-use-of-artillery",
+        "publisher": "Encyclopaedia Britannica",
+        "year": 2026,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       }
     ]
   },
   {
     "id": "arquebus",
-    "name": "Arquebus",
+    "name": "Harquebus / Arquebus",
     "era": "Medieval",
-    "description": "An early type of long gun that used a matchlock firing mechanism, representing the first firearm portable and effective enough for widespread infantry use.",
+    "description": "Early shoulder-fired smoothbore matchlock gun with a hooked support, developed in the mid-15th century.",
     "prerequisites": [
       "gunpowder",
-      "cannons",
       "advanced_metallurgy_medieval"
     ],
-    "firstKnownDate": 500,
-    "datePrecision": "century",
-    "region": "Afro-Eurasia and other medieval societies",
-    "reviewStatus": "structurally_validated",
+    "firstKnownDate": 1450,
+    "datePrecision": "decade",
+    "region": "Spain and wider late-medieval Europe",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "gunpowder",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Gunpowder provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "cannons",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Cannons provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "required",
+        "confidence": 0.9,
+        "evidence_level": "textbook",
+        "note": "The harquebus is a gunpowder firearm, so black powder is a direct operating prerequisite.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Harquebus",
+            "url": "https://www.britannica.com/technology/harquebus",
+            "publisher": "Encyclopaedia Britannica",
+            "year": 2026,
+            "source_type": "textbook",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "advanced_metallurgy_medieval",
@@ -3286,6 +3296,22 @@
         "evidence_level": "expert_inference",
         "note": "Advanced Metallurgy (Medieval) provides a capability that enables this technology without being the only possible path.",
         "reviewStatus": "structurally_validated"
+      }
+    ],
+    "scopeNote": "Scoped to the shoulder-fired harquebus/arquebus, not earlier hand cannons or later muskets. The mid-15th-century date follows Britannica's Spain-origin summary.",
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "Harquebus",
+        "url": "https://www.britannica.com/technology/harquebus",
+        "publisher": "Encyclopaedia Britannica",
+        "year": 2026,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "edge",
+          "maturity"
+        ]
       }
     ]
   },

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T20:13:53.365Z",
+  "generatedAt": "2026-06-11T20:24:54.855Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 631,
+      "value": 634,
       "denominator": 1660,
-      "formatted": "631 / 1,660",
-      "note": "38.0%"
+      "formatted": "634 / 1,660",
+      "note": "38.2%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 665,
+      "value": 668,
       "denominator": 1660,
-      "formatted": "665 / 1,660",
-      "note": "40.1%"
+      "formatted": "668 / 1,660",
+      "note": "40.2%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1911,
-      "denominator": 5537,
-      "formatted": "1,911 / 5,537",
-      "note": "34.5%"
+      "value": 1913,
+      "denominator": 5531,
+      "formatted": "1,913 / 5,531",
+      "note": "34.6%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 541,
+      "value": 538,
       "denominator": 1660,
-      "formatted": "541 / 1,660",
-      "note": "32.6%"
+      "formatted": "538 / 1,660",
+      "note": "32.4%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 665,
-    "sourceChecked": 631,
+    "nodesWithSources": 668,
+    "sourceChecked": 634,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 541,
+    "eraDefaultDates": 538,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5537,
-    "edgesWithSources": 1911
+    "totalEdges": 5531,
+    "edgesWithSources": 1913
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T20:13:53.365Z
+Generated: 2026-06-11T20:24:54.855Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 631 / 1,660 (38.0%) |
-| Nodes with node-level sources | 665 / 1,660 (40.1%) |
-| Dependency edges with edge-level sources | 1,911 / 5,537 (34.5%) |
-| Era-default placeholder dates | 541 / 1,660 (32.6%) |
+| Source-checked nodes | 634 / 1,660 (38.2%) |
+| Nodes with node-level sources | 668 / 1,660 (40.2%) |
+| Dependency edges with edge-level sources | 1,913 / 5,531 (34.6%) |
+| Era-default placeholder dates | 538 / 1,660 (32.4%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-arquebus-cannons-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-arquebus-cannons-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-arquebus-cannons-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "arquebus",
+    "prerequisite": "cannons"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Cannons provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from arquebus to cannons. The corrected arquebus node is scoped to shoulder-fired matchlock guns, not a direct derivative of artillery pieces.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.britannica.com/technology/harquebus",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Harquebus entry: defines it as the first gun fired from the shoulder and dates invention in Spain to the mid-15th century.",
+    "source_claim_summary": "The source supports the harquebus as a shoulder-fired matchlock gun, not as directly depending on cannon technology.",
+    "source_support_rationale": "Gunpowder and metallurgical craft are sufficient direct context; cannons are a parallel gunpowder-artillery branch rather than a direct prerequisite."
+  },
+  "ontology_before": "The graph treated cannons as a direct enabler of the arquebus.",
+  "ontology_after": "The graph keeps the arquebus as a small-arms branch with gunpowder as the direct operating prerequisite.",
+  "invariant_preserved_or_changed": "Changed: cannons is absent as a direct prerequisite for arquebus.",
+  "would_reject_if": [
+    "A source showed early harquebuses directly evolved from cannon technology rather than general hand-gun/small-arm development.",
+    "The node were rescoped to a generic firearm lineage rather than shoulder-fired harquebuses.",
+    "A narrower hand-cannon predecessor node were added and source-checked."
+  ],
+  "short_reason": "Cannons are not source-backed as a direct prerequisite for the harquebus.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-cannons-blast-furnace-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-cannons-blast-furnace-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-cannons-blast-furnace-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "cannons",
+    "prerequisite": "blast_furnace"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Blast Furnace provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from cannons to blast_furnace. Early cannon could be bronze or wrought iron, so the broad blast-furnace node is not a universal direct prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.britannica.com/technology/military-technology/Early-use-of-artillery",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Early-use-of-artillery section discusses wrought-iron and bronze cannon categories and later cast-iron cannon separately.",
+    "source_claim_summary": "The source supports multiple early cannon material traditions and does not make blast furnaces a universal prerequisite.",
+    "source_support_rationale": "A blast furnace may matter for some later cast-iron ordnance, but it is too narrow and later-specific for the early-cannon scope."
+  },
+  "ontology_before": "The graph treated blast furnaces as a direct enabler of all cannons.",
+  "ontology_after": "The graph keeps cannon metallurgy edges broad enough for bronze and iron traditions without a blast-furnace requirement.",
+  "invariant_preserved_or_changed": "Changed: blast_furnace is absent as a direct prerequisite for cannons.",
+  "would_reject_if": [
+    "The node were rescoped specifically to cast-iron blast-furnace cannon.",
+    "A source showed all early cannon in scope required blast-furnace iron.",
+    "A narrower cast-iron cannon node were added with blast_furnace as a source-backed dependency."
+  ],
+  "short_reason": "Blast furnaces are not a universal direct prerequisite for early cannon.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-cannons-construction-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-cannons-construction-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-cannons-construction-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "cannons",
+    "prerequisite": "construction"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Construction provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from cannons to construction. The corrected cannon node is scoped to gunpowder artillery, and the source does not support broad construction as a direct technology prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.britannica.com/technology/military-technology/The-gunpowder-revolution-c-1300-1650",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Gunpowder revolution and early-artillery sections describe cannon as gunpowder artillery and classify ordnance, not as a construction dependency.",
+    "source_claim_summary": "The source supports early gunpowder artillery around c. 1300-1650, not broad construction as a direct prerequisite.",
+    "source_support_rationale": "Construction is a contextual field for fortifications and siege use, but it does not pass the direct absence-breaks test for cannon as a weapon technology."
+  },
+  "ontology_before": "The graph treated classical construction as a direct enabler of cannons.",
+  "ontology_after": "The graph keeps cannon dependencies focused on gunpowder and metalworking capabilities.",
+  "invariant_preserved_or_changed": "Changed: construction is absent as a direct prerequisite for cannons.",
+  "would_reject_if": [
+    "A source showed a specific construction technology was required for the scoped cannon design.",
+    "The node were rescoped to fortification-breaching siege systems rather than cannon hardware.",
+    "A narrower source-backed gun-foundry construction node were added."
+  ],
+  "short_reason": "Broad construction is not source-backed as a direct cannon prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-gunpowder-alchemy-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-gunpowder-alchemy-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-gunpowder-alchemy-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "gunpowder",
+    "prerequisite": "alchemy"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Alchemy provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from gunpowder to alchemy. Alchemical experimentation is historically relevant, but this source-backed node is scoped to the recorded 1044 military formula and the local alchemy node remains broad.",
+  "source_supports_edge": "no",
+  "source_url": "https://afe.easia.columbia.edu/songdynasty-module/tech-gunpowder.html",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Gunpowder section: describes Song military engineers, the 1044 Wujing zongyao formula, and early military applications.",
+    "source_claim_summary": "The source supports Song military formula documentation and does not cite the broad alchemy node as a direct dependency.",
+    "source_support_rationale": "Alchemy may be a historical context, but keeping this edge would overclaim a broad unsourced node as a direct prerequisite."
+  },
+  "ontology_before": "The graph treated broad alchemy as a direct enabler of gunpowder.",
+  "ontology_after": "The graph keeps the source-backed formula node free of unsupported broad-context prerequisites.",
+  "invariant_preserved_or_changed": "Changed: alchemy is absent as a direct prerequisite for gunpowder.",
+  "would_reject_if": [
+    "The alchemy node were split or source-checked to the specific Chinese alchemical recipe tradition behind gunpowder.",
+    "A source explicitly supported alchemy as the direct prerequisite for the scoped 1044 formula node.",
+    "The gunpowder node were rescoped to the earlier discovery process rather than the recorded military formula."
+  ],
+  "short_reason": "Alchemy is relevant historical context but not source-backed here as a direct prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/gunpowder.before.json /tmp/gunpowder.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-gunpowder-basic-chemistry-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-gunpowder-basic-chemistry-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-gunpowder-basic-chemistry-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "gunpowder",
+    "prerequisite": "basic_chemistry"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Basic Chemistry is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from gunpowder to basic_chemistry. The current basic_chemistry node is broad and not source-checked as the direct predecessor of the Wujing zongyao formula.",
+  "source_supports_edge": "no",
+  "source_url": "https://afe.easia.columbia.edu/songdynasty-module/tech-gunpowder.html",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Gunpowder section: identifies the 1044 Wujing zongyao as recording the first true gunpowder formula and describes early incendiary use.",
+    "source_claim_summary": "The source supports a documented military recipe and uses, not the broad basic_chemistry graph node as a predecessor.",
+    "source_support_rationale": "A broad chemistry label is too unspecific for a hard or historical edge unless the source connects that exact knowledge tradition to the formula."
+  },
+  "ontology_before": "The graph routed gunpowder through a broad basic_chemistry placeholder.",
+  "ontology_after": "The graph avoids making a broad, weakly scoped chemistry node the direct predecessor of the Song formula.",
+  "invariant_preserved_or_changed": "Changed: basic_chemistry is absent as a direct prerequisite for gunpowder.",
+  "would_reject_if": [
+    "basic_chemistry were source-checked and scoped to documented Chinese chemical recipe traditions preceding gunpowder.",
+    "A source explicitly connected the Wujing zongyao formula to the graph's basic_chemistry node.",
+    "The gunpowder node were rescoped to a broader chemistry-development history."
+  ],
+  "short_reason": "The source supports a specific recorded formula, not a broad basic_chemistry prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/gunpowder.before.json /tmp/gunpowder.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-gunpowder-mining-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-gunpowder-mining-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-gunpowder-mining-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "gunpowder",
+    "prerequisite": "mining"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Mining provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from gunpowder to mining. The corrected node is scoped to the documented 1044 Song formula, and the source does not identify broad mining as a direct prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://afe.easia.columbia.edu/songdynasty-module/tech-gunpowder.html",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Gunpowder section: states that the Wujing zongyao, a military manual from 1044 CE, records the first true gunpowder formula and large-scale production.",
+    "source_claim_summary": "The source supports the 1044 recorded formula and early military uses, not a direct dependency on the broad mining node.",
+    "source_support_rationale": "Ingredient supply matters, but this source does not prove mining as the direct technology dependency for the scoped written formula."
+  },
+  "ontology_before": "The graph treated broad mining as a direct enabler for gunpowder.",
+  "ontology_after": "The graph anchors gunpowder to the documented Song formula without an unsupported broad mining edge.",
+  "invariant_preserved_or_changed": "Changed: mining is absent as a direct prerequisite for gunpowder.",
+  "would_reject_if": [
+    "A source showed the scoped 1044 formula depended specifically on the graph's mining node.",
+    "A narrower saltpeter extraction or refining node were added and source-checked as a direct prerequisite.",
+    "The gunpowder node were rescoped to raw-material supply chains rather than documented formulae."
+  ],
+  "short_reason": "The 1044 formula source does not support broad mining as a direct prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/gunpowder.before.json /tmp/gunpowder.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-cannons-arquebus-chronology.json
+++ b/docs/graph-invariants/2026-06-11-cannons-arquebus-chronology.json
@@ -1,0 +1,51 @@
+{
+  "id": "2026-06-11-cannons-arquebus-chronology",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "cannons",
+      "operator": "eq",
+      "value": 1300,
+      "reason": "The node is scoped to early gunpowder artillery in the c. 1300-1650 gunpowder-revolution frame."
+    },
+    {
+      "type": "first_known_date",
+      "node": "arquebus",
+      "operator": "eq",
+      "value": 1450,
+      "reason": "The node is scoped to the mid-15th-century shoulder-fired harquebus."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "cannons",
+      "prerequisite": "gunpowder",
+      "expected": "required",
+      "reason": "Gunpowder is the direct operating propellant for early gunpowder artillery."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "arquebus",
+      "prerequisite": "gunpowder",
+      "expected": "required",
+      "reason": "The harquebus is a gunpowder firearm."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "cannons",
+      "prerequisite": "construction",
+      "reason": "Broad construction is contextual, not a direct cannon prerequisite."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "cannons",
+      "prerequisite": "blast_furnace",
+      "reason": "Early cannon were not universally dependent on blast-furnace cast iron."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "arquebus",
+      "prerequisite": "cannons",
+      "reason": "The arquebus is not modeled as directly dependent on cannon technology."
+    }
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-song-gunpowder-formula-scope.json
+++ b/docs/graph-invariants/2026-06-11-song-gunpowder-formula-scope.json
@@ -1,0 +1,30 @@
+{
+  "id": "2026-06-11-song-gunpowder-formula-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "gunpowder",
+      "operator": "eq",
+      "value": 1044,
+      "reason": "The node is scoped to the Wujing zongyao record of true gunpowder formulas in 1044 CE."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "gunpowder",
+      "prerequisite": "mining",
+      "reason": "The source does not support broad mining as a direct prerequisite for the scoped written formula."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "gunpowder",
+      "prerequisite": "basic_chemistry",
+      "reason": "The broad basic_chemistry node is too unspecific to remain as a source-backed direct predecessor."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "gunpowder",
+      "prerequisite": "alchemy",
+      "reason": "Alchemy is historical context but is not source-backed here as a direct graph prerequisite."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
Source-backed correction for the small gunpowder weapons cluster: `gunpowder`, `cannons`, and `arquebus`.

I started with `gunpowder`, but correcting its 1044 CE date exposed two direct temporal failures: `cannons` and `arquebus` were still placeholder-dated to 500 CE while depending on gunpowder. This PR fixes that immediate cluster rather than leaving validation red.

## Old Claims
- `gunpowder`: broad unsourced node dated `500`, region `Afro-Eurasia and other medieval societies`, with inferred prerequisites from `mining`, `basic_chemistry`, and `alchemy`.
- `cannons`: broad unsourced node dated `500`, with inferred prerequisites including `construction` and `blast_furnace`.
- `arquebus`: broad unsourced node dated `500`, with an inferred direct dependency on `cannons`.

## New Claims
- `gunpowder` is now scoped as `Song Gunpowder Formula`, anchored to the 1044 `Wujing zongyao` record of true gunpowder formulas.
- `cannons` is now scoped to early gunpowder artillery in the c. 1300-1650 gunpowder-revolution frame.
- `arquebus` is now scoped to the mid-15th-century shoulder-fired harquebus/arquebus.

## Sources
- Columbia Asia for Educators, `Gunpowder - Song Dynasty China`: https://afe.easia.columbia.edu/songdynasty-module/tech-gunpowder.html
- Encyclopaedia Britannica, `Military technology - The gunpowder revolution, c. 1300-1650`: https://www.britannica.com/technology/military-technology/The-gunpowder-revolution-c-1300-1650
- Encyclopaedia Britannica, `Military technology - Early use of artillery`: https://www.britannica.com/technology/military-technology/Early-use-of-artillery
- Encyclopaedia Britannica, `Harquebus`: https://www.britannica.com/technology/harquebus

## Edge Changes
Removed unsupported/contextual direct edges:
- `mining -> gunpowder`
- `basic_chemistry -> gunpowder`
- `alchemy -> gunpowder`
- `construction -> cannons`
- `blast_furnace -> cannons`
- `cannons -> arquebus`

Upgraded source-backed required edges:
- `gunpowder -> cannons`
- `gunpowder -> arquebus`

## Why Better
The old graph made post-gunpowder weapons depend on a 500 CE gunpowder placeholder and over-modeled broad context as direct prerequisites. The new claims align chronology, scope, and direct operating dependencies.

## Adversarial Note
The strongest reason this could be incomplete is that early cannon chronology is regionally complex: China, Europe, and Islamic-world artillery evidence should eventually be split into narrower nodes. This PR uses a conservative c. 1300 frame rather than trying to settle every earliest-cannon dispute.

## Validation
- `npm run node-snapshot-diff -- /tmp/gunpowder.before.json /tmp/gunpowder.after.json --require-behavior-change` passed
- `npm run edge-receipts` passed
- `npm run graph-invariants && npm run invariant-coverage` passed
- `npm test` passed after correcting dependent chronology
- `npm run agent:check -- --run` passed through local checks; first source URL audit hit unrelated existing Bluetooth URL `ECONNREFUSED`
- `npm run source-urls` rerun passed for 759 unique URLs
- `npm run accuracy:risks -- --markdown --limit 24` passed

## Snapshot Delta
- Source-checked nodes: 634 / 1,660 (38.2%)
- Nodes with node-level sources: 668 / 1,660 (40.2%)
- Era-default placeholder dates: 538 / 1,660 (32.4%)
- Dependency edges with edge-level sources: 1,913 / 5,531 (34.6%)