### PR TITLE
Source-check Sumerian organized warfare

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 637 / 1,660 (38.4%) |
-| Nodes with node-level sources | 671 / 1,660 (40.4%) |
-| Dependency edges with edge-level sources | 1,916 / 5,523 (34.7%) |
+| Source-checked nodes | 638 / 1,660 (38.4%) |
+| Nodes with node-level sources | 672 / 1,660 (40.5%) |
+| Dependency edges with edge-level sources | 1,917 / 5,519 (34.7%) |
 | Era-default placeholder dates | 535 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -5702,35 +5702,64 @@
   },
   {
     "id": "organized_warfare",
-    "name": "Organized Warfare",
+    "name": "Early Dynastic Sumerian Organized Warfare",
     "era": "Ancient",
-    "description": "The conduct of war using trained, disciplined bodies of soldiers with standardized equipment and basic tactical formations.",
+    "description": "Organized Sumerian warfare represented by disciplined infantry, military wagons, shielded formations, and city-state victory monuments.",
     "prerequisites": [
-      "city_states",
-      "iron_working"
+      "city_states"
     ],
-    "firstKnownDate": -3000,
+    "firstKnownDate": -2550,
     "datePrecision": "century",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Ur and Lagash, Sumer",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "city_states",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "City-States provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "confidence": 0.76,
+        "evidence_level": "textbook",
+        "note": "The cited Early Dynastic evidence is embedded in Sumerian city-state conflict and royal victory display, but city-states are treated as enabling context rather than a universal prerequisite for warfare.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Stele of the Vultures",
+            "url": "https://collections.louvre.fr/en/ark:/53355/cl010121794",
+            "publisher": "Musee du Louvre",
+            "year": 2026,
+            "source_type": "museum",
+            "supports": [
+              "node",
+              "edge"
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": [
+      {
+        "title": "The Standard of Ur",
+        "url": "https://www.britishmuseum.org/collection/object/W_1928-1010-3",
+        "publisher": "British Museum",
+        "year": 2026,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       },
       {
-        "prerequisite": "iron_working",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Iron Working provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "title": "Stele of the Vultures",
+        "url": "https://collections.louvre.fr/en/ark:/53355/cl010121794",
+        "publisher": "Musee du Louvre",
+        "year": 2026,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       }
-    ]
+    ],
+    "scopeNote": "Covers source-attested Early Dynastic Sumerian organized warfare, not warfare globally and not iron-armed warfare. The iron_working node is scoped to hammered meteoritic iron beads and later iron traditions, so it is not a prerequisite for this Bronze Age warfare evidence."
   },
   {
     "id": "sewers_and_drainage",
@@ -7348,8 +7377,7 @@
     "description": "Practical medicine for bleeding control, splinting, wound cleaning, bandaging, and recovery after hunting accidents, labor injuries, and organized warfare.",
     "prerequisites": [
       "primitive_surgery_trepanation",
-      "herbal_medicine_preparation",
-      "organized_warfare"
+      "herbal_medicine_preparation"
     ],
     "firstKnownDate": -3000,
     "datePrecision": "century",
@@ -7370,14 +7398,6 @@
         "confidence": 0.68,
         "evidence_level": "expert_inference",
         "note": "Herbal Medicine Preparation provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "organized_warfare",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Organized Warfare provides a capability that enables this technology without being the only possible path.",
         "reviewStatus": "structurally_validated"
       }
     ]
@@ -7553,8 +7573,7 @@
     "description": "Raised lookout and signaling structures for guarding settlements, fields, roads, borders, and water sources.",
     "prerequisites": [
       "early_fortifications",
-      "masonry",
-      "organized_warfare"
+      "masonry"
     ],
     "firstKnownDate": -3000,
     "datePrecision": "century",
@@ -7575,14 +7594,6 @@
         "confidence": 0.68,
         "evidence_level": "expert_inference",
         "note": "Masonry provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "organized_warfare",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Organized Warfare provides a capability that enables this technology without being the only possible path.",
         "reviewStatus": "structurally_validated"
       }
     ]
