### PR TITLE
[codex] Source-check Sibudu bow-and-arrow use

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 634 / 1,660 (38.2%) |
-| Nodes with node-level sources | 668 / 1,660 (40.2%) |
-| Dependency edges with edge-level sources | 1,913 / 5,531 (34.6%) |
-| Era-default placeholder dates | 538 / 1,660 (32.4%) |
+| Source-checked nodes | 635 / 1,660 (38.3%) |
+| Nodes with node-level sources | 669 / 1,660 (40.3%) |
+| Dependency edges with edge-level sources | 1,914 / 5,529 (34.6%) |
+| Era-default placeholder dates | 537 / 1,660 (32.3%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -3438,42 +3438,52 @@
   },
   {
     "id": "archery",
-    "name": "Archery",
+    "name": "Sibudu Bow-and-Arrow Use",
     "era": "Ancient",
-    "description": "Development of the bow and arrow, a revolutionary weapon for hunting and warfare at a distance.",
+    "description": "Stone-tipped bow-and-arrow hunting technology inferred from Sibudu Cave lithic evidence.",
     "prerequisites": [
-      "advanced_hunting_gathering",
-      "composite_tools",
-      "atlatl"
+      "stone_tool_making"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -64000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Sibudu Cave, KwaZulu-Natal, South Africa",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
-        "prerequisite": "advanced_hunting_gathering",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Hunting & Gathering provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
+        "prerequisite": "stone_tool_making",
+        "type": "required",
+        "confidence": 0.84,
+        "evidence_level": "primary_source",
+        "note": "The Sibudu claim is inferred from stone artefacts and their context, so stone-tool production is the direct material prerequisite for this scoped stone-tipped arrow evidence.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Indications of bow and stone-tipped arrow use 64 000 years ago in KwaZulu-Natal, South Africa",
+            "url": "https://www.cambridge.org/core/journals/antiquity/article/abs/indications-of-bow-and-stonetipped-arrow-use-64-000-years-ago-in-kwazulunatal-south-africa/89AF638BE5E64CEAC63363EFDD4D5E8F",
+            "publisher": "Antiquity",
+            "year": 2010,
+            "source_type": "primary_paper",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
+      }
+    ],
+    "scopeNote": "Scoped to source-backed indications of bow-and-stone-tipped-arrow use at Sibudu Cave around 64 ka. It does not claim the first bow worldwide, all later archery traditions, atlatl technology, or preserved organic bow parts.",
+    "maturity": "established",
+    "sources": [
       {
-        "prerequisite": "composite_tools",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Composite Tools provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "atlatl",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Atlatl provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "title": "Indications of bow and stone-tipped arrow use 64 000 years ago in KwaZulu-Natal, South Africa",
+        "url": "https://www.cambridge.org/core/journals/antiquity/article/abs/indications-of-bow-and-stonetipped-arrow-use-64-000-years-ago-in-kwazulunatal-south-africa/89AF638BE5E64CEAC63363EFDD4D5E8F",
+        "publisher": "Antiquity",
+        "year": 2010,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "edge",
+          "maturity"
+        ]
       }
     ]
   },

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T20:24:54.855Z",
+  "generatedAt": "2026-06-11T20:30:27.094Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 634,
+      "value": 635,
       "denominator": 1660,
-      "formatted": "634 / 1,660",
-      "note": "38.2%"
+      "formatted": "635 / 1,660",
+      "note": "38.3%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 668,
+      "value": 669,
       "denominator": 1660,
-      "formatted": "668 / 1,660",
-      "note": "40.2%"
+      "formatted": "669 / 1,660",
+      "note": "40.3%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1913,
-      "denominator": 5531,
-      "formatted": "1,913 / 5,531",
+      "value": 1914,
+      "denominator": 5529,
+      "formatted": "1,914 / 5,529",
       "note": "34.6%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 538,
+      "value": 537,
       "denominator": 1660,
