### PR TITLE
Source-check Sintashta chariots

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 640 / 1,660 (38.6%) |
-| Nodes with node-level sources | 674 / 1,660 (40.6%) |
-| Dependency edges with edge-level sources | 1,918 / 5,516 (34.8%) |
+| Source-checked nodes | 641 / 1,660 (38.6%) |
+| Nodes with node-level sources | 675 / 1,660 (40.7%) |
+| Dependency edges with edge-level sources | 1,920 / 5,514 (34.8%) |
 | Era-default placeholder dates | 534 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -5652,53 +5652,75 @@
   },
   {
     "id": "chariot",
-    "name": "Chariot",
+    "name": "Sintashta-Petrovka Early Chariots",
     "era": "Ancient",
-    "description": "A light, two-wheeled vehicle pulled by horses, used as a prestigious and powerful platform for archery and warfare.",
+    "description": "Early light horse-drawn chariots of the Sintashta-Petrovka complex, evidenced by spoked-wheel pits, horse teams, and horse tack.",
     "prerequisites": [
       "wheeled_vehicles",
-      "horseback_riding",
-      "bronze_working",
-      "archery"
+      "yokes_and_harnesses"
     ],
     "firstKnownDate": -2000,
-    "datePrecision": "century",
-    "region": "Eurasian steppe and Near East",
-    "reviewStatus": "structurally_validated",
+    "datePrecision": "decade",
+    "region": "Sintashta-Petrovka complex, Central Eurasian Steppe",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "wheeled_vehicles",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Wheeled Vehicles provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "required",
+        "confidence": 0.9,
+        "evidence_level": "review",
+        "note": "The scoped chariot evidence includes pits for spoked wheels, so wheeled-vehicle technology is required for the chariot artifact class.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Chariots in the Eurasian Steppe: a Bayesian approach to the emergence of horse-drawn transport in the early second millennium BC",
+            "url": "https://www.cambridge.org/core/journals/antiquity/article/chariots-in-the-eurasian-steppe-a-bayesian-approach-to-the-emergence-of-horsedrawn-transport-in-the-early-second-millennium-bc/C4FDF8C5E7D1D20A28BEB7F6C50A9AF4",
+            "publisher": "Antiquity / Cambridge University Press",
+            "year": 2020,
+            "source_type": "review",
+            "supports": [
+              "node",
+              "edge"
+            ]
+          }
+        ]
       },
       {
-        "prerequisite": "horseback_riding",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Horseback Riding provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "bronze_working",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Bronze Working provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "archery",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Archery provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "prerequisite": "yokes_and_harnesses",
+        "type": "required",
+        "confidence": 0.86,
+        "evidence_level": "review",
+        "note": "The scoped chariots are horse-drawn vehicles with horse teams and tack, so traction harnessing is required.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Chariots in the Eurasian Steppe: a Bayesian approach to the emergence of horse-drawn transport in the early second millennium BC",
+            "url": "https://www.cambridge.org/core/journals/antiquity/article/chariots-in-the-eurasian-steppe-a-bayesian-approach-to-the-emergence-of-horsedrawn-transport-in-the-early-second-millennium-bc/C4FDF8C5E7D1D20A28BEB7F6C50A9AF4",
+            "publisher": "Antiquity / Cambridge University Press",
+            "year": 2020,
+            "source_type": "review",
+            "supports": [
+              "node",
+              "edge"
+            ]
+          }
+        ]
       }
