### PR TITLE
Source-check Katanda bone harpoons

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 639 / 1,660 (38.5%) |
-| Nodes with node-level sources | 673 / 1,660 (40.5%) |
-| Dependency edges with edge-level sources | 1,917 / 5,517 (34.7%) |
-| Era-default placeholder dates | 535 / 1,660 (32.2%) |
+| Source-checked nodes | 640 / 1,660 (38.6%) |
+| Nodes with node-level sources | 674 / 1,660 (40.6%) |
+| Dependency edges with edge-level sources | 1,918 / 5,516 (34.8%) |
+| Era-default placeholder dates | 534 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Full generated snapshot: [docs/QUALITY_SNAPSHOT.md](docs/QUALITY_SNAPSHOT.md).

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -9160,35 +9160,53 @@
   },
   {
     "id": "fishing_spear_gigs",
-    "name": "Fishing Spears & Gigs",
+    "name": "Katanda Bone Harpoon Points",
     "era": "Ancient",
-    "description": "Barbed spears, multi-pronged gigs, and night-fishing tools for shallow water and river harvests.",
+    "description": "Barbed bone harpoon points from Katanda used for spearing large freshwater fish in Central Africa.",
     "prerequisites": [
-      "archery",
-      "fire_control"
+      "bone_tool_making"
     ],
-    "firstKnownDate": -10000,
+    "firstKnownDate": -90000,
     "datePrecision": "millennium",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "region": "Katanda, Democratic Republic of Congo",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
-        "prerequisite": "archery",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Archery provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "fire_control",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Fire Control is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated"
+        "prerequisite": "bone_tool_making",
+        "type": "required",
+        "confidence": 0.9,
+        "evidence_level": "textbook",
+        "note": "The scoped artifact is a worked bone harpoon point; bone tool-making capability is required for producing it.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Katanda Bone Harpoon Point",
+            "url": "https://humanorigins.si.edu/evidence/behavior/getting-food/katanda-bone-harpoon-point",
+            "publisher": "Smithsonian National Museum of Natural History",
+            "year": 2022,
+            "source_type": "museum",
+            "supports": [
+              "node",
+              "edge"
+            ]
+          }
+        ]
       }
