### PR TITLE
Source-check factory system scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 644 / 1,660 (38.8%) |
 | Nodes with node-level sources | 678 / 1,660 (40.8%) |
-| Dependency edges with edge-level sources | 1,920 / 5,509 (34.9%) |
+| Dependency edges with edge-level sources | 1,918 / 5,507 (34.8%) |
 | Era-default placeholder dates | 533 / 1,660 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/industrial.json
+++ b/data/industrial.json
@@ -2899,12 +2899,10 @@
     "id": "factory_system",
     "name": "Factory System",
     "era": "Industrial",
-    "description": "A method of manufacturing using machinery and division of labor, centralizing production in a single location.",
+    "description": "Centralized industrial production in purpose-built mills or factories, combining powered machinery, disciplined wage labor, and coordinated processes under one roof or factory complex.",
     "prerequisites": [
       "steam_engine",
       "textiles_weaving",
-      "banking",
-      "mechanical_clocks",
       "watermills",
       "division_of_labor"
     ],
@@ -2915,25 +2913,28 @@
       "Mechanical Engineering": "Automation & Systems"
     },
     "firstKnownDate": 1760,
-    "datePrecision": "exact",
-    "region": "Europe, North America, and industrializing regions",
+    "datePrecision": "decade",
+    "region": "Cromford and the Derwent Valley, England; later Britain, North America, and global industrial regions",
+    "scopeNote": "Covers the modern factory system as developed through Arkwright's late-1760s water-frame patenting and established by the Cromford water-powered cotton mill in 1771, then spreading through textile and later steam-powered manufacturing. It is not a generic claim about all workshops, proto-industrial putting-out systems, or every form of business organization.",
     "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "steam_engine",
         "type": "commercial_or_scaling_dependency",
-        "confidence": 0.72,
-        "evidence_level": "expert_inference",
-        "note": "Steam Engine supports manufacturing, deployment, commercialization, or operational scaling.",
+        "confidence": 0.78,
+        "evidence_level": "review",
+        "note": "Early factories were water-powered, while steam engines later let textile mills scale and relocate beyond fast-flowing rural water sites.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Factory system",
-            "url": "https://en.wikipedia.org/wiki/Factory_system",
-            "publisher": "Wikipedia",
-            "year": 2026,
+            "title": "Mapping Manchester's engines",
+            "url": "https://www.scienceandindustrymuseum.org.uk/objects-and-stories/mapping-manchesters-engines",
+            "publisher": "Science and Industry Museum",
+            "year": 2025,
             "source_type": "review",
             "supports": [
+              "node",
+              "maturity",
               "edge"
             ]
           }