@@ -7779,8 +7790,7 @@
     "description": "Standardized stone, clay, or cast metal sling ammunition used for hunting, guarding, and organized warfare.",
     "prerequisites": [
       "basic_rope_making",
-      "stone_tool_making",
-      "organized_warfare"
+      "stone_tool_making"
     ],
     "firstKnownDate": -3000,
     "datePrecision": "century",
@@ -7801,14 +7811,6 @@
         "confidence": 0.75,
         "evidence_level": "expert_inference",
         "note": "Stone Tool Making is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "organized_warfare",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Organized Warfare provides a capability that enables this technology without being the only possible path.",
         "reviewStatus": "structurally_validated"
       }
     ]

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T20:56:57.348Z",
+  "generatedAt": "2026-06-11T21:05:21.499Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,23 +11,23 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 637,
+      "value": 638,
       "denominator": 1660,
-      "formatted": "637 / 1,660",
+      "formatted": "638 / 1,660",
       "note": "38.4%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 671,
+      "value": 672,
       "denominator": 1660,
-      "formatted": "671 / 1,660",
-      "note": "40.4%"
+      "formatted": "672 / 1,660",
+      "note": "40.5%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1916,
-      "denominator": 5523,
-      "formatted": "1,916 / 5,523",
+      "value": 1917,
+      "denominator": 5519,
+      "formatted": "1,917 / 5,519",
       "note": "34.7%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 671,
-    "sourceChecked": 637,
+    "nodesWithSources": 672,
+    "sourceChecked": 638,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 535,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5523,
-    "edgesWithSources": 1916
+    "totalEdges": 5519,
+    "edgesWithSources": 1917
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,15 +1,15 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T20:56:57.348Z
+Generated: 2026-06-11T21:05:21.499Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 637 / 1,660 (38.4%) |
-| Nodes with node-level sources | 671 / 1,660 (40.4%) |
-| Dependency edges with edge-level sources | 1,916 / 5,523 (34.7%) |
+| Source-checked nodes | 638 / 1,660 (38.4%) |
+| Nodes with node-level sources | 672 / 1,660 (40.5%) |
+| Dependency edges with edge-level sources | 1,917 / 5,519 (34.7%) |
 | Era-default placeholder dates | 535 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-battlefield-wound-care-organized-warfare-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-battlefield-wound-care-organized-warfare-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-11-battlefield-wound-care-organized-warfare-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "battlefield_wound_care",
