### PR TITLE
Remove writing prerequisite from customary law

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | --- | --- |
 | Technologies | 1,660 |
 | Source-checked nodes | 636 / 1,660 (38.3%) |
-| Nodes with node-level sources | 669 / 1,660 (40.3%) |
-| Dependency edges with edge-level sources | 1,915 / 5,525 (34.7%) |
+| Nodes with node-level sources | 670 / 1,660 (40.4%) |
+| Dependency edges with edge-level sources | 1,915 / 5,524 (34.7%) |
 | Era-default placeholder dates | 536 / 1,660 (32.3%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -5184,7 +5184,6 @@
     "era": "Ancient",
     "description": "Systems of established rules, orally transmitted, that govern social behavior, property disputes, and criminal acts within a society.",
     "prerequisites": [
-      "writing",
       "chieftainship"
     ],
     "firstKnownDate": -3000,
@@ -5193,14 +5192,6 @@
     "reviewStatus": "structurally_validated",
     "dependencyEdges": [
       {
-        "prerequisite": "writing",
-        "type": "common_dependency",
-        "confidence": 0.55,
-        "evidence_level": "weak_inference",
-        "note": "Writing is contextual infrastructure or shared knowledge, not a strict hard prerequisite.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
         "prerequisite": "chieftainship",
         "type": "common_dependency",
         "confidence": 0.55,
@@ -5208,7 +5199,21 @@
         "note": "Chieftainship is contextual infrastructure or shared knowledge, not a strict hard prerequisite.",
         "reviewStatus": "structurally_validated"
       }
-    ]
+    ],
+    "sources": [
+      {
+        "title": "Human rights and traditional justice systems in Africa",
+        "url": "https://www.sdgfund.org/human-rights-and-traditional-justice-systems-africa",
+        "publisher": "OHCHR / Sustainable Development Goals Fund",
+        "year": 2016,
+        "source_type": "official_agency",
+        "supports": [
+          "node",
+          "edge"
+        ]
+      }
+    ],
+    "scopeNote": "Covers customary community rule systems that may be oral or written and may or may not be recorded. The date remains a coarse ancient placeholder; this node should not be treated as source-checked chronology."
   },
   {
     "id": "standardized_weights_and_measures",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T20:42:37.716Z",
+  "generatedAt": "2026-06-11T20:51:04.258Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -18,16 +18,16 @@
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 669,
+      "value": 670,
       "denominator": 1660,
-      "formatted": "669 / 1,660",
-      "note": "40.3%"
+      "formatted": "670 / 1,660",
+      "note": "40.4%"
     },
     {
       "label": "Dependency edges with edge-level sources",
       "value": 1915,
-      "denominator": 5525,
-      "formatted": "1,915 / 5,525",
+      "denominator": 5524,
+      "formatted": "1,915 / 5,524",
       "note": "34.7%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 669,
+    "nodesWithSources": 670,
     "sourceChecked": 636,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 536,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5525,
+    "totalEdges": 5524,
     "edgesWithSources": 1915
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T20:42:37.716Z
+Generated: 2026-06-11T20:51:04.258Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -8,8 +8,8 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | --- | --- |
 | Technologies | 1,660 |
 | Source-checked nodes | 636 / 1,660 (38.3%) |
-| Nodes with node-level sources | 669 / 1,660 (40.3%) |
-| Dependency edges with edge-level sources | 1,915 / 5,525 (34.7%) |
+| Nodes with node-level sources | 670 / 1,660 (40.4%) |
+| Dependency edges with edge-level sources | 1,915 / 5,524 (34.7%) |
 | Era-default placeholder dates | 536 / 1,660 (32.3%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-customary-law-writing-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-customary-law-writing-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-customary-law-writing-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "customary_law",
+    "prerequisite": "writing"
+  },
+  "old_claim": {
+    "type": "common_dependency",
+    "confidence": 0.55,
+    "evidence_level": "weak_inference",
+    "note": "Writing is contextual infrastructure or shared knowledge, not a strict hard prerequisite."
+  },
+  "new_claim_absent": "No direct edge remains from writing to customary_law. Customary law can be oral or written, so writing is not a prerequisite for the scoped concept.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.sdgfund.org/human-rights-and-traditional-justice-systems-africa",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "About section: traditional justice systems are based on customary practices, traditions and rules; customary law may be oral or written, and decisions may or may not be recorded.",
+    "source_claim_summary": "The source explicitly allows customary law to be oral, which contradicts writing as a direct prerequisite.",
+    "source_support_rationale": "Writing can document or codify some customary law, but it is not necessary for customary law itself."
+  },
+  "ontology_before": "The graph modeled writing as a direct common dependency for customary_law even though the node was described as orally transmitted.",
+  "ontology_after": "The graph separates customary/oral law from written or codified law-code technologies.",
+  "invariant_preserved_or_changed": "Changed: writing is absent as a direct prerequisite for customary_law.",
+  "would_reject_if": [
+    "The node were rescoped to written customary-law compilations rather than customary law itself.",
+    "A source showed the graph's customary_law scope specifically required written records."
+  ],
+  "short_reason": "Customary law may be oral, so writing is not a prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/customary_law.before.json /tmp/customary_law.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-customary-law-oral-scope.json
+++ b/docs/graph-invariants/2026-06-11-customary-law-oral-scope.json
@@ -1,0 +1,11 @@
+{
+  "id": "2026-06-11-customary-law-oral-scope",
+  "checks": [
+    {
+      "type": "direct_edge_absent",
+      "dependent": "customary_law",
+      "prerequisite": "writing",
+      "reason": "Customary law may be oral or written, so writing must not be reintroduced as a direct prerequisite."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node edge correction for `customary_law`.

## Old Claim
- `customary_law` described orally transmitted rules but listed `writing` as a direct `common_dependency`.

## New Claim
- Removed `writing -> customary_law`.
- Added an OHCHR/SDG Fund source and scope note clarifying that customary law may be oral or written.
- Kept `reviewStatus: structurally_validated` because the source supports the concept/edge correction, not the ancient chronology placeholder.

## Source / Locator
- OHCHR / Sustainable Development Goals Fund, `Human rights and traditional justice systems in Africa`:
  https://www.sdgfund.org/human-rights-and-traditional-justice-systems-africa
- Locator: About section says traditional justice systems are based on customary practices, traditions, and rules, and that customary law may be oral or written; decisions may or may not be recorded.

## Edge Changes
- Removed `writing -> customary_law`.
- Added edge-change receipt and graph invariant so writing is not reintroduced as a direct prerequisite.

## Why This Is Better
The previous edge contradicted the node’s own oral-transmission scope. Writing can document or codify customary law, but it is not required for customary law itself.

## Adversarial Note
Strongest reason this correction could be wrong: if this node were later rescoped to written/customary-law compilations, writing might become relevant again. That should be modeled as a separate written/codified customary-law node rather than on broad customary law.

## Validation
Passed:
- `npm run edge-receipts`
- `npm run graph-invariants && npm run invariant-coverage`
- `npm run node-snapshot-diff -- /tmp/customary_law.before.json /tmp/customary_law.after.json --require-behavior-change`
- `npm run agent:check -- --run`
- `npm run source-urls`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`