@@ -2941,59 +2942,21 @@
       },
       {
         "prerequisite": "textiles_weaving",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Textiles & Weaving provides a capability that enables this technology without being the only possible path.",
+        "type": "historical_predecessor",
+        "confidence": 0.82,
+        "evidence_level": "review",
+        "note": "The factory system emerged from mechanizing textile production that had previously relied on home-based putting-out, spinning wheels, and hand looms.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Factory system",
-            "url": "https://en.wikipedia.org/wiki/Factory_system",
-            "publisher": "Wikipedia",
-            "year": 2026,
-            "source_type": "review",
+            "title": "The Industrial Revolution in England",
+            "url": "https://www.nps.gov/lowe/learn/photosmultimedia/industry.htm",
+            "publisher": "National Park Service",
+            "year": 2015,
+            "source_type": "official_agency",
             "supports": [
-              "edge"
-            ]
-          }
-        ]
-      },
-      {
-        "prerequisite": "banking",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Banking provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "source_checked",
-        "sources": [
-          {
-            "title": "Factory system",
-            "url": "https://en.wikipedia.org/wiki/Factory_system",
-            "publisher": "Wikipedia",
-            "year": 2026,
-            "source_type": "review",
-            "supports": [
-              "edge"
-            ]
-          }
-        ]
-      },
-      {
-        "prerequisite": "mechanical_clocks",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Mechanical Clocks provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "source_checked",
-        "sources": [
-          {
-            "title": "Factory system",
-            "url": "https://en.wikipedia.org/wiki/Factory_system",
-            "publisher": "Wikipedia",
-            "year": 2026,
-            "source_type": "review",
-            "supports": [
+              "node",
+              "maturity",
               "edge"
             ]
           }
@@ -3002,18 +2965,20 @@
       {
         "prerequisite": "watermills",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Watermills provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.84,
+        "evidence_level": "review",
+        "note": "The scoped factory system was established in water-powered cotton mills; waterpower drove the machinery at Cromford and other Derwent Valley mills.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Factory system",
-            "url": "https://en.wikipedia.org/wiki/Factory_system",
-            "publisher": "Wikipedia",
+            "title": "Derwent Valley Mills",
+            "url": "https://whc.unesco.org/en/list/1030/",
+            "publisher": "UNESCO World Heritage Centre",
             "year": 2026,
-            "source_type": "review",
+            "source_type": "official_agency",
             "supports": [
+              "node",
+              "maturity",
               "edge"
             ]
           }
@@ -3022,18 +2987,20 @@
       {
         "prerequisite": "division_of_labor",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Division of Labor provides a capability that enables this technology without being the only possible path.",
+        "confidence": 0.78,
+        "evidence_level": "review",
+        "note": "Arkwright-style factories transformed work into coordinated machine tending, shifts, and disciplined labor inside large mills.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Factory system",
-            "url": "https://en.wikipedia.org/wiki/Factory_system",
-            "publisher": "Wikipedia",
-            "year": 2026,
+            "title": "Richard Arkwright",
+            "url": "https://www.scienceandindustrymuseum.org.uk/objects-and-stories/richard-arkwright",
+            "publisher": "Science and Industry Museum",
+            "year": 2019,
             "source_type": "review",
             "supports": [
+              "node",
+              "maturity",
               "edge"
             ]
           }
@@ -3042,11 +3009,33 @@
     ],
     "sources": [
       {
-        "title": "Factory system",
-        "url": "https://en.wikipedia.org/wiki/Factory_system",
-        "publisher": "Wikipedia",
+        "title": "Derwent Valley Mills",
+        "url": "https://whc.unesco.org/en/list/1030/",
+        "publisher": "UNESCO World Heritage Centre",
         "year": 2026,
+        "source_type": "official_agency",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Richard Arkwright",
+        "url": "https://www.scienceandindustrymuseum.org.uk/objects-and-stories/richard-arkwright",
+        "publisher": "Science and Industry Museum",
+        "year": 2019,
         "source_type": "review",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Sir Richard Arkwright",
+        "url": "https://www.britannica.com/biography/Richard-Arkwright",
+        "publisher": "Encyclopaedia Britannica",
+        "year": 2026,
+        "source_type": "textbook",
         "supports": [
           "node",
           "maturity"

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T15:07:25.577Z",
+  "generatedAt": "2026-06-12T15:18:33.497Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,10 +25,10 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1920,
-      "denominator": 5509,
-      "formatted": "1,920 / 5,509",
-      "note": "34.9%"
+      "value": 1918,
+      "denominator": 5507,
+      "formatted": "1,918 / 5,507",
+      "note": "34.8%"
     },
     {
       "label": "Era-default placeholder dates",
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 533,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5509,
-    "edgesWithSources": 1920
+    "totalEdges": 5507,
+    "edgesWithSources": 1918
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T15:07:25.577Z
+Generated: 2026-06-12T15:18:33.497Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 644 / 1,660 (38.8%) |
 | Nodes with node-level sources | 678 / 1,660 (40.8%) |
-| Dependency edges with edge-level sources | 1,920 / 5,509 (34.9%) |
+| Dependency edges with edge-level sources | 1,918 / 5,507 (34.8%) |
 | Era-default placeholder dates | 533 / 1,660 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-12-factory-system-banking-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-factory-system-banking-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-12-factory-system-banking-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "factory_system",
+    "prerequisite": "banking"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Banking provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because the inspected sources explain the factory system through powered textile machinery, waterpower, labor organization, and later steam scaling rather than banking.",
+  "source_supports_edge": "no",
+  "source_url": "https://whc.unesco.org/en/list/1030/",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "UNESCO Outstanding Universal Value describes the factory system through Arkwright's water-powered cotton mills and industrial settlements.",
+    "source_claim_summary": "UNESCO frames the factory system as a water-powered cotton-mill and industrial-settlement development, not a banking dependency.",
+    "source_support_rationale": "The source provides a concrete technology and organization lineage, making a direct banking prerequisite unsupported for this node."
+  },
+  "ontology_before": "The graph treated banking as a direct prerequisite for the factory system based on weak generic inference.",
+  "ontology_after": "The graph removes the banking edge; finance remains relevant to industrial capitalism but not as a direct technology dependency here.",
+  "invariant_preserved_or_changed": "Changed: direct factory_system -> banking edge removed.",
+  "would_reject_if": [
+    "The node were rescoped to industrial-capital financing systems rather than factory production.",
+    "A stronger source showed banking was a direct prerequisite for the Cromford/Derwent Valley factory-system technology."
+  ],
+  "short_reason": "Banking is context, not a direct factory-system prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/factory_system.before.json /tmp/factory_system.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-factory-system-division-labor-enabling.json
+++ b/docs/edge-change-receipts/2026-06-12-factory-system-division-labor-enabling.json
@@ -1,0 +1,44 @@
+{
+  "id": "2026-06-12-factory-system-division-labor-enabling",
+  "decision_date": "2026-06-12",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "factory_system",
+    "prerequisite": "division_of_labor"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Division of Labor provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.78,
+    "evidence_level": "review",
+    "note": "Arkwright-style factories transformed work into coordinated machine tending, shifts, and disciplined labor inside large mills."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.scienceandindustrymuseum.org.uk/objects-and-stories/richard-arkwright",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Science and Industry Museum section 'Working lives transformed' describes machine tending, huge mills, and two 13-hour shifts in Arkwright's mills.",
+    "source_claim_summary": "Arkwright's factories reorganized labor around machine tending and shift work in large mills.",
+    "source_support_rationale": "The source supports coordinated labor organization as enabling factory production, without making it a narrow hard prerequisite."
+  },
+  "ontology_before": "The graph had a plausible division_of_labor edge backed only by expert inference.",
+  "ontology_after": "The graph keeps division_of_labor as enabling and ties it to sourced factory labor organization.",
+  "invariant_preserved_or_changed": "Preserved: division_of_labor remains enabling; changed: evidence and note are source-backed.",
+  "would_reject_if": [
+    "The node were rescoped to factory buildings only, excluding labor organization.",
+    "A more precise industrial labor discipline node replaces division_of_labor."
+  ],
+  "short_reason": "Factory production reorganized labor around coordinated machine work.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-factory-system-mechanical-clocks-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-factory-system-mechanical-clocks-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-12-factory-system-mechanical-clocks-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "factory_system",
+    "prerequisite": "mechanical_clocks"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Mechanical Clocks provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because the inspected sources support powered textile machinery and factory labor organization, but not mechanical clocks as a direct prerequisite for the Cromford factory system.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.scienceandindustrymuseum.org.uk/objects-and-stories/richard-arkwright",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Science and Industry Museum sections 'Creating a factory system' and 'Working lives transformed' describe water-powered machinery, machine tending, and shifts without making clocks a prerequisite.",
+    "source_claim_summary": "The source explains factory-system organization through powered machinery and disciplined mill work, not mechanical clocks.",
+    "source_support_rationale": "Clock-time discipline may matter to later industrial labor, but this source does not support mechanical clocks as a direct upstream technology for the scoped node."
+  },
+  "ontology_before": "The graph treated mechanical clocks as a direct factory-system prerequisite based on weak generic inference.",
+  "ontology_after": "The graph removes the mechanical_clocks edge and keeps labor organization represented through division_of_labor.",
+  "invariant_preserved_or_changed": "Changed: direct factory_system -> mechanical_clocks edge removed.",
+  "would_reject_if": [
+    "The node were rescoped to industrial timekeeping systems rather than factory production.",
+    "A stronger source showed Arkwright-style factory operation directly required mechanical clocks as a technology prerequisite."
+  ],
+  "short_reason": "Mechanical clocks are not sourced as a direct prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/factory_system.before.json /tmp/factory_system.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-factory-system-steam-scaling.json
+++ b/docs/edge-change-receipts/2026-06-12-factory-system-steam-scaling.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-12-factory-system-steam-scaling",
+  "decision_date": "2026-06-12",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "factory_system",
+    "prerequisite": "steam_engine"
+  },
+  "old_claim": {
+    "type": "commercial_or_scaling_dependency",
+    "confidence": 0.72,
+    "evidence_level": "expert_inference",
+    "note": "Steam Engine supports manufacturing, deployment, commercialization, or operational scaling."
+  },
+  "new_claim": {
+    "type": "commercial_or_scaling_dependency",
+    "confidence": 0.78,
+    "evidence_level": "review",
+    "note": "Early factories were water-powered, while steam engines later let textile mills scale and relocate beyond fast-flowing rural water sites."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.scienceandindustrymuseum.org.uk/objects-and-stories/mapping-manchesters-engines",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Science and Industry Museum section 'Textile power' describes steam engines powering textile mills from the late 1700s and enabling mills away from water sites.",
+    "source_claim_summary": "Steam power spread through textile mills after early water-powered mills and improved reliability and location choice.",
+    "source_support_rationale": "The source supports steam as a scaling and siting dependency, not as a hard prerequisite for the original factory system."
+  },
+  "ontology_before": "The graph had the correct broad edge type but relied on Wikipedia-backed expert inference.",
+  "ontology_after": "The graph keeps steam as scaling infrastructure and backs the edge with a museum source.",
+  "invariant_preserved_or_changed": "Preserved: steam_engine remains commercial_or_scaling_dependency; changed: evidence and note are source-backed.",
+  "would_reject_if": [
+    "The node were rescoped to steam-powered urban factories only.",
+    "A stronger source showed the Cromford factory system itself required steam power."
+  ],
+  "short_reason": "Steam scaled factories after water-powered origins.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/factory_system.before.json /tmp/factory_system.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-factory-system-textiles-lineage.json
+++ b/docs/edge-change-receipts/2026-06-12-factory-system-textiles-lineage.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-12-factory-system-textiles-lineage",
+  "decision_date": "2026-06-12",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "factory_system",
+    "prerequisite": "textiles_weaving"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Textiles & Weaving provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.82,
+    "evidence_level": "review",
+    "note": "The factory system emerged from mechanizing textile production that had previously relied on home-based putting-out, spinning wheels, and hand looms."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.nps.gov/lowe/learn/photosmultimedia/industry.htm",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "establishes_historical_lineage",
+    "source_locator": "NPS Lowell page explains putting-out textile production, spinning wheels, hand looms, and Arkwright's water frame ushering in the modern factory.",
+    "source_claim_summary": "The modern factory emerged from mechanized textile production after home-based textile production methods.",
+    "source_support_rationale": "The source supports a textile-production lineage, so historical_predecessor is more precise than a generic enabling edge."
+  },
+  "ontology_before": "The graph treated textiles_weaving as a generic enabling prerequisite.",
+  "ontology_after": "The graph treats textile production as the historical lineage from which the factory system emerged.",
+  "invariant_preserved_or_changed": "Changed: factory_system -> textiles_weaving is historical_predecessor.",
+  "would_reject_if": [
+    "The node were rescoped away from the textile-mill factory system into a broader abstract management system.",
+    "A stronger source showed the first factory system was outside textile production."
+  ],
+  "short_reason": "Factory-system origins are in mechanized textile production.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/factory_system.before.json /tmp/factory_system.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-factory-system-waterpower-enabling.json
+++ b/docs/edge-change-receipts/2026-06-12-factory-system-waterpower-enabling.json
@@ -1,0 +1,44 @@
+{
+  "id": "2026-06-12-factory-system-waterpower-enabling",
+  "decision_date": "2026-06-12",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "factory_system",
+    "prerequisite": "watermills"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Watermills provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.84,
+    "evidence_level": "review",
+    "note": "The scoped factory system was established in water-powered cotton mills; waterpower drove the machinery at Cromford and other Derwent Valley mills."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://whc.unesco.org/en/list/1030/",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "UNESCO Outstanding Universal Value describes Arkwright's 1771 water-powered Cromford spinning mill and Derwent water powering cotton mills.",
+    "source_claim_summary": "The modern factory system was developed in Derwent Valley water-powered cotton mills.",
+    "source_support_rationale": "The source supports waterpower as an enabling capability for the scoped Cromford/Derwent Valley factory system."
+  },
+  "ontology_before": "The graph had a plausible watermills edge backed only by Wikipedia-style inference.",
+  "ontology_after": "The graph keeps watermills as enabling and backs it with UNESCO source evidence.",
+  "invariant_preserved_or_changed": "Preserved: watermills remains enabling; changed: evidence and note are source-backed.",
+  "would_reject_if": [
+    "The node were rescoped to steam-powered factories only.",
+    "A more precise water-frame or industrial-waterpower node replaces watermills."
+  ],
+  "short_reason": "Waterpower enabled the Cromford factory system.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-factory-system-cromford-scope.json
+++ b/docs/graph-invariants/2026-06-12-factory-system-cromford-scope.json
@@ -1,0 +1,53 @@
+{
+  "id": "2026-06-12-factory-system-cromford-scope",
+  "description": "Lock the factory_system node to Arkwright-style water-powered cotton mills beginning at Cromford in 1771, not generic workshops or unsupported business context.",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "factory_system",
+      "operator": "eq",
+      "value": 1760,
+      "reason": "This node uses a decade bucket for Arkwright's late-1760s water-frame patenting and the 1771 Cromford mill, while the scope note names Cromford 1771 explicitly."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "factory_system",
+      "prerequisite": "steam_engine",
+      "expected": "commercial_or_scaling_dependency",
+      "reason": "Steam power later scaled and relocated textile mills; it did not create the original water-powered Cromford factory system."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "factory_system",
+      "prerequisite": "textiles_weaving",
+      "expected": "historical_predecessor",
+      "reason": "The factory system emerged from mechanized textile production after home-based textile work and hand methods."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "factory_system",
+      "prerequisite": "watermills",
+      "expected": "enabling",
+      "reason": "The scoped factory system was established in water-powered cotton mills."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "factory_system",
+      "prerequisite": "division_of_labor",
+      "expected": "enabling",
+      "reason": "The scoped factories organized machine tending and long shifts inside large mills."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "factory_system",
+      "prerequisite": "banking",
+      "reason": "Banking and investment context may support industrial capitalism, but the inspected factory-system sources do not support it as a direct technology prerequisite."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "factory_system",
+      "prerequisite": "mechanical_clocks",
+      "reason": "Clock-time discipline is relevant to later industrial labor systems but is not sourced as a direct prerequisite for the Cromford factory-system scope."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Improves one source-checked Industrial node that was still backed only by Wikipedia as a `review` source:

- `factory_system`
  - replaces Wikipedia node/edge sources with UNESCO, Science and Industry Museum, NPS, and Britannica sources
  - changes false exact `1760` to `1760` with `datePrecision: "decade"`
  - adds a scope note naming the late-1760s Arkwright water-frame context and the 1771 Cromford water-powered cotton mill anchor
  - keeps direct prerequisites to source-backed technology/organization edges:
    - `steam_engine` as `commercial_or_scaling_dependency`
    - `textiles_weaving` as `historical_predecessor`
    - `watermills` as `enabling`
    - `division_of_labor` as `enabling`
  - removes unsupported direct edges to `banking` and `mechanical_clocks`
  - adds receipts and a graph invariant locking the corrected scope

Generated quality snapshot files were refreshed.

## Why the previous model was misleading

The old node claimed exact `1760` and used Wikipedia as both node and edge support. It also modeled broad context (`banking`, `mechanical_clocks`) as direct prerequisites. The stronger sources support a tighter Arkwright/Cromford factory-system lineage: powered textile machinery, water-powered mills, disciplined factory labor, and later steam-powered scaling.

The date remains `1760` as a decade bucket because the repo currently stores decade values as the decade start and several dependent Industrial nodes still use 1760-era placeholders. The scope note explicitly names 1771 Cromford as the concrete anchor.

## Sources used

- UNESCO World Heritage Centre, `Derwent Valley Mills`: https://whc.unesco.org/en/list/1030/
- Science and Industry Museum, `Richard Arkwright`: https://www.scienceandindustrymuseum.org.uk/objects-and-stories/richard-arkwright
- National Park Service, `The Industrial Revolution in England`: https://www.nps.gov/lowe/learn/photosmultimedia/industry.htm
- Science and Industry Museum, `Mapping Manchester's engines`: https://www.scienceandindustrymuseum.org.uk/objects-and-stories/mapping-manchesters-engines
- Encyclopaedia Britannica, `Sir Richard Arkwright`: https://www.britannica.com/biography/Richard-Arkwright

## Validation

Passed:

- `npm run node-packet -- factory_system --json`
- `npm run node-snapshot-diff -- /tmp/factory_system.before.json /tmp/factory_system.after.json --require-behavior-change`
- `npm run edge-receipts`
- `npm run graph-invariants && npm run invariant-coverage`
- `npm run source-urls -- --node factory_system` passed for touched sources except one unrelated transient timeout on `stock_exchange_early`; full source URL audit later passed
- `npm run agent:check -- --run`
- `npm run accuracy:risks -- --markdown --limit 24`

Final risk metrics:

- Technologies: 1660
- Nodes with node-level sources: 678/1660 (40.8%)
- Source-checked nodes: 644/1660 (38.8%)
- Era-default placeholder dates: 533/1660 (32.1%)
- Source-checked era-default placeholder dates: 0/644
- Dependency edges with edge-level sources: 1918/5507 (34.8%)

## Remaining uncertainty / follow-up

This PR intentionally does not repair all downstream Industrial placeholder dates. The factory-system correction exposed that dependents such as `mass_production`, `labor_unions_collective_bargaining`, and `sewing_machine` still need their own chronology and edge-quality reviews. Those should be separate small PRs rather than folded into this source replacement.