-    ]
+    ],
+    "sources": [
+      {
+        "title": "Chariots in the Eurasian Steppe: a Bayesian approach to the emergence of horse-drawn transport in the early second millennium BC",
+        "url": "https://www.cambridge.org/core/journals/antiquity/article/chariots-in-the-eurasian-steppe-a-bayesian-approach-to-the-emergence-of-horsedrawn-transport-in-the-early-second-millennium-bc/C4FDF8C5E7D1D20A28BEB7F6C50A9AF4",
+        "publisher": "Antiquity / Cambridge University Press",
+        "year": 2020,
+        "source_type": "review",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "scopeNote": "Covers source-attested early horse-drawn Sintashta-Petrovka chariots around the turn of the second millennium BCE. It does not cover later Near Eastern chariot warfare, chariot archery, racing, or generic horse riding."
   },
   {
     "id": "organized_warfare",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T22:25:34.724Z",
+  "generatedAt": "2026-06-11T22:33:04.188Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,23 +11,23 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 640,
+      "value": 641,
       "denominator": 1660,
-      "formatted": "640 / 1,660",
+      "formatted": "641 / 1,660",
       "note": "38.6%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 674,
+      "value": 675,
       "denominator": 1660,
-      "formatted": "674 / 1,660",
-      "note": "40.6%"
+      "formatted": "675 / 1,660",
+      "note": "40.7%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1918,
-      "denominator": 5516,
-      "formatted": "1,918 / 5,516",
+      "value": 1920,
+      "denominator": 5514,
+      "formatted": "1,920 / 5,514",
       "note": "34.8%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 674,
-    "sourceChecked": 640,
+    "nodesWithSources": 675,
+    "sourceChecked": 641,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 534,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5516,
-    "edgesWithSources": 1918
+    "totalEdges": 5514,
+    "edgesWithSources": 1920
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,15 +1,15 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T22:25:34.724Z
+Generated: 2026-06-11T22:33:04.188Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 640 / 1,660 (38.6%) |
-| Nodes with node-level sources | 674 / 1,660 (40.6%) |
-| Dependency edges with edge-level sources | 1,918 / 5,516 (34.8%) |
+| Source-checked nodes | 641 / 1,660 (38.6%) |
+| Nodes with node-level sources | 675 / 1,660 (40.7%) |
+| Dependency edges with edge-level sources | 1,920 / 5,514 (34.8%) |
 | Era-default placeholder dates | 534 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-11-sintashta-chariot-archery-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-sintashta-chariot-archery-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-sintashta-chariot-archery-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "chariot",
+    "prerequisite": "archery"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Archery provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from archery to chariot. Archery is a later or parallel use of chariots in warfare, not a prerequisite for the vehicle technology itself.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.cambridge.org/core/journals/antiquity/article/chariots-in-the-eurasian-steppe-a-bayesian-approach-to-the-emergence-of-horsedrawn-transport-in-the-early-second-millennium-bc/C4FDF8C5E7D1D20A28BEB7F6C50A9AF4",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Article scope and discussion: addresses emergence of horse-drawn transport and early chariot evidence, not archery as a technical prerequisite.",
+    "source_claim_summary": "The source supports early chariot vehicle emergence without requiring archery.",
+    "source_support_rationale": "Archery can be an application of chariots, but it is not a component or production method."
+  },
+  "ontology_before": "The graph treated archery as a direct enabler of chariots.",
+  "ontology_after": "The graph separates chariot vehicle technology from later chariot archery use.",
+  "invariant_preserved_or_changed": "Changed: archery is absent as a direct prerequisite for chariot.",
+  "would_reject_if": [
+    "The node were rescoped specifically to chariot archery tactics.",
+    "A source established bow technology as necessary for the scoped chariot artifact."
+  ],
+  "short_reason": "Archery is not a prerequisite for early chariot vehicle technology.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/chariot.before.json /tmp/chariot.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-sintashta-chariot-bronze-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-sintashta-chariot-bronze-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-sintashta-chariot-bronze-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "chariot",
+    "prerequisite": "bronze_working"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Bronze Working provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from bronze_working to chariot. The scoped source supports chariot evidence through spoked wheels, horse teams, and horse tack, not bronze working as a direct prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.cambridge.org/core/journals/antiquity/article/chariots-in-the-eurasian-steppe-a-bayesian-approach-to-the-emergence-of-horsedrawn-transport-in-the-early-second-millennium-bc/C4FDF8C5E7D1D20A28BEB7F6C50A9AF4",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Discussion of early chariot evidence: describes wheel pits, radiocarbon dates, ceramics, and horse tack rather than a bronze-working prerequisite.",
+    "source_claim_summary": "The source does not make bronze working a direct prerequisite for early chariots.",
+    "source_support_rationale": "Bronze may occur in Bronze Age contexts, but the direct chariot technology is vehicle and traction architecture."
+  },
+  "ontology_before": "The graph treated bronze working as a direct enabler of chariots.",
+  "ontology_after": "The graph avoids using broad Bronze Age material context as a chariot prerequisite.",
+  "invariant_preserved_or_changed": "Changed: bronze_working is absent as a direct prerequisite for chariot.",
+  "would_reject_if": [
+    "The node were rescoped to bronze chariot fittings specifically.",
+    "A source showed bronze-working was necessary for the scoped Sintashta-Petrovka chariots."
+  ],
+  "short_reason": "Bronze working is not source-backed as a direct chariot prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/chariot.before.json /tmp/chariot.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-sintashta-chariot-harness-required.json
+++ b/docs/edge-change-receipts/2026-06-11-sintashta-chariot-harness-required.json
@@ -1,0 +1,50 @@
+{
+  "id": "2026-06-11-sintashta-chariot-harness-required",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "replaced_edge": {
+    "dependent": "chariot",
+    "prerequisite": "horseback_riding"
+  },
+  "edge": {
+    "dependent": "chariot",
+    "prerequisite": "yokes_and_harnesses"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Horseback Riding provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.86,
+    "evidence_level": "review",
+    "note": "The scoped chariots are horse-drawn vehicles with horse teams and tack, so traction harnessing is required."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.cambridge.org/core/journals/antiquity/article/chariots-in-the-eurasian-steppe-a-bayesian-approach-to-the-emergence-of-horsedrawn-transport-in-the-early-second-millennium-bc/C4FDF8C5E7D1D20A28BEB7F6C50A9AF4",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Discussion of Sintashta light chariots: identifies horse teams and horse tack associated with the early chariot evidence.",
+    "source_claim_summary": "The source supports traction equipment for horse-drawn chariots.",
+    "source_support_rationale": "For horse-drawn chariots, harness/tack capability is the direct traction prerequisite."
+  },
+  "ontology_before": "The graph modeled horse riding as the direct animal-use prerequisite.",
+  "ontology_after": "The graph models traction harnessing as the direct animal-use prerequisite for horse-drawn chariots.",
+  "invariant_preserved_or_changed": "Changed: yokes_and_harnesses is required and horseback_riding is absent.",
+  "would_reject_if": [
+    "A narrower horse tack node is added and this edge is rewired to it.",
+    "The chariot node is broadened away from horse-drawn chariots."
+  ],
+  "short_reason": "Horse-drawn chariots require harness/tack, not horseback riding.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/chariot.before.json /tmp/chariot.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-sintashta-chariot-horseback-removal.json
+++ b/docs/edge-change-receipts/2026-06-11-sintashta-chariot-horseback-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-11-sintashta-chariot-horseback-removal",
+  "decision_date": "2026-06-11",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "chariot",
+    "prerequisite": "horseback_riding"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Horseback Riding provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from horseback_riding to chariot. The scoped source supports horse-drawn chariots with horse teams and tack, not ridden mounts as a prerequisite.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.cambridge.org/core/journals/antiquity/article/chariots-in-the-eurasian-steppe-a-bayesian-approach-to-the-emergence-of-horsedrawn-transport-in-the-early-second-millennium-bc/C4FDF8C5E7D1D20A28BEB7F6C50A9AF4",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Discussion of early chariots and horse teams: supports horse-drawn transport and horse tack, not mounted horseback riding as a production prerequisite.",
+    "source_claim_summary": "The source supports horse-drawn vehicle technology rather than ridden mounts.",
+    "source_support_rationale": "Horseback riding and horse-drawn vehicle traction are distinct technologies in the graph."
+  },
+  "ontology_before": "The graph treated ridden horse use as a direct enabler of chariots.",
+  "ontology_after": "The graph separates ridden mounts from horse-drawn chariot traction.",
+  "invariant_preserved_or_changed": "Changed: horseback_riding is absent as a direct prerequisite for chariot.",
+  "would_reject_if": [
+    "The node were rescoped to mounted horse archery or cavalry.",
+    "A source showed ridden-horse technology was necessary for the scoped chariot assemblage."
+  ],
+  "short_reason": "Chariots are horse-drawn vehicles, not horseback riding.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/chariot.before.json /tmp/chariot.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-11-sintashta-chariot-wheeled-vehicles-required.json
+++ b/docs/edge-change-receipts/2026-06-11-sintashta-chariot-wheeled-vehicles-required.json
@@ -1,0 +1,46 @@
+{
+  "id": "2026-06-11-sintashta-chariot-wheeled-vehicles-required",
+  "decision_date": "2026-06-11",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "chariot",
+    "prerequisite": "wheeled_vehicles"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Wheeled Vehicles provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.9,
+    "evidence_level": "review",
+    "note": "The scoped chariot evidence includes pits for spoked wheels, so wheeled-vehicle technology is required for the chariot artifact class."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.cambridge.org/core/journals/antiquity/article/chariots-in-the-eurasian-steppe-a-bayesian-approach-to-the-emergence-of-horsedrawn-transport-in-the-early-second-millennium-bc/C4FDF8C5E7D1D20A28BEB7F6C50A9AF4",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Discussion of Sintashta evidence: describes light chariots, pits for spoked wheels, radiocarbon dates, and horse teams around the turn of the second millennium BC.",
+    "source_claim_summary": "The source identifies wheel evidence as part of the early chariot assemblage.",
+    "source_support_rationale": "A chariot is a wheeled vehicle; for this scoped artifact class, wheeled-vehicle technology is required rather than merely enabling."
+  },
+  "ontology_before": "The graph treated wheeled vehicles as a generic enabler for chariots.",
+  "ontology_after": "The graph treats wheeled vehicles as a required component class for the scoped chariot node.",
+  "invariant_preserved_or_changed": "Changed: wheeled_vehicles is required for chariot.",
+  "would_reject_if": [
+    "The node were broadened to include non-wheeled sledges or horse-drawn platforms.",
+    "The source did not identify wheel evidence as part of the scoped chariot assemblage."
+  ],
+  "short_reason": "Early chariots require wheeled-vehicle technology.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/chariot.before.json /tmp/chariot.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-11-sintashta-chariot-scope.json
+++ b/docs/graph-invariants/2026-06-11-sintashta-chariot-scope.json
@@ -1,0 +1,44 @@
+{
+  "id": "2026-06-11-sintashta-chariot-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "chariot",
+      "operator": "eq",
+      "value": -2000,
+      "reason": "The node is scoped to early Sintashta-Petrovka chariots around the turn of the second millennium BCE."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "chariot",
+      "prerequisite": "wheeled_vehicles",
+      "expected": "required",
+      "reason": "A chariot is a wheeled vehicle artifact class."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "chariot",
+      "prerequisite": "yokes_and_harnesses",
+      "expected": "required",
+      "reason": "Horse-drawn chariots require traction harness/tack capability."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "chariot",
+      "prerequisite": "horseback_riding",
+      "reason": "Ridden mounts are not a prerequisite for horse-drawn chariots."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "chariot",
+      "prerequisite": "bronze_working",
+      "reason": "Bronze working must not stand in as unsourced broad Bronze Age context."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "chariot",
+      "prerequisite": "archery",
+      "reason": "Chariot archery is an application, not a prerequisite for chariot vehicle technology."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
One-node correction for `chariot`.

## Old Claim
- Broad `Chariot`, dated `-2000` with century precision.
- No node sources.
- Direct prerequisites: `wheeled_vehicles`, `horseback_riding`, `bronze_working`, `archery`.

## New Claim
- Rescoped to `Sintashta-Petrovka Early Chariots`.
- Date: `-2000`, `datePrecision: decade`.
- Region: Sintashta-Petrovka complex, Central Eurasian Steppe.
- Direct prerequisites now:
  - `wheeled_vehicles`, typed `required`
  - `yokes_and_harnesses`, typed `required`
- Removed `horseback_riding`, `bronze_working`, and `archery` as direct prerequisites.

## Source / Locator
- Antiquity / Cambridge University Press, `Chariots in the Eurasian Steppe: a Bayesian approach to the emergence of horse-drawn transport in the early second millennium BC`:
  https://www.cambridge.org/core/journals/antiquity/article/chariots-in-the-eurasian-steppe-a-bayesian-approach-to-the-emergence-of-horsedrawn-transport-in-the-early-second-millennium-bc/C4FDF8C5E7D1D20A28BEB7F6C50A9AF4
  - Locator: article discusses early Sintashta-Petrovka horse-drawn transport/chariot evidence, spoked-wheel pits, horse teams, horse tack, and dates around the turn of the second millennium BCE.

## Edge Changes
- `wheeled_vehicles -> chariot`: `enabling` -> `required`.
- Replaced ridden-mount dependency with traction gear: `horseback_riding` removed, `yokes_and_harnesses` added as `required`.
- Removed `bronze_working -> chariot`.
- Removed `archery -> chariot`.
- Added five edge-change receipts and one graph invariant.

## Why This Is Better
The previous node mixed chariot construction, later warfare use, and broad Bronze Age context. The corrected scope follows the source: early horse-drawn chariot vehicle evidence. Riding and archery are not prerequisites for the vehicle itself, and bronze working is not source-backed as a direct dependency.

## Adversarial Note
Strongest reason this could be wrong: `yokes_and_harnesses` is broader than horse tack. A later ontology pass could add a narrower `horse_tack` or `chariot_harness` node and rewire this edge there.

## Validation
Passed:
- `npm run edge-receipts`
- `npm run graph-invariants && npm run invariant-coverage`
- `npm run node-snapshot-diff -- /tmp/chariot.before.json /tmp/chariot.after.json --require-behavior-change`
- `npm run agent:check -- --run`
- `npm run source-urls`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`