-    ]
+    ],
+    "sources": [
+      {
+        "title": "Katanda Bone Harpoon Point",
+        "url": "https://humanorigins.si.edu/evidence/behavior/getting-food/katanda-bone-harpoon-point",
+        "publisher": "Smithsonian National Museum of Natural History",
+        "year": 2022,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "scopeNote": "Covers the Katanda barbed bone harpoon/fishing points dated about 90,000-80,000 years ago, not all fishing spears, gigs, bowfishing, or fire-assisted night fishing."
   },
   {
     "id": "loom_weights",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T21:11:07.823Z",
+  "generatedAt": "2026-06-11T22:25:34.724Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,30 +11,30 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 639,
+      "value": 640,
       "denominator": 1660,
-      "formatted": "639 / 1,660",
-      "note": "38.5%"
+      "formatted": "640 / 1,660",
+      "note": "38.6%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 673,
+      "value": 674,
       "denominator": 1660,
-      "formatted": "673 / 1,660",
-      "note": "40.5%"
+      "formatted": "674 / 1,660",
+      "note": "40.6%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1917,
-      "denominator": 5517,
-      "formatted": "1,917 / 5,517",
-      "note": "34.7%"
+      "value": 1918,
+      "denominator": 5516,
+      "formatted": "1,918 / 5,516",
+      "note": "34.8%"
     },
     {
       "label": "Era-default placeholder dates",
-      "value": 535,
+      "value": 534,
       "denominator": 1660,
-      "formatted": "535 / 1,660",
+      "formatted": "534 / 1,660",
       "note": "32.2%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 673,
-    "sourceChecked": 639,
+    "nodesWithSources": 674,
+    "sourceChecked": 640,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
-    "eraDefaultDates": 535,
+    "eraDefaultDates": 534,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5517,
-    "edgesWithSources": 1917
+    "totalEdges": 5516,
+    "edgesWithSources": 1918
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,16 +1,16 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T21:11:07.823Z
+Generated: 2026-06-11T22:25:34.724Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 639 / 1,660 (38.5%) |
-| Nodes with node-level sources | 673 / 1,660 (40.5%) |
-| Dependency edges with edge-level sources | 1,917 / 5,517 (34.7%) |
-| Era-default placeholder dates | 535 / 1,660 (32.2%) |
+| Source-checked nodes | 640 / 1,660 (38.6%) |
+| Nodes with node-level sources | 674 / 1,660 (40.6%) |
+| Dependency edges with edge-level sources | 1,918 / 5,516 (34.8%) |
+| Era-default placeholder dates | 534 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 
 Manual sample source: [docs/ACCURACY_SAMPLE_2026-06-06.md](ACCURACY_SAMPLE_2026-06-06.md)

--- a/docs/edge-change-receipts/2026-06-11-katanda-harpoon-archery-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-katanda-harpoon-archery-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-katanda-harpoon-archery-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "fishing_spear_gigs",
+    "prerequisite": "archery"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Archery provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from archery to fishing_spear_gigs. The scoped Katanda artifacts are barbed bone harpoon points for spearing fish, not bow-and-arrow technology.",
+  "source_supports_edge": "no",
+  "source_url": "https://humanorigins.si.edu/evidence/behavior/getting-food/katanda-bone-harpoon-point",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Katanda Bone Harpoon Point page: identifies the artifact as a barbed harpoon point from Katanda used to spear large fish, dated about 90,000-80,000 years old.",
+    "source_claim_summary": "The source supports bone harpoon fishing technology, not archery.",
+    "source_support_rationale": "Archery is a separate projectile technology and should not be modeled as a prerequisite for Katanda harpoon points."
+  },
+  "ontology_before": "The graph treated archery as a direct enabler of fishing spears and gigs.",
+  "ontology_after": "The graph separates bone harpoon fishing technology from bow-and-arrow technology.",
+  "invariant_preserved_or_changed": "Changed: archery is absent as a direct prerequisite for fishing_spear_gigs.",
+  "would_reject_if": [
+    "The node were rescoped to bowfishing technology.",
+    "A source showed the Katanda bone harpoon points depended on bow-and-arrow technology."
+  ],
+  "short_reason": "Katanda harpoons are not archery technology.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/fishing_spear_gigs.before.json /tmp/fishing_spear_gigs.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-katanda-harpoon-bone-tool-required.json
+++ b/docs/edge-change-receipts/2026-06-11-katanda-harpoon-bone-tool-required.json
@@ -1,0 +1,50 @@
+{
+  "id": "2026-06-11-katanda-harpoon-bone-tool-required",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "replaced_edge": {
+    "dependent": "fishing_spear_gigs",
+    "prerequisite": "archery"
+  },
+  "edge": {
+    "dependent": "fishing_spear_gigs",
+    "prerequisite": "bone_tool_making"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Archery provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.9,
+    "evidence_level": "textbook",
+    "note": "The scoped artifact is a worked bone harpoon point; bone tool-making capability is required for producing it."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://humanorigins.si.edu/evidence/behavior/getting-food/katanda-bone-harpoon-point",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Katanda Bone Harpoon Point page: names the artifact as a bone harpoon point with barbed points for spearing fish.",
+    "source_claim_summary": "The source identifies the technology as a worked bone harpoon point.",
+    "source_support_rationale": "Because the scoped artifact is made from bone, bone tool-making is the direct material/manufacturing prerequisite."
+  },
+  "ontology_before": "The graph used archery as the direct technology input for fishing spears and gigs.",
+  "ontology_after": "The graph uses bone tool-making as the direct manufacturing basis for the scoped Katanda bone harpoon points.",
+  "invariant_preserved_or_changed": "Changed: bone_tool_making is the required prerequisite for fishing_spear_gigs.",
+  "would_reject_if": [
+    "The node were broadened away from bone harpoon points to wooden fishing spears or metal gigs.",
+    "A source showed the scoped Katanda artifacts were not bone tools."
+  ],
+  "short_reason": "Katanda bone harpoon points require bone tool-making, not archery.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/fishing_spear_gigs.before.json /tmp/fishing_spear_gigs.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-katanda-harpoon-fire-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-katanda-harpoon-fire-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-katanda-harpoon-fire-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "fishing_spear_gigs",
+    "prerequisite": "fire_control"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Fire Control is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from fire_control to fishing_spear_gigs. The scoped Katanda evidence supports barbed bone harpoon points for spearing fish, not fire-assisted night fishing or fire as a technical predecessor.",
+  "source_supports_edge": "no",
+  "source_url": "https://humanorigins.si.edu/evidence/behavior/getting-food/katanda-bone-harpoon-point",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Katanda Bone Harpoon Point page: describes barbed harpoon points used to spear large prehistoric catfish and gives the Katanda age/site; it does not mention fire as part of the technology.",
+    "source_claim_summary": "The source supports worked bone fishing points without a fire-control dependency.",
+    "source_support_rationale": "Fire may be relevant to some fishing methods, but it is not source-backed as a direct prerequisite for the Katanda bone harpoon points."
+  },
+  "ontology_before": "The graph treated fire_control as a historical predecessor for fishing spears and gigs.",
+  "ontology_after": "The graph keeps the Katanda harpoon node tied to worked bone technology rather than generic fire context.",
+  "invariant_preserved_or_changed": "Changed: fire_control is absent as a direct prerequisite for fishing_spear_gigs.",
+  "would_reject_if": [
+    "The node were rescoped to fire-assisted night fishing or torch fishing.",
+    "A source showed fire control was necessary for producing or using the Katanda harpoon points."
+  ],
+  "short_reason": "Fire control is not a source-backed prerequisite for Katanda bone harpoon points.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/fishing_spear_gigs.before.json /tmp/fishing_spear_gigs.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-katanda-bone-harpoon-scope.json
+++ b/docs/graph-invariants/2026-06-11-katanda-bone-harpoon-scope.json
@@ -1,0 +1,31 @@
+{
+  "id": "2026-06-11-katanda-bone-harpoon-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "fishing_spear_gigs",
+      "operator": "eq",
+      "value": -90000,
+      "reason": "The node is scoped to Katanda bone harpoon points dated about 90,000-80,000 years old."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "fishing_spear_gigs",
+      "prerequisite": "bone_tool_making",
+      "expected": "required",
+      "reason": "The scoped artifact is a worked bone harpoon point."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "fishing_spear_gigs",
+      "prerequisite": "archery",
+      "reason": "Katanda bone harpoon points are not bow-and-arrow technology."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "fishing_spear_gigs",
+      "prerequisite": "fire_control",
+      "reason": "Fire control is not source-backed as a direct prerequisite for the Katanda bone harpoon points."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node correction for `fishing_spear_gigs`.

## Old Claim
- Broad `Fishing Spears & Gigs`, ancient placeholder date `-10000`, global scope.
- No node sources.
- Direct prerequisites: `archery`, `fire_control`.

## New Claim
- Rescoped to `Katanda Bone Harpoon Points`.
- Date: `-90000`, `datePrecision: millennium`.
- Region: Katanda, Democratic Republic of Congo.
- Direct prerequisite changed to `bone_tool_making`, typed `required` with edge source.
- Removed weak/false `archery` and `fire_control` prerequisites.

## Source / Locator
- Smithsonian National Museum of Natural History, `Katanda Bone Harpoon Point`:
  https://humanorigins.si.edu/evidence/behavior/getting-food/katanda-bone-harpoon-point
  - Locator: page identifies the artifact as a Katanda bone harpoon point with barbed points for spearing fish; site is Katanda, Democratic Republic of Congo; age is about 90,000-80,000 years old.

## Edge Changes
- Added `bone_tool_making -> fishing_spear_gigs` as `required`.
- Removed `archery -> fishing_spear_gigs`.
- Removed `fire_control -> fishing_spear_gigs`.
- Added three edge-change receipts and one graph invariant.

## Why This Is Better
The old node mixed later/general fishing spear ideas with unsupported prerequisites. The corrected node is pinned to a concrete archaeological object class and uses the direct manufacturing prerequisite supported by the source: worked bone tool production.

## Adversarial Note
Strongest reason this could be wrong: the stable id still says `fishing_spear_gigs`, while the corrected scope is specifically Katanda bone harpoon points. A later ontology pass may split general fishing spear/gig technologies from this source-attested Paleolithic bone harpoon node.

## Validation
Passed:
- `npm run edge-receipts`
- `npm run graph-invariants && npm run invariant-coverage`
- `npm run node-snapshot-diff -- /tmp/fishing_spear_gigs.before.json /tmp/fishing_spear_gigs.after.json --require-behavior-change`
- `npm run agent:check -- --run`
- `npm run source-urls`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`