+    "prerequisite": "organized_warfare"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Organized Warfare provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from organized_warfare to battlefield_wound_care. The node covers practical wound care after hunting accidents, labor injuries, and warfare; organized warfare is one use context, not a prerequisite for wound care.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.britishmuseum.org/collection/object/W_1928-1010-3",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Object record for the Standard of Ur: supports Early Dynastic Sumerian warfare scenes, but does not establish warfare as a prerequisite for wound-care practices.",
+    "source_claim_summary": "The source supports organized warfare evidence, not a dependency from wound care to organized warfare.",
+    "source_support_rationale": "Wound care predates and extends beyond organized warfare contexts; the edge would launder one application context into a prerequisite."
+  },
+  "ontology_before": "The graph made organized_warfare a direct enabler of battlefield_wound_care.",
+  "ontology_after": "The graph treats warfare as one application context for wound care, not a prerequisite.",
+  "invariant_preserved_or_changed": "Changed: organized_warfare is absent as a direct prerequisite for battlefield_wound_care.",
+  "would_reject_if": [
+    "The node were rescoped narrowly to formal military battlefield medicine rather than general practical wound care.",
+    "A source established organized military institutions as necessary for the scoped wound-care technology."
+  ],
+  "short_reason": "Warfare is a use context for wound care, not a prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-defensive-watchtowers-organized-warfare-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-defensive-watchtowers-organized-warfare-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-11-defensive-watchtowers-organized-warfare-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "defensive_watchtowers",
+    "prerequisite": "organized_warfare"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Organized Warfare provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from organized_warfare to defensive_watchtowers. Watchtowers guard settlements, fields, roads, borders, and water sources; organized warfare is not required for lookout or signaling structures.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.britishmuseum.org/collection/object/W_1928-1010-3",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Object record for the Standard of Ur: supports Early Dynastic Sumerian warfare scenes, but does not establish watchtowers as dependent on organized warfare.",
+    "source_claim_summary": "The source supports organized warfare, not watchtower dependency.",
+    "source_support_rationale": "Defensive lookouts and signaling structures can arise from settlement security needs without organized battlefield formations."
+  },
+  "ontology_before": "The graph made organized_warfare a direct enabler of defensive_watchtowers.",
+  "ontology_after": "The graph keeps watchtowers tied to fortification and masonry capabilities rather than to a specific warfare node.",
+  "invariant_preserved_or_changed": "Changed: organized_warfare is absent as a direct prerequisite for defensive_watchtowers.",
+  "would_reject_if": [
+    "The node were rescoped to military watchtowers within organized armies.",
+    "A source established organized warfare as necessary for the scoped watchtower technology."
+  ],
+  "short_reason": "Watchtowers do not require organized warfare as a direct prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-organized-warfare-iron-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-organized-warfare-iron-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-organized-warfare-iron-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "organized_warfare",
+    "prerequisite": "iron_working"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Iron Working provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from iron_working to organized_warfare. The scoped evidence is Early Dynastic Sumerian organized warfare, while the graph's iron_working node is pinned to hammered meteoritic iron beads and later iron traditions rather than Bronze Age military organization.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.britishmuseum.org/collection/object/W_1928-1010-3",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Object record for the Standard of Ur: dates the object to Early Dynastic III, about 2600 BC, and describes the war side with soldiers, wagons, and captives.",
+    "source_claim_summary": "The source supports organized Sumerian warfare centuries before iron weapons are relevant to the scoped claim.",
+    "source_support_rationale": "The source shows organized warfare without requiring the graph's iron_working technology; iron_working is therefore a false direct dependency."
+  },
+  "ontology_before": "The graph modeled iron_working as an enabler of organized_warfare.",
+  "ontology_after": "The graph separates Bronze Age organized warfare from later or unrelated iron-working traditions.",
+  "invariant_preserved_or_changed": "Changed: iron_working is absent as a direct prerequisite for organized_warfare.",
+  "would_reject_if": [
+    "The node were rescoped to Iron Age infantry equipment or iron-armed warfare.",
+    "A source showed the specific Early Dynastic Sumerian warfare evidence depended on iron weapons."
+  ],
+  "short_reason": "Early organized warfare evidence does not require the iron_working node.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/organized_warfare.before.json /tmp/organized_warfare.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-sling-projectiles-organized-warfare-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-sling-projectiles-organized-warfare-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-11-sling-projectiles-organized-warfare-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "sling_projectiles",
+    "prerequisite": "organized_warfare"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Organized Warfare provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from organized_warfare to sling_projectiles. Sling ammunition can be used for hunting, guarding, and warfare; organized warfare is an application context, not a prerequisite for shaped sling projectiles.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.britishmuseum.org/collection/object/W_1928-1010-3",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Object record for the Standard of Ur: supports Early Dynastic Sumerian warfare scenes, but does not establish sling projectiles as dependent on organized warfare.",
+    "source_claim_summary": "The source supports organized warfare evidence, not a prerequisite relationship for sling projectiles.",
+    "source_support_rationale": "Projectile technology can precede or exist outside organized armies; keeping this edge would confuse use context with causation."
+  },
+  "ontology_before": "The graph made organized_warfare a direct enabler of sling_projectiles.",
+  "ontology_after": "The graph keeps sling projectiles tied to rope/tool capabilities rather than organized warfare.",
+  "invariant_preserved_or_changed": "Changed: organized_warfare is absent as a direct prerequisite for sling_projectiles.",
+  "would_reject_if": [
+    "The node were rescoped to standardized military sling ammunition only.",
+    "A source established organized warfare as necessary for the scoped sling projectile technology."
+  ],
+  "short_reason": "Organized warfare is a use context for sling projectiles, not a prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-organized-warfare-sumerian-scope.json
+++ b/docs/graph-invariants/2026-06-11-organized-warfare-sumerian-scope.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-11-organized-warfare-sumerian-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "organized_warfare",
+      "operator": "eq",
+      "value": -2550,
+      "reason": "The node is scoped to Early Dynastic Sumerian organized warfare evidence from the mid-third millennium BCE."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "organized_warfare",
+      "prerequisite": "iron_working",
+      "reason": "Iron working must not be reintroduced as a prerequisite for Bronze Age Sumerian organized warfare evidence."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "organized_warfare",
+      "prerequisite": "city_states",
+      "expected": "enabling",
+      "reason": "Sumerian city-states are enabling context for the source-attested case, not a universal hard prerequisite for warfare."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "battlefield_wound_care",
+      "prerequisite": "organized_warfare",
+      "reason": "Warfare is one use context for wound care, not a direct prerequisite."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "defensive_watchtowers",
+      "prerequisite": "organized_warfare",
+      "reason": "Watchtowers can arise from settlement security and signaling needs without organized warfare as a direct prerequisite."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "sling_projectiles",
+      "prerequisite": "organized_warfare",
+      "reason": "Sling projectiles can be hunting or guarding technology as well as warfare equipment."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
Source-backed correction for `organized_warfare` plus direct downstream edge cleanup caused by the new chronology.

