### PR TITLE
Source-check thermodynamics scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 644 / 1,660 (38.8%) |
 | Nodes with node-level sources | 678 / 1,660 (40.8%) |
-| Dependency edges with edge-level sources | 1,921 / 5,510 (34.9%) |
+| Dependency edges with edge-level sources | 1,920 / 5,509 (34.9%) |
 | Era-default placeholder dates | 533 / 1,660 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/industrial.json
+++ b/data/industrial.json
@@ -784,7 +784,6 @@
       "steam_engine",
       "scientific_method",
       "mathematics",
-      "advanced_chemistry",
       "logarithms_calculus_early"
     ],
     "fields": [
@@ -793,26 +792,41 @@
     "fieldLanes": {
       "Mechanical Engineering": "Power & Thermal Systems"
     },
-    "firstKnownDate": 1850,
-    "datePrecision": "decade",
-    "region": "Europe, North America, and industrializing regions",
+    "firstKnownDate": 1824,
+    "datePrecision": "exact",
+    "region": "France, Britain, Germany, and later global physical science and engineering",
+    "scopeNote": "Covers classical thermodynamics beginning with Carnot's 1824 heat-engine theory and later 19th-century formalization by Joule, Kelvin, Clausius, Rankine, Maxwell, and others. It does not cover statistical thermodynamics or every later thermodynamic subfield.",
     "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "steam_engine",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Steam Engine provides a capability that enables this technology without being the only possible path.",
+        "type": "historical_predecessor",
+        "confidence": 0.86,
+        "evidence_level": "textbook",
+        "note": "Practical steam-engine efficiency problems motivated Carnot's 1824 heat-engine theory, making steam engines the historical problem lineage rather than a required component of thermodynamics.",
         "reviewStatus": "source_checked",
         "sources": [
           {
             "title": "Thermodynamics",
-            "url": "https://en.wikipedia.org/wiki/Thermodynamics",
-            "publisher": "Wikipedia",
+            "url": "https://www.britannica.com/science/thermodynamics",
+            "publisher": "Encyclopaedia Britannica",
             "year": 2026,
-            "source_type": "review",
+            "source_type": "textbook",
             "supports": [
+              "node",
+              "maturity",
+              "edge"
+            ]
+          },
+          {
+            "title": "Sadi Carnot's Reflections on the Motive Power of Fire",
+            "url": "https://www.asme.org/getmedia/86ef5356-ffdd-4990-a017-cfe3ec05364b/275-carnot-brochure.pdf",
+            "publisher": "ASME",
+            "year": 2020,
+            "source_type": "museum",
+            "supports": [
+              "node",
+              "maturity",
               "edge"
             ]
           }
@@ -835,26 +849,6 @@
         "reviewStatus": "structurally_validated"
       },
       {
-        "prerequisite": "advanced_chemistry",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Chemistry provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "source_checked",
-        "sources": [
-          {
-            "title": "Thermodynamics",
-            "url": "https://en.wikipedia.org/wiki/Thermodynamics",
-            "publisher": "Wikipedia",
-            "year": 2026,
-            "source_type": "review",
-            "supports": [
-              "edge"
-            ]
-          }
-        ]
-      },
-      {
         "prerequisite": "logarithms_calculus_early",
         "type": "historical_predecessor",
         "confidence": 0.75,
@@ -866,9 +860,31 @@
     "sources": [
       {
         "title": "Thermodynamics",
-        "url": "https://en.wikipedia.org/wiki/Thermodynamics",
-        "publisher": "Wikipedia",
+        "url": "https://www.britannica.com/science/thermodynamics",
+        "publisher": "Encyclopaedia Britannica",
         "year": 2026,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Sadi Carnot's Reflections on the Motive Power of Fire",
+        "url": "https://www.asme.org/getmedia/86ef5356-ffdd-4990-a017-cfe3ec05364b/275-carnot-brochure.pdf",
+        "publisher": "ASME",
+        "year": 2020,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "June 12, 1824: Sadi Carnot Publishes Treatise on Heat Engines",
+        "url": "https://www.aps.org/apsnews/2009/05/sadi-carnot-heat-engines",
+        "publisher": "American Physical Society",
+        "year": 2009,
         "source_type": "review",
         "supports": [
           "node",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T14:57:11.747Z",
+  "generatedAt": "2026-06-12T15:07:25.577Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,9 +25,9 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1921,
-      "denominator": 5510,
-      "formatted": "1,921 / 5,510",
+      "value": 1920,
+      "denominator": 5509,
+      "formatted": "1,920 / 5,509",
       "note": "34.9%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 533,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5510,
-    "edgesWithSources": 1921
+    "totalEdges": 5509,
+    "edgesWithSources": 1920
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T14:57:11.747Z
+Generated: 2026-06-12T15:07:25.577Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 644 / 1,660 (38.8%) |
 | Nodes with node-level sources | 678 / 1,660 (40.8%) |
-| Dependency edges with edge-level sources | 1,921 / 5,510 (34.9%) |
+| Dependency edges with edge-level sources | 1,920 / 5,509 (34.9%) |
 | Era-default placeholder dates | 533 / 1,660 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-12-thermodynamics-advanced-chemistry-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-thermodynamics-advanced-chemistry-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-12-thermodynamics-advanced-chemistry-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "thermodynamics",
+    "prerequisite": "advanced_chemistry"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Chemistry provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because the inspected sources anchor thermodynamics in heat-engine theory, heat/work/temperature/energy relations, and later physical formalization rather than advanced chemistry.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.asme.org/getmedia/86ef5356-ffdd-4990-a017-cfe3ec05364b/275-carnot-brochure.pdf",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "ASME landmark brochure pages 2, 4, and 8 describe Carnot's 1824 book as early heat-engine theory and as laying foundations for thermodynamics.",
+    "source_claim_summary": "ASME grounds thermodynamics in heat-engine theory and mechanical engineering rather than advanced chemistry.",
+    "source_support_rationale": "The source provides a concrete upstream lineage for the node, making the broad advanced_chemistry edge unsupported and unnecessary."
+  },
+  "ontology_before": "The graph made thermodynamics depend directly on advanced chemistry based only on a Wikipedia-backed expert inference.",
+  "ontology_after": "The graph removes the unsupported chemistry edge and keeps the node anchored to heat engines, scientific method, mathematics, and early calculus.",
+  "invariant_preserved_or_changed": "Changed: direct thermodynamics -> advanced_chemistry edge removed.",
+  "would_reject_if": [
+    "The node were rescoped to chemical thermodynamics specifically.",
+    "A stronger source showed advanced chemistry was a direct prerequisite for Carnot-era classical thermodynamics."
+  ],
+  "short_reason": "Classical thermodynamics should not directly depend on advanced chemistry.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/thermodynamics.before.json /tmp/thermodynamics.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-thermodynamics-steam-engine-lineage.json
+++ b/docs/edge-change-receipts/2026-06-12-thermodynamics-steam-engine-lineage.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-12-thermodynamics-steam-engine-lineage",
+  "decision_date": "2026-06-12",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "thermodynamics",
+    "prerequisite": "steam_engine"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Steam Engine provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.86,
+    "evidence_level": "textbook",
+    "note": "Practical steam-engine efficiency problems motivated Carnot's 1824 heat-engine theory, making steam engines the historical problem lineage rather than a required component of thermodynamics."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/science/thermodynamics",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "establishes_historical_lineage",
+    "source_locator": "Britannica thermodynamics overview: Sadi Carnot introduced the heat-engine cycle and reversibility in 1824 in work on the maximum work obtainable from a steam engine.",
+    "source_claim_summary": "Carnot's work on steam-engine limits is described as a pioneer contribution to thermodynamics.",
+    "source_support_rationale": "The source ties the steam engine to the historical problem that produced thermodynamic theory, so historical_predecessor is more accurate than a generic enabling edge."
+  },
+  "ontology_before": "The graph treated steam_engine as a generic enabling prerequisite for thermodynamics.",
+  "ontology_after": "The graph treats steam_engine as the historical problem lineage that motivated Carnot's heat-engine theory.",
+  "invariant_preserved_or_changed": "Changed: thermodynamics -> steam_engine is historical_predecessor.",
+  "would_reject_if": [
+    "The node were narrowed to modern engineering thermodynamics courses rather than the historical emergence of classical thermodynamics.",
+    "A stronger source showed steam engines were a direct technical component required to practice thermodynamic science."
+  ],
+  "short_reason": "Steam engines motivated thermodynamics historically.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/thermodynamics.before.json /tmp/thermodynamics.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-thermodynamics-carnot-scope.json
+++ b/docs/graph-invariants/2026-06-12-thermodynamics-carnot-scope.json
@@ -1,0 +1,26 @@
+{
+  "id": "2026-06-12-thermodynamics-carnot-scope",
+  "description": "Lock thermodynamics to classical thermodynamics beginning with Carnot's 1824 heat-engine theory and later 19th-century formalization.",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "thermodynamics",
+      "operator": "eq",
+      "value": 1824,
+      "reason": "Carnot's 1824 Reflections introduced the heat-engine cycle and reversibility concepts that anchor the scoped classical thermodynamics node."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "thermodynamics",
+      "prerequisite": "steam_engine",
+      "expected": "historical_predecessor",
+      "reason": "Steam engines supplied the practical efficiency problem lineage for Carnot's theory, not a component prerequisite for thermodynamics as a science."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "thermodynamics",
+      "prerequisite": "advanced_chemistry",
+      "reason": "The inspected thermodynamics sources support heat engines, heat/work, and energy theory rather than advanced chemistry as a direct prerequisite."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Improves one foundational source-checked node that was still backed by Wikipedia as a `review` source:

- `thermodynamics`
  - replaces the Wikipedia node source with Britannica, ASME, and APS sources
  - changes `firstKnownDate` from `1850` decade to exact `1824`
  - adds a scope note: classical thermodynamics begins with Carnot's 1824 heat-engine theory and later 19th-century formalization; statistical thermodynamics and later subfields are out of scope
  - retypes `steam_engine -> thermodynamics` from generic `enabling` to sourced `historical_predecessor`
  - removes unsupported direct `advanced_chemistry -> thermodynamics`
  - adds edge-change receipts and a graph invariant locking the corrected scope

Generated quality snapshot files were refreshed.

## Why the previous model was misleading

The old node treated thermodynamics as a vague 1850s Industrial science node while using Wikipedia as both node support and edge support. The stronger sources show the scoped starting point is Carnot's 1824 heat-engine theory, with steam engines as the historical engineering problem lineage. They do not support advanced chemistry as a direct prerequisite for classical thermodynamics.

## Sources used

- Britannica, `Thermodynamics`: https://www.britannica.com/science/thermodynamics
- ASME Historic Mechanical Engineering Landmark brochure, `Sadi Carnot's Reflections on the Motive Power of Fire`: https://www.asme.org/getmedia/86ef5356-ffdd-4990-a017-cfe3ec05364b/275-carnot-brochure.pdf
- APS News, `June 12, 1824: Sadi Carnot Publishes Treatise on Heat Engines`: https://www.aps.org/apsnews/2009/05/sadi-carnot-heat-engines

## Validation

Passed:

- `npm run node-packet -- thermodynamics --json`
- `npm run node-snapshot-diff -- /tmp/thermodynamics.before.json /tmp/thermodynamics.after.json --require-behavior-change`
- `npm run edge-receipts`
- `npm run graph-invariants && npm run invariant-coverage`
- `npm run source-urls -- --node thermodynamics`
- `npm run agent:check -- --run`
- `npm run accuracy:risks -- --markdown --limit 24`

Final risk metrics:

- Technologies: 1660
- Nodes with node-level sources: 678/1660 (40.8%)
- Source-checked nodes: 644/1660 (38.8%)
- Era-default placeholder dates: 533/1660 (32.1%)
- Source-checked era-default placeholder dates: 0/644
- Dependency edges with edge-level sources: 1920/5509 (34.9%)

## Remaining uncertainty / follow-up

This PR only fixes the thermodynamics node. Remaining source-type inflation still exists on several Wikipedia-backed source-checked nodes such as `factory_system`, `steel_production`, `corporation_limited_liability`, and others. Those should be replaced or downgraded in separate small PRs rather than silently mass-edited.