-      "formatted": "538 / 1,660",
-      "note": "32.4%"
+      "formatted": "537 / 1,660",
+      "note": "32.3%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 668,
-    "sourceChecked": 634,
+    "nodesWithSources": 669,
+    "sourceChecked": 635,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 538,
+    "eraDefaultDates": 537,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5531,
-    "edgesWithSources": 1913
+    "totalEdges": 5529,
+    "edgesWithSources": 1914
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T20:24:54.855Z
+Generated: 2026-06-11T20:30:27.094Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 634 / 1,660 (38.2%) |
-| Nodes with node-level sources | 668 / 1,660 (40.2%) |
-| Dependency edges with edge-level sources | 1,913 / 5,531 (34.6%) |
-| Era-default placeholder dates | 538 / 1,660 (32.4%) |
+| Source-checked nodes | 635 / 1,660 (38.3%) |
+| Nodes with node-level sources | 669 / 1,660 (40.3%) |
+| Dependency edges with edge-level sources | 1,914 / 5,529 (34.6%) |
+| Era-default placeholder dates | 537 / 1,660 (32.3%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-archery-advanced-hunting-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-archery-advanced-hunting-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-archery-advanced-hunting-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "archery",
+    "prerequisite": "advanced_hunting_gathering"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Hunting & Gathering provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from archery to advanced_hunting_gathering. The corrected node is scoped to Sibudu stone-tipped bow-and-arrow evidence, and the source does not identify the broad hunting node as a prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.cambridge.org/core/journals/antiquity/article/abs/indications-of-bow-and-stonetipped-arrow-use-64-000-years-ago-in-kwazulunatal-south-africa/89AF638BE5E64CEAC63363EFDD4D5E8F",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: the authors infer bow-and-arrow use from stone artefacts and their context at Sibudu Cave 64 millennia ago.",
+    "source_claim_summary": "The source supports stone-tipped arrow evidence at Sibudu, not a broad advanced hunting-and-gathering prerequisite.",
+    "source_support_rationale": "Hunting use is the application context, but the graph should not convert that context into a direct technology dependency."
+  },
+  "ontology_before": "The graph treated broad advanced hunting-and-gathering as a direct enabler of archery.",
+  "ontology_after": "The graph anchors the direct prerequisite to stone-tool production for the scoped lithic evidence.",
+  "invariant_preserved_or_changed": "Changed: advanced_hunting_gathering is absent as a direct prerequisite for archery.",
+  "would_reject_if": [
+    "A source showed the graph's advanced_hunting_gathering node as a direct prerequisite for Sibudu bow-and-arrow technology.",
+    "The node were rescoped to a later broad hunting-system package.",
+    "Advanced_hunting_gathering were source-checked and narrowed to the exact Sibudu projectile context."
+  ],
+  "short_reason": "The source supports bow-and-arrow evidence, not the broad hunting node as a direct prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/archery.before.json /tmp/archery.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-archery-atlatl-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-archery-atlatl-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-archery-atlatl-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "archery",
+    "prerequisite": "atlatl"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Atlatl provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from archery to atlatl. Bow-and-arrow technology and spear-thrower technology are separate projectile systems, and the Sibudu source does not make atlatl a prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.cambridge.org/core/journals/antiquity/article/abs/indications-of-bow-and-stonetipped-arrow-use-64-000-years-ago-in-kwazulunatal-south-africa/89AF638BE5E64CEAC63363EFDD4D5E8F",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: identifies indications of bow-and-arrow technology at Sibudu Cave 64 millennia ago, with no atlatl prerequisite.",
+    "source_claim_summary": "The source supports early bow-and-arrow use independently of spear-thrower technology.",
+    "source_support_rationale": "Atlatl should be modeled as a parallel projectile technology unless a source supports a specific historical lineage into archery."
+  },
+  "ontology_before": "The graph modeled atlatl as a direct enabler of archery.",
+  "ontology_after": "The graph treats archery and atlatl as separate projectile technologies rather than a prerequisite chain.",
+  "invariant_preserved_or_changed": "Changed: atlatl is absent as a direct prerequisite for archery.",
+  "would_reject_if": [
+    "A source showed the scoped bow-and-arrow technology evolved directly from atlatl technology.",
+    "The atlatl node were narrowed to a source-backed projectile prerequisite for this region and period.",
+    "The archery node were rescoped to a later regional tradition where atlatl-to-bow transition is evidenced."
+  ],
+  "short_reason": "Atlatl is a parallel projectile system, not source-backed as a direct archery prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/archery.before.json /tmp/archery.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-archery-composite-tools-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-archery-composite-tools-removal.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-archery-composite-tools-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "archery",
+    "prerequisite": "composite_tools"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Composite Tools provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from archery to composite_tools. The current composite_tools node is scoped to KP1 hafted stone-point spears, not Sibudu bow-and-arrow technology.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.cambridge.org/core/journals/antiquity/article/abs/indications-of-bow-and-stonetipped-arrow-use-64-000-years-ago-in-kwazulunatal-south-africa/89AF638BE5E64CEAC63363EFDD4D5E8F",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract: the argument depends on classes of stone artefacts and their context for bow-and-arrow inference.",
+    "source_claim_summary": "The source supports stone artefacts as evidence for arrows, but not KP1 hafted spear technology as a direct prerequisite.",
+    "source_support_rationale": "After the composite_tools node was narrowed to KP1 hafted spears, keeping it as a direct archery prerequisite would smuggle in the old broader meaning."
+  },
+  "ontology_before": "The graph used composite_tools as a broad composite-weapon prerequisite for archery.",
+  "ontology_after": "The graph uses stone_tool_making as the direct material prerequisite for the Sibudu stone-tipped arrow scope.",
+  "invariant_preserved_or_changed": "Changed: composite_tools is absent as a direct prerequisite for archery.",
+  "would_reject_if": [
+    "A broader composite_projectile_technology node were added and source-checked to Sibudu arrows.",
+    "The composite_tools node were broadened back from KP1 hafted spear points.",
+    "A source showed KP1 hafted spear technology directly enabled Sibudu bow-and-arrow use."
+  ],
+  "short_reason": "The current composite_tools scope is KP1 hafted spears, not a direct archery prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/archery.before.json /tmp/archery.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-sibudu-archery-scope.json
+++ b/docs/graph-invariants/2026-06-11-sibudu-archery-scope.json
@@ -1,0 +1,37 @@
+{
+  "id": "2026-06-11-sibudu-archery-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "archery",
+      "operator": "eq",
+      "value": -64000,
+      "reason": "The node is scoped to indications of bow-and-arrow use at Sibudu Cave 64 millennia ago."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "archery",
+      "prerequisite": "stone_tool_making",
+      "expected": "required",
+      "reason": "The scoped evidence is inferred from stone artefacts and their context."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "archery",
+      "prerequisite": "advanced_hunting_gathering",
+      "reason": "Application context should not be modeled as a direct technology prerequisite."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "archery",
+      "prerequisite": "composite_tools",
+      "reason": "The current composite_tools node is scoped to KP1 hafted spears, not Sibudu archery."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "archery",
+      "prerequisite": "atlatl",
+      "reason": "Atlatl and archery are separate projectile systems unless a source supports a direct lineage."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node source-backed correction for `archery`.

## Old Claim
`archery` was a broad unsourced `Archery` node dated to `-10000` / `millennium`, region `Global / multiple regions`, with inferred direct prerequisites from `advanced_hunting_gathering`, `composite_tools`, and `atlatl`.

## New Claim
The node is now scoped as `Sibudu Bow-and-Arrow Use`: stone-tipped bow-and-arrow hunting technology inferred from Sibudu Cave lithic evidence around 64,000 years ago (`firstKnownDate: -64000`, `datePrecision: millennium`).

## Source
- Lombard & Phillipson, `Indications of bow and stone-tipped arrow use 64 000 years ago in KwaZulu-Natal, South Africa`, Antiquity, 2010
- URL: https://www.cambridge.org/core/journals/antiquity/article/abs/indications-of-bow-and-stonetipped-arrow-use-64-000-years-ago-in-kwazulunatal-south-africa/89AF638BE5E64CEAC63363EFDD4D5E8F
- Locator: abstract states the authors infer bow-and-arrow technology at Sibudu Cave 64 millennia ago from stone artefacts and their context.

## Edge Changes
Removed unsupported direct edges:
- `advanced_hunting_gathering -> archery`
- `composite_tools -> archery` because `composite_tools` is now scoped to KP1 hafted stone-point spears, not all composite projectile technology
- `atlatl -> archery` because atlatl and bow-and-arrow are parallel projectile systems unless a source supports a direct lineage

Added source-backed direct edge:
- `stone_tool_making -> archery` as `required`, because the scoped claim is inferred from stone artefacts.

## Why Better
The old graph modeled application context and parallel projectile systems as prerequisites. The new scope is narrower, dated, source-backed, and uses the direct material evidence as the dependency boundary.

## Adversarial Note
The strongest reason this could be incomplete is that organic bow parts do not preserve at Sibudu; the paper argues from lithic evidence. This PR labels the node as indications of use rather than claiming preserved complete bows.

## Validation
- `npm run node-snapshot-diff -- /tmp/archery.before.json /tmp/archery.after.json --require-behavior-change` passed
- `npm run edge-receipts` passed
- `npm run graph-invariants && npm run invariant-coverage` passed
- `npm test` passed
- `npm run agent:check -- --run` passed
- `npm run source-urls` passed for 760 unique URLs
- `npm run accuracy:risks -- --markdown --limit 24` passed

## Snapshot Delta
- Source-checked nodes: 635 / 1,660 (38.3%)
- Nodes with node-level sources: 669 / 1,660 (40.3%)
- Era-default placeholder dates: 537 / 1,660 (32.3%)
- Dependency edges with edge-level sources: 1,914 / 5,529 (34.6%)