## Old Claim
- `Organized Warfare`, broad ancient/global scope, date `-3000`.
- Direct prerequisites: `city_states`, `iron_working`.
- `iron_working` in this graph is scoped to hammered meteoritic iron beads and later iron traditions, which does not support Bronze Age organized warfare.

## New Claim
- Rescoped as `Early Dynastic Sumerian Organized Warfare`.
- Date: `-2550`, `datePrecision: century`.
- Region: Ur and Lagash, Sumer.
- Removed `iron_working -> organized_warfare`.
- Kept `city_states -> organized_warfare` as `enabling`, source-checked, not required.
- Removed `organized_warfare` as a direct prerequisite from:
  - `battlefield_wound_care`
  - `defensive_watchtowers`
  - `sling_projectiles`

## Sources / Locators
- British Museum, `The Standard of Ur`:
  https://www.britishmuseum.org/collection/object/W_1928-1010-3
  - Locator: object record dates the Standard of Ur to Early Dynastic III, about 2600 BCE, and describes war-side scenes with soldiers, military wagons, and captives.
- Musee du Louvre, `Stele of the Vultures`:
  https://collections.louvre.fr/en/ark:/53355/cl010121794
  - Locator: object record identifies the Lagash victory monument / Stele of the Vultures, supporting city-state warfare and formed troops.
- UCL / Journal of Archaeological Science, `5,000 years old Egyptian iron beads made from hammered meteoritic iron`:
  https://discovery.ucl.ac.uk/1430496/
  - Locator: existing graph source for `iron_working`; supports early meteoritic iron beads, not organized warfare equipment.

## Why This Is Better
The old edge laundered a materials-history node into a military-organization node. The corrected node is pinned to actual Early Dynastic Sumerian visual/material evidence and avoids treating later/irrelevant iron working as an enabler.

## Downstream Cleanup
After pinning `organized_warfare` to `-2550`, temporal validation correctly caught three dependents dated `-3000`. Instead of pushing those unsourced nodes later, this PR removes weak context edges: wound care, watchtowers, and sling projectiles can exist outside organized warfare.

## Adversarial Note
Strongest reason this could be wrong: the stable id `organized_warfare` now names a specific source-attested case rather than the broad global phenomenon. A future ontology improvement may split this into `organized_warfare_general` and `early_dynastic_sumerian_warfare`.

## Validation
Passed:
- `npm run edge-receipts`
- `npm run graph-invariants && npm run invariant-coverage`
- `npm run node-snapshot-diff -- /tmp/organized_warfare.before.json /tmp/organized_warfare.after.json --require-behavior-change`
- `npm run agent:check -- --run` after rerunning transient `source-urls`
- `npm run source-urls`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`