### PR TITLE
Source-check Near Eastern clay accounting tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 642 / 1,660 (38.7%) |
-| Nodes with node-level sources | 676 / 1,660 (40.7%) |
-| Dependency edges with edge-level sources | 1,920 / 5,514 (34.8%) |
+| Source-checked nodes | 643 / 1,660 (38.7%) |
+| Nodes with node-level sources | 677 / 1,660 (40.8%) |
+| Dependency edges with edge-level sources | 1,918 / 5,512 (34.8%) |
 | Era-default placeholder dates | 534 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/ancient.json
+++ b/data/ancient.json
@@ -8049,13 +8049,11 @@
   },
   {
     "id": "clay_accounting_tokens",
-    "name": "Clay Accounting Tokens",
+    "name": "Near Eastern Clay Accounting Tokens",
     "era": "Ancient",
-    "description": "Small shaped tokens used to count goods, livestock, grain, labor, and obligations before or alongside written accounting.",
+    "description": "Small shaped clay counters used in the prehistoric Near East for finance and accounting records of goods before the emergence of cuneiform writing.",
     "prerequisites": [
-      "pottery",
-      "record_keeping",
-      "standardized_weights_and_measures"
+      "clay_gathering_and_preparation"
     ],
     "fields": [
       "Finance & Markets"
@@ -8063,72 +8061,67 @@
     "fieldLanes": {
       "Finance & Markets": "Money & Accounting"
     },
-    "firstKnownDate": -3000,
-    "datePrecision": "century",
-    "region": "Global / multiple regions",
-    "reviewStatus": "structurally_validated",
+    "sources": [
+      {
+        "title": "The token system of the ancient Near East: Its role in counting, writing, the economy and cognition",
+        "url": "https://www.cambridge.org/core/books/abs/archaeology-of-measurement/token-system-of-the-ancient-near-east-its-role-in-counting-writing-the-economy-and-cognition/0AB9E89E74F94FE95F53F145F59CCA59",
+        "publisher": "Cambridge University Press",
+        "year": 2010,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "From Accounting to Writing",
+        "url": "https://sites.utexas.edu/dsb/tokens/from-accounting-to-writing/",
+        "publisher": "Denise Schmandt-Besserat / University of Texas at Austin",
+        "year": 2015,
+        "source_type": "review",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Reconsidering 'Tokens': The Neolithic Origins of Accounting or Multifunctional, Utilitarian Tools?",
+        "url": "https://www.cambridge.org/core/journals/cambridge-archaeological-journal/article/abs/reconsidering-tokens-the-neolithic-origins-of-accounting-or-multifunctional-utilitarian-tools/7E6C04CB040AD8AA0EA84B94D4D275C4",
+        "publisher": "Cambridge Archaeological Journal",
+        "year": 2019,
+        "source_type": "primary_paper",
+        "supports": [
+          "node"
+        ]
+      }
+    ],
+    "firstKnownDate": -7500,
+    "datePrecision": "millennium",
+    "region": "Prehistoric Near East, especially sites from Turkey, Syria, Jordan, Israel, Iraq, and Iran",
+    "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
-        "prerequisite": "pottery",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Pottery provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated",
+        "prerequisite": "clay_gathering_and_preparation",
+        "type": "required",
+        "confidence": 0.86,
+        "evidence_level": "textbook",
+        "note": "The scoped counters are shaped clay tokens; prepared clay is the direct material prerequisite, while fired pottery vessel production is not required.",
+        "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Pottery",
-            "url": "https://en.wikipedia.org/wiki/Pottery",
-            "source_type": "weak_web",
+            "title": "The token system of the ancient Near East: Its role in counting, writing, the economy and cognition",
+            "url": "https://www.cambridge.org/core/books/abs/archaeology-of-measurement/token-system-of-the-ancient-near-east-its-role-in-counting-writing-the-economy-and-cognition/0AB9E89E74F94FE95F53F145F59CCA59",
+            "publisher": "Cambridge University Press",
+            "year": 2010,
+            "source_type": "textbook",
             "supports": [
               "edge"
-            ],
-            "publisher": "Wikipedia",
-            "year": 2026
-          }
-        ]
-      },
-      {
-        "prerequisite": "record_keeping",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Record Keeping is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
-        "reviewStatus": "structurally_validated",
-        "sources": [
-          {
-            "title": "How to write cuneiform",
-            "url": "https://www.britishmuseum.org/blog/how-write-cuneiform",
-            "source_type": "museum",
-            "supports": [
-              "edge"
-            ],
-            "publisher": "The British Museum",
-            "year": 2026
-          }
-        ]
-      },
-      {
-        "prerequisite": "standardized_weights_and_measures",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Standardized Weights and Measures provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated",
-        "sources": [
-          {
-            "title": "Weights and measures",
-            "url": "https://en.wikipedia.org/wiki/Weights_and_measures",
-            "source_type": "weak_web",
-            "supports": [
-              "edge"
-            ],
-            "publisher": "Wikipedia",
-            "year": 2026
+            ]
           }
         ]
       }
