### PR TITLE
Source-check Edwin Smith trauma care

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 638 / 1,660 (38.4%) |
-| Nodes with node-level sources | 672 / 1,660 (40.5%) |
-| Dependency edges with edge-level sources | 1,917 / 5,519 (34.7%) |
+| Source-checked nodes | 639 / 1,660 (38.5%) |
+| Nodes with node-level sources | 673 / 1,660 (40.5%) |
+| Dependency edges with edge-level sources | 1,917 / 5,517 (34.7%) |
 | Era-default placeholder dates | 535 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -7372,35 +7372,40 @@
   },
   {
     "id": "battlefield_wound_care",
-    "name": "Battlefield Wound Care",
+    "name": "Edwin Smith Trauma Wound Care",
     "era": "Ancient",
-    "description": "Practical medicine for bleeding control, splinting, wound cleaning, bandaging, and recovery after hunting accidents, labor injuries, and organized warfare.",
-    "prerequisites": [
-      "primitive_surgery_trepanation",
-      "herbal_medicine_preparation"
-    ],
-    "firstKnownDate": -3000,
+    "description": "Ancient Egyptian clinical trauma care for wounds, fractures, dislocations, diagnosis, prognosis, bandaging, suturing, splinting, and related treatments.",
+    "prerequisites": [],
+    "firstKnownDate": -1600,
     "datePrecision": "century",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
-    "dependencyEdges": [
+    "region": "Ancient Egypt",
+    "reviewStatus": "source_checked",
+    "dependencyEdges": [],
+    "sources": [
       {
-        "prerequisite": "primitive_surgery_trepanation",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Primitive Surgery (e.g., Trepanation) provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "title": "Edwin Smith papyrus",
+        "url": "https://www.britannica.com/topic/Edwin-Smith-papyrus",
+        "publisher": "Encyclopaedia Britannica",
+        "year": 2026,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       },
       {
-        "prerequisite": "herbal_medicine_preparation",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Herbal Medicine Preparation provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "title": "The Edwin Smith papyrus: a clinical reappraisal of the oldest known document on spinal injuries",
+        "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2989268/",
+        "publisher": "European Spine Journal",
+        "year": 2010,
+        "source_type": "review",
+        "supports": [
+          "node",
+          "maturity"
+        ]
       }
-    ]
+    ],
+    "scopeNote": "Covers documented trauma and wound-care procedures in the Edwin Smith Papyrus, not battlefield medicine as a general institution and not all prehistoric wound care. The source supports the surviving text around 1600 BCE; older textual traditions remain possible but are not used as this node's date."
   },
   {
     "id": "mortar_and_pestle",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T21:05:21.499Z",
+  "generatedAt": "2026-06-11T21:11:07.823Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,23 +11,23 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 638,
+      "value": 639,
       "denominator": 1660,
-      "formatted": "638 / 1,660",
-      "note": "38.4%"
+      "formatted": "639 / 1,660",
+      "note": "38.5%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 672,
+      "value": 673,
       "denominator": 1660,
-      "formatted": "672 / 1,660",
+      "formatted": "673 / 1,660",
       "note": "40.5%"
     },
     {
       "label": "Dependency edges with edge-level sources",
       "value": 1917,
-      "denominator": 5519,
-      "formatted": "1,917 / 5,519",
+      "denominator": 5517,
+      "formatted": "1,917 / 5,517",
       "note": "34.7%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 672,
-    "sourceChecked": 638,
+    "nodesWithSources": 673,
+    "sourceChecked": 639,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 535,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5519,
+    "totalEdges": 5517,
     "edgesWithSources": 1917
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,15 +1,15 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T21:05:21.499Z
+Generated: 2026-06-11T21:11:07.823Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 638 / 1,660 (38.4%) |
-| Nodes with node-level sources | 672 / 1,660 (40.5%) |
-| Dependency edges with edge-level sources | 1,917 / 5,519 (34.7%) |
+| Source-checked nodes | 639 / 1,660 (38.5%) |
+| Nodes with node-level sources | 673 / 1,660 (40.5%) |
+| Dependency edges with edge-level sources | 1,917 / 5,517 (34.7%) |
 | Era-default placeholder dates | 535 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-edwin-smith-trauma-herbal-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-edwin-smith-trauma-herbal-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-edwin-smith-trauma-herbal-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "battlefield_wound_care",
+    "prerequisite": "herbal_medicine_preparation"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Herbal Medicine Preparation provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from herbal_medicine_preparation to battlefield_wound_care. The scoped Edwin Smith trauma-care evidence includes bandaging, splinting, suturing, and wound treatments; herbal preparation is not a required prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2989268/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Clinical reappraisal summary: describes trauma cases, examination, diagnosis, prognosis, and treatments such as bandaging and splints rather than deriving the practice from herbal medicine preparation.",
+    "source_claim_summary": "The source supports trauma-care procedures, not a dependency on herbal preparation.",
+    "source_support_rationale": "Herbal medicine may overlap with ancient medicine generally, but it is not necessary for the scoped trauma-care practices."
+  },
+  "ontology_before": "The graph treated herbal medicine preparation as a direct enabler of battlefield_wound_care.",
+  "ontology_after": "The graph keeps Edwin Smith trauma care scoped to documented clinical procedures without requiring herbal preparation.",
+  "invariant_preserved_or_changed": "Changed: herbal_medicine_preparation is absent as a direct prerequisite for battlefield_wound_care.",
+  "would_reject_if": [
+    "The node were rescoped to herbal wound salves rather than trauma-care procedure.",
+    "A source established herbal preparation as necessary for the scoped Edwin Smith trauma-care practice."
+  ],
+  "short_reason": "Herbal preparation is not required for Edwin Smith trauma wound care.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/battlefield_wound_care.before.json /tmp/battlefield_wound_care.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-edwin-smith-trauma-trepanation-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-edwin-smith-trauma-trepanation-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-edwin-smith-trauma-trepanation-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "battlefield_wound_care",
+    "prerequisite": "primitive_surgery_trepanation"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Primitive Surgery (e.g., Trepanation) provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from primitive_surgery_trepanation to battlefield_wound_care. The scoped Edwin Smith trauma-care node includes wound examination, diagnosis, prognosis, bandaging, suturing, splinting, and other trauma treatments; trepanation is not a prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2989268/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Abstract and clinical summary: describes 48 cases of wounds, injuries, fractures, and treatments in the Edwin Smith Papyrus, without making trepanation a prerequisite.",
+    "source_claim_summary": "The source supports trauma-care documentation, not a prerequisite relationship from trepanation.",
+    "source_support_rationale": "Trepanation is one possible surgical procedure elsewhere, but trauma wound care does not require it."
+  },
+  "ontology_before": "The graph treated primitive surgery/trepanation as a direct enabler of battlefield_wound_care.",
+  "ontology_after": "The graph treats Edwin Smith trauma care as a documented clinical wound-care tradition without a trepanation prerequisite.",
+  "invariant_preserved_or_changed": "Changed: primitive_surgery_trepanation is absent as a direct prerequisite for battlefield_wound_care.",
+  "would_reject_if": [
+    "The node were rescoped narrowly to cranial trepanation after battlefield injury.",
+    "A source established trepanation as necessary for the scoped Edwin Smith trauma-care procedures."
+  ],
+  "short_reason": "Trepanation is not required for Edwin Smith trauma wound care.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/battlefield_wound_care.before.json /tmp/battlefield_wound_care.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-edwin-smith-trauma-care-scope.json
+++ b/docs/graph-invariants/2026-06-11-edwin-smith-trauma-care-scope.json
@@ -1,0 +1,24 @@
+{
+  "id": "2026-06-11-edwin-smith-trauma-care-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "battlefield_wound_care",
+      "operator": "eq",
+      "value": -1600,
+      "reason": "The node is scoped to the surviving Edwin Smith Papyrus trauma-care text around 1600 BCE."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "battlefield_wound_care",
+      "prerequisite": "primitive_surgery_trepanation",
+      "reason": "Trepanation is not a prerequisite for the scoped trauma wound-care procedures."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "battlefield_wound_care",
+      "prerequisite": "herbal_medicine_preparation",
+      "reason": "Herbal preparation must not be used as a generic prerequisite for documented trauma-care procedures."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node correction for `battlefield_wound_care`.

## Old Claim
- Broad `Battlefield Wound Care`, dated `-3000`, global placeholder.
- No node sources.
- Direct prerequisites: `primitive_surgery_trepanation`, `herbal_medicine_preparation`.

## New Claim
- Rescoped to `Edwin Smith Trauma Wound Care`.
- Date: `-1600`, `datePrecision: century`.
- Region: Ancient Egypt.
- Source-checked to documented trauma/wound-care procedures in the Edwin Smith Papyrus.
- Removed weak generic prerequisites; no direct prerequisites remain.

## Sources / Locators
- Encyclopaedia Britannica, `Edwin Smith papyrus`:
  https://www.britannica.com/topic/Edwin-Smith-papyrus
  - Locator: describes the papyrus as written in ancient Egypt about 1600 BCE and containing 48 injury cases with examination, diagnosis, treatment, and prognosis.
- European Spine Journal / PMC, `The Edwin Smith papyrus: a clinical reappraisal of the oldest known document on spinal injuries`:
  https://pmc.ncbi.nlm.nih.gov/articles/PMC2989268/
  - Locator: abstract/summary describes wounds, injuries, fractures, and practical treatments including bandaging/splints.

## Edge Changes
- Removed `primitive_surgery_trepanation -> battlefield_wound_care`.
- Removed `herbal_medicine_preparation -> battlefield_wound_care`.
- Added two receipts and one invariant.

## Why This Is Better
The previous node used an unsourced broad battlefield-medicine label and generic prerequisites. The new scope is pinned to a surviving ancient medical text and avoids treating adjacent ancient medicine categories as prerequisites.

## Adversarial Note
Strongest reason this could be wrong: the stable id still includes `battlefield_wound_care`, while the new name is broader clinical trauma care from the Edwin Smith Papyrus. A later ontology pass could split formal battlefield medicine from documented ancient trauma-care manuals.

## Validation
Passed:
- `npm run edge-receipts`
- `npm run graph-invariants && npm run invariant-coverage`
- `npm run node-snapshot-diff -- /tmp/battlefield_wound_care.before.json /tmp/battlefield_wound_care.after.json --require-behavior-change`
- `npm run agent:check -- --run`
- `npm run source-urls`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`