### PR TITLE
Source-check Ur III clay tablet receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@
 <!-- QUALITY_SNAPSHOT_START -->
 ## Quality Snapshot
 
-Generated 2026-06-11 from the same dataset audit used by `npm run accuracy:risks`. This is a trust snapshot, not proof of global accuracy.
+Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks`. This is a trust snapshot, not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 641 / 1,660 (38.6%) |
-| Nodes with node-level sources | 675 / 1,660 (40.7%) |
+| Source-checked nodes | 642 / 1,660 (38.7%) |
+| Nodes with node-level sources | 676 / 1,660 (40.7%) |
 | Dependency edges with edge-level sources | 1,920 / 5,514 (34.8%) |
 | Era-default placeholder dates | 534 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -9915,12 +9915,12 @@
   },
   {
     "id": "clay_tablet_receipts",
-    "name": "Clay Tablet Receipts",
+    "name": "Ur III Clay Tablet Receipts",
     "era": "Ancient",
-    "description": "Portable written records for deliveries, taxes, debts, wages, and warehouse movements.",
+    "description": "Neo-Sumerian clay cuneiform receipt tablets recording deliveries or receipts of goods within Ur III administration.",
     "prerequisites": [
       "writing",
-      "pottery"
+      "clay_gathering_and_preparation"
     ],
     "fields": [
       "Finance & Markets"
@@ -9928,52 +9928,77 @@
     "fieldLanes": {
       "Finance & Markets": "Money & Accounting"
     },
-    "firstKnownDate": -3000,
-    "datePrecision": "century",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "sources": [
+      {
+        "title": "Cuneiform tablet: receipt of cattle",
+        "url": "https://www.metmuseum.org/art/collection/search/322446",
+        "publisher": "The Metropolitan Museum of Art",
+        "year": 2026,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Cuneiform tablet: receipt of metals",
+        "url": "https://www.metmuseum.org/art/collection/search/324589",
+        "publisher": "The Metropolitan Museum of Art",
+        "year": 2026,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      }
+    ],
+    "firstKnownDate": -2041,
+    "datePrecision": "decade",
+    "region": "Ur III Mesopotamia, including Drehem (ancient Puzrish-Dagan) and Nippur",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "writing",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Writing is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated",
+        "type": "required",
+        "confidence": 0.9,
+        "evidence_level": "primary_source",
+        "note": "The scoped receipts are cuneiform tablets; a written sign system is required for the receipt record.",
+        "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Writing",
-            "url": "https://en.wikipedia.org/wiki/Writing",
-            "source_type": "weak_web",
+            "title": "Cuneiform tablet: receipt of cattle",
+            "url": "https://www.metmuseum.org/art/collection/search/322446",
+            "publisher": "The Metropolitan Museum of Art",
+            "year": 2026,
+            "source_type": "museum",
             "supports": [
               "edge"
-            ],
-            "publisher": "Wikipedia",
-            "year": 2026
+            ]
           }
         ]
       },
       {
-        "prerequisite": "pottery",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Pottery provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated",
+        "prerequisite": "clay_gathering_and_preparation",
+        "type": "required",
+        "confidence": 0.84,
+        "evidence_level": "primary_source",
+        "note": "The scoped receipts are clay tablets, so prepared clay suitable for inscription is the direct material prerequisite; fired pottery vessels are not required.",
+        "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Pottery",
-            "url": "https://en.wikipedia.org/wiki/Pottery",
-            "source_type": "weak_web",
+            "title": "Cuneiform tablet: receipt of metals",
+            "url": "https://www.metmuseum.org/art/collection/search/324589",
+            "publisher": "The Metropolitan Museum of Art",
+            "year": 2026,
+            "source_type": "museum",
             "supports": [
               "edge"
-            ],
-            "publisher": "Wikipedia",
-            "year": 2026
+            ]
           }
         ]
       }
-    ]
+    ],
+    "scopeNote": "Scoped to preserved Ur III administrative cuneiform receipt tablets made of clay; this node should not stand for all early accounting, all writing, or fired ceramic pottery."
   },
   {
     "id": "oil_wick_lamps",

--- a/data/modern.json
+++ b/data/modern.json
@@ -33759,11 +33759,11 @@
         ]
       },
       {
-        "title": "Combined Cycles: A Brief History and Evolution of Cycles",
-        "url": "https://www.softinway.com/combined-cycles-a-brief-history-and-evolution-of-cycles/",
-        "publisher": "SoftInWay",
-        "year": 2021,
-        "source_type": "generic_overview",
+        "title": "Most combined-cycle power plants employ two combustion turbines with one steam turbine",
+        "url": "https://www.eia.gov/todayinenergy/detail.php?id=52158",
+        "publisher": "U.S. Energy Information Administration",
+        "year": 2022,
+        "source_type": "official_agency",
         "supports": [
           "node",
           "maturity"
@@ -33779,16 +33779,16 @@
         "prerequisite": "steam_turbine_power_generation",
         "type": "required",
         "confidence": 0.86,
-        "evidence_level": "review",
+        "evidence_level": "textbook",
         "note": "A combined-cycle gas-turbine plant couples a gas-turbine topping cycle to a steam-turbine bottoming cycle.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Combined Cycles: A Brief History and Evolution of Cycles",
-            "url": "https://www.softinway.com/combined-cycles-a-brief-history-and-evolution-of-cycles/",
-            "publisher": "SoftInWay",
-            "year": 2021,
-            "source_type": "generic_overview",
+            "title": "Most combined-cycle power plants employ two combustion turbines with one steam turbine",
+            "url": "https://www.eia.gov/todayinenergy/detail.php?id=52158",
+            "publisher": "U.S. Energy Information Administration",
+            "year": 2022,
+            "source_type": "official_agency",
             "supports": [
               "node",
               "edge"

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T22:33:04.188Z",
+  "generatedAt": "2026-06-12T14:14:13.266Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,16 +11,16 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 641,
+      "value": 642,
       "denominator": 1660,
-      "formatted": "641 / 1,660",
-      "note": "38.6%"
+      "formatted": "642 / 1,660",
+      "note": "38.7%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 675,
+      "value": 676,
       "denominator": 1660,
-      "formatted": "675 / 1,660",
+      "formatted": "676 / 1,660",
       "note": "40.7%"
     },
     {
@@ -54,8 +54,8 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 675,
-    "sourceChecked": 641,
+    "nodesWithSources": 676,
+    "sourceChecked": 642,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,14 +1,14 @@
 # Quality Snapshot
 
-Generated: 2026-06-11T22:33:04.188Z
+Generated: 2026-06-12T14:14:13.266Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 641 / 1,660 (38.6%) |
-| Nodes with node-level sources | 675 / 1,660 (40.7%) |
+| Source-checked nodes | 642 / 1,660 (38.7%) |
+| Nodes with node-level sources | 676 / 1,660 (40.7%) |
 | Dependency edges with edge-level sources | 1,920 / 5,514 (34.8%) |
 | Era-default placeholder dates | 534 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |

--- a/docs/edge-change-receipts/2026-06-12-clay-tablet-receipts-clay-preparation-replaces-pottery.json
+++ b/docs/edge-change-receipts/2026-06-12-clay-tablet-receipts-clay-preparation-replaces-pottery.json
@@ -1,0 +1,50 @@
+{
+  "id": "2026-06-12-clay-tablet-receipts-clay-preparation-replaces-pottery",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "replaced_edge": {
+    "dependent": "clay_tablet_receipts",
+    "prerequisite": "pottery"
+  },
+  "edge": {
+    "dependent": "clay_tablet_receipts",
+    "prerequisite": "clay_gathering_and_preparation"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Pottery provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.84,
+    "evidence_level": "primary_source",
+    "note": "The scoped receipts are clay tablets, so prepared clay suitable for inscription is the direct material prerequisite; fired pottery vessels are not required."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.metmuseum.org/art/collection/search/324589",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Object page details: 'Cuneiform tablet: receipt of metals', period Ur III, date ca. 2112-2004 BCE, medium clay.",
+    "source_claim_summary": "The source identifies the receipt tablet medium as clay.",
+    "source_support_rationale": "The direct material requirement is prepared clay for tablet inscription, not the broader technology of fired ceramic vessels."
+  },
+  "ontology_before": "The graph routed clay tablet receipts through pottery, implying fired ceramic vessel production was the relevant direct prerequisite.",
+  "ontology_after": "The graph routes clay tablet receipts through clay preparation as the direct material prerequisite and removes pottery as a false specificity.",
+  "invariant_preserved_or_changed": "Changed: clay_gathering_and_preparation is required and pottery is absent.",
+  "would_reject_if": [
+    "The node were rescoped to ceramic receipt vessels rather than inscribed clay tablets.",
+    "A source showed the scoped administrative receipt tablets were normally produced through pottery vessel manufacture."
+  ],
+  "short_reason": "Clay receipt tablets require prepared clay, not pottery.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/clay_tablet_receipts.before.json /tmp/clay_tablet_receipts.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-clay-tablet-receipts-writing-required.json
+++ b/docs/edge-change-receipts/2026-06-12-clay-tablet-receipts-writing-required.json
@@ -1,0 +1,46 @@
+{
+  "id": "2026-06-12-clay-tablet-receipts-writing-required",
+  "decision_date": "2026-06-12",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "clay_tablet_receipts",
+    "prerequisite": "writing"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Writing is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.9,
+    "evidence_level": "primary_source",
+    "note": "The scoped receipts are cuneiform tablets; a written sign system is required for the receipt record."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.metmuseum.org/art/collection/search/322446",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Object page title and details: 'Cuneiform tablet: receipt of cattle', period Ur III, date ca. 2041 BCE, medium clay.",
+    "source_claim_summary": "The object is a cuneiform receipt tablet.",
+    "source_support_rationale": "Because the scoped artifact is a written cuneiform receipt, writing is a direct requirement rather than only a historical predecessor."
+  },
+  "ontology_before": "The graph treated writing as general background for clay tablet receipts.",
+  "ontology_after": "The graph treats writing as a direct requirement for the scoped cuneiform receipt record.",
+  "invariant_preserved_or_changed": "Changed: writing is a required direct prerequisite for clay_tablet_receipts.",
+  "would_reject_if": [
+    "The node were rescoped to non-written counting tokens or sealed containers.",
+    "A narrower cuneiform-writing node is added and this edge is rewired to it."
+  ],
+  "short_reason": "Cuneiform receipt tablets require writing.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/clay_tablet_receipts.before.json /tmp/clay_tablet_receipts.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-combined-cycle-eia-source-replacement.json
+++ b/docs/edge-change-receipts/2026-06-12-combined-cycle-eia-source-replacement.json
@@ -1,0 +1,46 @@
+{
+  "id": "2026-06-12-combined-cycle-eia-source-replacement",
+  "decision_date": "2026-06-12",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "combined_cycle_gas_turbines",
+    "prerequisite": "steam_turbine_power_generation"
+  },
+  "old_claim": {
+    "type": "required",
+    "confidence": 0.86,
+    "evidence_level": "review",
+    "note": "A combined-cycle gas-turbine plant couples a gas-turbine topping cycle to a steam-turbine bottoming cycle.",
+    "source_url": "https://www.softinway.com/combined-cycles-a-brief-history-and-evolution-of-cycles/"
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.86,
+    "evidence_level": "textbook",
+    "note": "A combined-cycle gas-turbine plant couples a gas-turbine topping cycle to a steam-turbine bottoming cycle.",
+    "source_url": "https://www.eia.gov/todayinenergy/detail.php?id=52158"
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.eia.gov/todayinenergy/detail.php?id=52158",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "EIA Today in Energy, April 25, 2022: combined-cycle systems include combustion turbines and steam turbines and send combustion-turbine exhaust heat to a heat-recovery steam generator that pressurizes steam for steam turbines.",
+    "source_claim_summary": "EIA describes steam turbines as a component of combined-cycle systems.",
+    "source_support_rationale": "The source directly supports the existing required edge from combined-cycle gas turbines to steam-turbine power generation while replacing an unstable vendor URL."
+  },
+  "invariant_preserved_or_changed": "Preserved: steam_turbine_power_generation remains a required prerequisite for combined_cycle_gas_turbines.",
+  "would_reject_if": [
+    "The node were rescoped to a different combined-cycle architecture without a steam bottoming cycle.",
+    "The EIA page stopped describing steam turbines as combined-cycle components."
+  ],
+  "short_reason": "Replaced an unstable generic vendor URL with a stable official-agency source for the same required edge.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage",
+    "npm run source-urls"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-clay-tablet-receipts-scope.json
+++ b/docs/graph-invariants/2026-06-12-clay-tablet-receipts-scope.json
@@ -1,0 +1,32 @@
+{
+  "id": "2026-06-12-clay-tablet-receipts-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "clay_tablet_receipts",
+      "operator": "eq",
+      "value": -2041,
+      "reason": "The node is scoped to Ur III cuneiform receipt tablets, with a Met object dated ca. 2041 BCE."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "clay_tablet_receipts",
+      "prerequisite": "writing",
+      "expected": "required",
+      "reason": "The scoped receipts are written cuneiform records."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "clay_tablet_receipts",
+      "prerequisite": "clay_gathering_and_preparation",
+      "expected": "required",
+      "reason": "The scoped artifacts are clay tablets and require prepared clay suitable for inscription."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "clay_tablet_receipts",
+      "prerequisite": "pottery",
+      "reason": "Fired pottery vessels are not the direct material prerequisite for inscribed clay receipt tablets."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

Source-checked `clay_tablet_receipts` as `Ur III Clay Tablet Receipts` instead of a broad global placeholder.

Old claim:
- `Clay Tablet Receipts`
- `firstKnownDate: -3000`, `datePrecision: century`, `region: Global / multiple regions`
- `writing` as historical predecessor via weak Wikipedia source
- `pottery` as an enabling edge via weak Wikipedia source

New claim:
- Scoped to preserved Neo-Sumerian Ur III clay cuneiform receipt tablets
- `firstKnownDate: -2041`, `datePrecision: decade`
- `region: Ur III Mesopotamia, including Drehem (ancient Puzrish-Dagan) and Nippur`
- `writing` is `required` with Met object source
- `clay_gathering_and_preparation` replaces `pottery` as the direct required material prerequisite

Also replaced the timed-out SoftInWay combined-cycle source with the EIA official-agency page for the existing `combined_cycle_gas_turbines -> steam_turbine_power_generation` edge, preserving graph topology while fixing the URL audit.

## Sources

- Met, `Cuneiform tablet: receipt of cattle`, object 11.217.2: https://www.metmuseum.org/art/collection/search/322446
- Met, `Cuneiform tablet: receipt of metals`, object 57.16.4: https://www.metmuseum.org/art/collection/search/324589
- EIA, `Most combined-cycle power plants employ two combustion turbines with one steam turbine`: https://www.eia.gov/todayinenergy/detail.php?id=52158

## Why this is better

The node no longer overclaims all early receipt tablets globally. It is pinned to museum-catalogued Ur III artifacts with object dates, medium, geography, and administrative receipt titles. The direct material dependency is prepared clay rather than fired pottery vessels.

## Adversarial note

The strongest reason this could be wrong is that older administrative clay receipt traditions may exist under a broader accounting-tablet scope. This PR avoids that by narrowing this node to Ur III receipt tablets rather than claiming the first possible receipt record.

## Validation

- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run invariant-coverage`
- `npm run node-snapshot-diff -- /tmp/clay_tablet_receipts.before.json /tmp/clay_tablet_receipts.after.json --require-behavior-change`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`
- `npm run source-urls`
- `npm run agent:check -- --run`