-    ]
+    ],
+    "scopeNote": "Scoped as a finance/accounting technology in the Near Eastern clay-token counting tradition, especially the 7500-3100 BCE token system described by Schmandt-Besserat. Do not use this node as proof that every Neolithic clay object was an accounting token; later work argues many early clay objects were multifunctional and not a unified administrative system."
   },
   {
     "id": "dyed_textiles",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T14:14:13.266Z",
+  "generatedAt": "2026-06-12T14:25:10.243Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -11,23 +11,23 @@
     },
     {
       "label": "Source-checked nodes",
-      "value": 642,
+      "value": 643,
       "denominator": 1660,
-      "formatted": "642 / 1,660",
+      "formatted": "643 / 1,660",
       "note": "38.7%"
     },
     {
       "label": "Nodes with node-level sources",
-      "value": 676,
+      "value": 677,
       "denominator": 1660,
-      "formatted": "676 / 1,660",
-      "note": "40.7%"
+      "formatted": "677 / 1,660",
+      "note": "40.8%"
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1920,
-      "denominator": 5514,
-      "formatted": "1,920 / 5,514",
+      "value": 1918,
+      "denominator": 5512,
+      "formatted": "1,918 / 5,512",
       "note": "34.8%"
     },
     {
@@ -54,14 +54,14 @@
   },
   "riskReportTotals": {
     "technologies": 1660,
-    "nodesWithSources": 676,
-    "sourceChecked": 642,
+    "nodesWithSources": 677,
+    "sourceChecked": 643,
     "sourceCheckedNoSources": 0,
     "sourceCheckedAllWeak": 0,
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 534,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5514,
-    "edgesWithSources": 1920
+    "totalEdges": 5512,
+    "edgesWithSources": 1918
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,15 +1,15 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T14:14:13.266Z
+Generated: 2026-06-12T14:25:10.243Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,660 |
-| Source-checked nodes | 642 / 1,660 (38.7%) |
-| Nodes with node-level sources | 676 / 1,660 (40.7%) |
-| Dependency edges with edge-level sources | 1,920 / 5,514 (34.8%) |
+| Source-checked nodes | 643 / 1,660 (38.7%) |
+| Nodes with node-level sources | 677 / 1,660 (40.8%) |
+| Dependency edges with edge-level sources | 1,918 / 5,512 (34.8%) |
 | Era-default placeholder dates | 534 / 1,660 (32.2%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-12-clay-accounting-tokens-clay-preparation-replaces-pottery.json
+++ b/docs/edge-change-receipts/2026-06-12-clay-accounting-tokens-clay-preparation-replaces-pottery.json
@@ -1,0 +1,50 @@
+{
+  "id": "2026-06-12-clay-accounting-tokens-clay-preparation-replaces-pottery",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "replaced_edge": {
+    "dependent": "clay_accounting_tokens",
+    "prerequisite": "pottery"
+  },
+  "edge": {
+    "dependent": "clay_accounting_tokens",
+    "prerequisite": "clay_gathering_and_preparation"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Pottery provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.86,
+    "evidence_level": "textbook",
+    "note": "The scoped counters are shaped clay tokens; prepared clay is the direct material prerequisite, while fired pottery vessel production is not required."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.cambridge.org/core/books/abs/archaeology-of-measurement/token-system-of-the-ancient-near-east-its-role-in-counting-writing-the-economy-and-cognition/0AB9E89E74F94FE95F53F145F59CCA59",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Chapter summary: describes a system of counters, clay tokens, used in the prehistoric Near East from 7500-3100 BC.",
+    "source_claim_summary": "The source identifies the represented accounting counters as clay tokens.",
+    "source_support_rationale": "Because the scoped artifacts are shaped clay counters, prepared clay is the direct material prerequisite; pottery vessel manufacture is over-specific context."
+  },
+  "ontology_before": "The graph routed clay accounting tokens through pottery, implying fired ceramic vessel production was the relevant material capability.",
+  "ontology_after": "The graph routes clay accounting tokens through clay preparation as the direct material prerequisite.",
+  "invariant_preserved_or_changed": "Changed: clay_gathering_and_preparation is required and pottery is absent.",
+  "would_reject_if": [
+    "The node were rescoped to ceramic accounting vessels rather than shaped tokens.",
+    "A source showed fired pottery manufacture, not prepared clay, was necessary for the scoped tokens."
+  ],
+  "short_reason": "Clay accounting tokens require shaped clay, not pottery vessels.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/clay_accounting_tokens.before.json /tmp/clay_accounting_tokens.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-clay-accounting-tokens-record-keeping-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-clay-accounting-tokens-record-keeping-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-12-clay-accounting-tokens-record-keeping-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "clay_accounting_tokens",
+    "prerequisite": "record_keeping"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Record Keeping is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim_absent": "No direct edge remains from record_keeping to clay_accounting_tokens. The scoped clay-token system is itself a record-keeping/counting medium, so a broad record-keeping node would be tautological rather than a source-backed predecessor.",
+  "source_supports_edge": "no",
+  "source_url": "https://sites.utexas.edu/dsb/tokens/from-accounting-to-writing/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Before Writing: Accounting with Tokens section: describes clay tokens as the accounting system used to count and account for goods.",
+    "source_claim_summary": "The source treats clay tokens as an accounting method, not as a technology downstream of a separate record-keeping technology.",
+    "source_support_rationale": "Keeping record_keeping as a direct prerequisite would collapse parent category and implementation."
+  },
+  "ontology_before": "The graph treated broad record keeping as a historical predecessor of the clay-token record-keeping implementation.",
+  "ontology_after": "The graph avoids a tautological parent-category prerequisite on the clay-token implementation.",
+  "invariant_preserved_or_changed": "Changed: record_keeping is absent as a direct prerequisite for clay_accounting_tokens.",
+  "would_reject_if": [
+    "The record_keeping node were split into a narrower pre-token counting medium that source-evidently preceded clay tokens.",
+    "A source established a distinct earlier record-keeping system as a direct predecessor of Near Eastern clay tokens."
+  ],
+  "short_reason": "Broad record keeping is the category, not a direct prerequisite for clay accounting tokens.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/clay_accounting_tokens.before.json /tmp/clay_accounting_tokens.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-clay-accounting-tokens-weights-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-clay-accounting-tokens-weights-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-12-clay-accounting-tokens-weights-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "clay_accounting_tokens",
+    "prerequisite": "standardized_weights_and_measures"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Standardized Weights and Measures provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct edge remains from standardized_weights_and_measures to clay_accounting_tokens. The token system is dated to 7500-3100 BCE, earlier than the graph's source-checked Mesopotamian/eastern Mediterranean standard weights node.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.cambridge.org/core/books/abs/archaeology-of-measurement/token-system-of-the-ancient-near-east-its-role-in-counting-writing-the-economy-and-cognition/0AB9E89E74F94FE95F53F145F59CCA59",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Chapter summary: clay tokens are used in the prehistoric Near East from 7500-3100 BC.",
+    "source_claim_summary": "The source dates clay-token use before the graph's standardized weights-and-measures node.",
+    "source_support_rationale": "A later standardized weights node cannot be a direct prerequisite for earlier clay counting tokens."
+  },
+  "ontology_before": "The graph made a later metrology system an enabling dependency for earlier clay tokens.",
+  "ontology_after": "The graph removes the chronology-reversed metrology dependency.",
+  "invariant_preserved_or_changed": "Changed: standardized_weights_and_measures is absent as a direct prerequisite for clay_accounting_tokens.",
+  "would_reject_if": [
+    "The clay_accounting_tokens node were narrowed to later urban complex tokens that demonstrably depended on standardized metrology.",
+    "The standardized_weights_and_measures node were respecified and dated earlier than the token system with source support."
+  ],
+  "short_reason": "Standardized weights are later metrology context, not a prerequisite for prehistoric clay tokens.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/clay_accounting_tokens.before.json /tmp/clay_accounting_tokens.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-clay-accounting-tokens-scope.json
+++ b/docs/graph-invariants/2026-06-12-clay-accounting-tokens-scope.json
@@ -1,0 +1,37 @@
+{
+  "id": "2026-06-12-clay-accounting-tokens-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "clay_accounting_tokens",
+      "operator": "eq",
+      "value": -7500,
+      "reason": "The node is scoped to the Near Eastern clay-token counting/accounting tradition described as 7500-3100 BCE."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "clay_accounting_tokens",
+      "prerequisite": "clay_gathering_and_preparation",
+      "expected": "required",
+      "reason": "The scoped artifacts are shaped clay tokens."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "clay_accounting_tokens",
+      "prerequisite": "pottery",
+      "reason": "Fired pottery vessels are not the direct material prerequisite for shaped clay counters."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "clay_accounting_tokens",
+      "prerequisite": "record_keeping",
+      "reason": "Broad record keeping is the category implemented by clay tokens, not a separate direct prerequisite."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "clay_accounting_tokens",
+      "prerequisite": "standardized_weights_and_measures",
+      "reason": "The scoped token system predates the source-checked standardized weights node."
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

Source-checked `clay_accounting_tokens` as `Near Eastern Clay Accounting Tokens`.

Old claim:
- `firstKnownDate: -3000`, `datePrecision: century`, `region: Global / multiple regions`
- prerequisites: `pottery`, `record_keeping`, `standardized_weights_and_measures`
- weak Wikipedia edge sources for pottery and weights

New claim:
- scoped to the prehistoric Near Eastern clay-token counting/accounting tradition
- `firstKnownDate: -7500`, `datePrecision: millennium`
- `region: Prehistoric Near East, especially sites from Turkey, Syria, Jordan, Israel, Iraq, and Iran`
- only direct prerequisite: `clay_gathering_and_preparation` as `required`
- removed `pottery`, `record_keeping`, and `standardized_weights_and_measures` direct prerequisites
- added a scope note warning that early Neolithic clay objects were multifunctional and not proof of a unified administrative accounting system

## Sources

- Cambridge University Press, `The token system of the ancient Near East: Its role in counting, writing, the economy and cognition`: https://www.cambridge.org/core/books/abs/archaeology-of-measurement/token-system-of-the-ancient-near-east-its-role-in-counting-writing-the-economy-and-cognition/0AB9E89E74F94FE95F53F145F59CCA59
- Denise Schmandt-Besserat / UT Austin, `From Accounting to Writing`: https://sites.utexas.edu/dsb/tokens/from-accounting-to-writing/
- Cambridge Archaeological Journal, `Reconsidering 'Tokens': The Neolithic Origins of Accounting or Multifunctional, Utilitarian Tools?`: https://www.cambridge.org/core/journals/cambridge-archaeological-journal/article/abs/reconsidering-tokens-the-neolithic-origins-of-accounting-or-multifunctional-utilitarian-tools/7E6C04CB040AD8AA0EA84B94D4D275C4

## Why this is better

The node no longer dates clay-token accounting to a late broad `-3000` placeholder. It also avoids a chronology-reversed dependency on standardized weights and removes the tautological broad `record_keeping` prerequisite. The caveat source keeps the graph honest about debate over the earliest Neolithic clay objects.

## Adversarial note

The strongest reason this could be wrong is that the accounting interpretation is not accepted for all early Neolithic clay objects. The PR handles that by scoping to the Near Eastern clay-token counting/accounting tradition and explicitly warning against treating every early clay object as an administrative accounting token.

## Validation

- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run invariant-coverage`
- `npm run node-snapshot-diff -- /tmp/clay_accounting_tokens.before.json /tmp/clay_accounting_tokens.after.json --require-behavior-change`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`
- `npm run source-urls`
- `npm run agent:check -- --run`