### PR TITLE
Source-check market weight inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 636 / 1,660 (38.3%) |
-| Nodes with node-level sources | 670 / 1,660 (40.4%) |
-| Dependency edges with edge-level sources | 1,915 / 5,524 (34.7%) |
-| Era-default placeholder dates | 536 / 1,660 (32.3%) |
+| Source-checked nodes | 637 / 1,660 (38.4%) |
+| Nodes with node-level sources | 671 / 1,660 (40.4%) |
+| Dependency edges with edge-level sources | 1,916 / 5,523 (34.7%) |
+| Era-default placeholder dates | 535 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/classical.json
+++ b/data/classical.json
@@ -9948,35 +9948,73 @@
   },
   {
     "id": "standard_weights_market_inspection",
-    "name": "Market Weight Inspection",
+    "name": "Athenian Market Weights Inspection",
     "era": "Classical",
-    "description": "Official measures, stamped weights, and inspector offices for fair trade in urban markets.",
+    "description": "Official master measures, stamped copies, and public enforcement rules requiring sellers to use correct weights and measures in Athenian markets.",
     "prerequisites": [
-      "currency",
-      "record_keeping"
+      "standardized_weights_and_measures"
     ],
-    "firstKnownDate": -500,
-    "datePrecision": "century",
-    "region": "Mediterranean, South Asia, East Asia, and other classical societies",
-    "reviewStatus": "structurally_validated",
+    "firstKnownDate": -120,
+    "datePrecision": "decade",
+    "region": "Athens, Piraeus, and Eleusis",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
-        "prerequisite": "currency",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Currency provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "prerequisite": "standardized_weights_and_measures",
+        "type": "required",
+        "confidence": 0.93,
+        "evidence_level": "primary_source",
+        "note": "The Athenian decree orders official copies equivalent to master measures and requires sellers to use these measures and weights.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "SEG 66.125 Decree about weights and measures",
+            "url": "https://www.atticinscriptions.com/inscription/SEG/66125",
+            "publisher": "Attic Inscriptions Online",
+            "year": 2024,
+            "source_type": "textbook",
+            "supports": [
+              "node",
+              "edge"
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": [
+      {
+        "title": "SEG 66.125 Decree about weights and measures",
+        "url": "https://www.atticinscriptions.com/inscription/SEG/66125",
+        "publisher": "Attic Inscriptions Online",
+        "year": 2024,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       },
       {
-        "prerequisite": "record_keeping",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Record Keeping is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "title": "Aediles",
+        "url": "https://penelope.uchicago.edu/Thayer/E/Roman/Texts/secondary/SMIGRA%2A/Aediles.html",
+        "publisher": "A Dictionary of Greek and Roman Antiquities",
+        "year": 1875,
+        "source_type": "textbook",
+        "supports": [
+          "node"
+        ]
+      },
+      {
+        "title": "Agoranomos",
+        "url": "https://www.encyclopedia.com/religion/encyclopedias-almanacs-transcripts-and-maps/agoranomos",
+        "publisher": "Encyclopaedia Judaica",
+        "year": 2007,
+        "source_type": "textbook",
+        "supports": [
+          "node"
+        ]
       }
-    ]
+    ],
+    "scopeNote": "Covers source-attested official market enforcement of weights and measures, pinned to the Athenian decree about weights and measures around 120 BCE. It does not claim that currency or generic accounting records were prerequisites."
   },
   {
     "id": "court_transcript_scribes",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T20:51:04.258Z",
+  "generatedAt": "2026-06-11T20:56:57.348Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,31 +11,31 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 636,
+      "value": 637,
       "denominator": 1660,
-      "formatted": "636 / 1,660",
-      "note": "38.3%"
+      "formatted": "637 / 1,660",
+      "note": "38.4%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 670,
+      "value": 671,
       "denominator": 1660,
-      "formatted": "670 / 1,660",
+      "formatted": "671 / 1,660",
       "note": "40.4%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1915,
-      "denominator": 5524,
-      "formatted": "1,915 / 5,524",
+      "value": 1916,
+      "denominator": 5523,
+      "formatted": "1,916 / 5,523",
       "note": "34.7%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 536,
+      "value": 535,
       "denominator": 1660,
-      "formatted": "536 / 1,660",
-      "note": "32.3%"
+      "formatted": "535 / 1,660",
+      "note": "32.2%"
     },
     {
       "label": "Manual risk-weighted sample",
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 670,
-    "sourceChecked": 636,
+    "nodesWithSources": 671,
+    "sourceChecked": 637,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 536,
+    "eraDefaultDates": 535,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5524,
-    "edgesWithSources": 1915
+    "totalEdges": 5523,
+    "edgesWithSources": 1916
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T20:51:04.258Z
+Generated: 2026-06-11T20:56:57.348Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 636 / 1,660 (38.3%) |
-| Nodes with node-level sources | 670 / 1,660 (40.4%) |
-| Dependency edges with edge-level sources | 1,915 / 5,524 (34.7%) |
-| Era-default placeholder dates | 536 / 1,660 (32.3%) |
+| Source-checked nodes | 637 / 1,660 (38.4%) |
+| Nodes with node-level sources | 671 / 1,660 (40.4%) |
+| Dependency edges with edge-level sources | 1,916 / 5,523 (34.7%) |
+| Era-default placeholder dates | 535 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-market-weight-inspection-currency-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-market-weight-inspection-currency-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-market-weight-inspection-currency-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "standard_weights_market_inspection",
+    "prerequisite": "currency"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Currency provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from currency to standard_weights_market_inspection. The scoped Athenian decree regulates master measures, copies, weights, sellers, and penalties; currency is context for some payments but not a prerequisite for market-weight inspection.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.atticinscriptions.com/inscription/SEG/66125",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "SEG 66.125 lines 8-19 and notes: officials make copies of master measures and compel sellers to use the correct measures and weights.",
+    "source_claim_summary": "The decree supports official enforcement of standardized measures and weights, not currency as a direct input.",
+    "source_support_rationale": "Currency appears only as penalty/payment context; the inspection technology depends on standards and enforcement."
+  },
+  "ontology_before": "The graph treated currency as a direct enabler of market-weight inspection.",
+  "ontology_after": "The graph treats standardized weights and measures as the direct technical basis for market-weight inspection.",
+  "invariant_preserved_or_changed": "Changed: currency is absent as a direct prerequisite for standard_weights_market_inspection.",
+  "would_reject_if": [
+    "The node were rescoped to monetary-market inspection rather than weights-and-measures enforcement.",
+    "A source showed currency was necessary for the specific inspection office or practice."
+  ],
+  "short_reason": "Market-weight inspection requires standards, not currency.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/standard_weights_market_inspection.before.json /tmp/standard_weights_market_inspection.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-market-weight-inspection-record-keeping-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-market-weight-inspection-record-keeping-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-market-weight-inspection-record-keeping-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "standard_weights_market_inspection",
+    "prerequisite": "record_keeping"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Record Keeping is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from record_keeping to standard_weights_market_inspection. The source supports master measures, copies, stamping, enforcement, and penalties; generic record keeping is not a direct prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.atticinscriptions.com/inscription/SEG/66125",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "SEG 66.125 lines 8-19, 37-43, and 60-65: official copies of master measures are distributed and stamped/validated for use by sellers and officials.",
+    "source_claim_summary": "The decree supports physical standards and enforcement procedures rather than generic accounting record keeping.",
+    "source_support_rationale": "Some administrative writing surrounds enforcement, but the direct technical prerequisite is standardized metrology."
+  },
+  "ontology_before": "The graph treated generic record keeping as a historical predecessor of market-weight inspection.",
+  "ontology_after": "The graph avoids laundering generic administration into a direct technical dependency for weights-and-measures inspection.",
+  "invariant_preserved_or_changed": "Changed: record_keeping is absent as a direct prerequisite for standard_weights_market_inspection.",
+  "would_reject_if": [
+    "The node were rescoped to written inspection registers or official accounting archives.",
+    "A source showed accounting record keeping was necessary for the specific market-weight inspection practice."
+  ],
+  "short_reason": "Generic record keeping is not the direct basis for market-weight inspection.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/standard_weights_market_inspection.before.json /tmp/standard_weights_market_inspection.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-market-weight-inspection-scope.json
+++ b/docs/graph-invariants/2026-06-11-market-weight-inspection-scope.json
@@ -1,0 +1,31 @@
+{
+  "id": "2026-06-11-market-weight-inspection-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "standard_weights_market_inspection",
+      "operator": "eq",
+      "value": -120,
+      "reason": "The node is scoped to the Athenian decree about weights and measures dated ca. 120 BCE."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "standard_weights_market_inspection",
+      "prerequisite": "standardized_weights_and_measures",
+      "expected": "required",
+      "reason": "Market-weight inspection requires standardized measures and weights to inspect against."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "standard_weights_market_inspection",
+      "prerequisite": "currency",
+      "reason": "Currency is not a direct prerequisite for weights-and-measures inspection."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "standard_weights_market_inspection",
+      "prerequisite": "record_keeping",
+      "reason": "Generic record keeping must not substitute for source-backed metrology as the direct dependency."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node correction for `standard_weights_market_inspection`.

## Old Claim
- `Market Weight Inspection`, broad Classical `-500` placeholder.
- No node sources.
- Direct prerequisites were generic `currency` and `record_keeping`.

## New Claim
- Rescoped to `Athenian Market Weights Inspection`.
- Date: `-120`, `datePrecision: decade`, pinned to an Athenian decree dated ca. 120 BCE.
- Region: Athens, Piraeus, and Eleusis.
- Direct dependency is now `standardized_weights_and_measures`, typed `required`, because inspection requires standards to inspect against.

## Sources / Locators
- Attic Inscriptions Online, `SEG 66.125 Decree about weights and measures`:
  https://www.atticinscriptions.com/inscription/SEG/66125
  - Locator: date line gives ca. 120 BC; lines 8-19 order official copies equivalent to master measures and require sellers in the Agora/workshops/shops/wine shops/warehouses to use correct measures and weights; later lines cover custody, stamped/validated measures, and penalties.
- Smith, `Aediles`, A Dictionary of Greek and Roman Antiquities:
  https://penelope.uchicago.edu/Thayer/E/Roman/Texts/secondary/SMIGRA%2A/Aediles.html
  - Locator: aediles supervised markets, goods for sale, and weights and measures.
- Encyclopaedia Judaica, `Agoranomos`:
  https://www.encyclopedia.com/religion/encyclopedias-almanacs-transcripts-and-maps/agoranomos
  - Locator: agoranomos supervised weights and measures, goods quality, and buyer/seller transactions.

## Edge Changes
- Added `standardized_weights_and_measures -> standard_weights_market_inspection` as `required` with edge source.
- Removed `currency -> standard_weights_market_inspection`.
- Removed `record_keeping -> standard_weights_market_inspection`.
- Added two edge-change receipts and one graph invariant.

## Adversarial Note
Strongest reason this could be wrong: `standardized_weights_and_measures` is broad and ancient, while this node is a specific late-Hellenistic enforcement regime. If the graph later adds a narrower `official_master_measures` or `metrology_standards_office` node, this required edge should be rewired to that more precise prerequisite.

## Validation
Passed:
- `npm run edge-receipts`
- `npm run graph-invariants && npm run invariant-coverage`
- `npm run node-snapshot-diff -- /tmp/standard_weights_market_inspection.before.json /tmp/standard_weights_market_inspection.after.json --require-behavior-change`
- `npm run agent:check -- --run`
- `npm run source-urls`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`