### PR TITLE
Source-check steel production scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 644 / 1,660 (38.8%) |
 | Nodes with node-level sources | 678 / 1,660 (40.8%) |
-| Dependency edges with edge-level sources | 1,918 / 5,507 (34.8%) |
+| Dependency edges with edge-level sources | 1,921 / 5,505 (34.9%) |
 | Era-default placeholder dates | 533 / 1,660 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/industrial.json
+++ b/data/industrial.json
@@ -3563,11 +3563,9 @@
     "id": "steel_production",
     "name": "Steel Production",
     "era": "Industrial",
-    "description": "The general capability to produce strong, versatile steel in large quantities, enabling modern infrastructure.",
+    "description": "Controlled production of iron-carbon steel, anchored here to Huntsman's 1740s crucible/cast-steel process in Sheffield; later Bessemer and open-hearth methods represent separate bulk steel scaling steps.",
     "prerequisites": [
       "iron_working",
-      "steam_engine",
-      "advanced_chemistry",
       "advanced_metallurgy_medieval",
       "blast_furnace"
     ],
@@ -3578,11 +3576,34 @@
       "Materials Science & Manufacturing": "Metals & Alloys"
     },
     "maturity": "established",
+    "scopeNote": "Covers established crucible/cast-steel production as an industrially important capability beginning in the 1740s. It does not claim that low-cost high-volume structural steel existed before the Bessemer and open-hearth processes.",
     "sources": [
       {
-        "title": "Steel",
-        "url": "https://en.wikipedia.org/wiki/Steel",
-        "publisher": "Wikipedia",
+        "title": "Benjamin Huntsman",
+        "url": "https://www.britannica.com/biography/Benjamin-Huntsman",
+        "publisher": "Encyclopaedia Britannica",
+        "year": 2026,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Benjamin Huntsman Clock",
+        "url": "https://www.sheffieldmuseums.org.uk/whats-on/benjamin-huntsman-clock/",
+        "publisher": "Sheffield Museums Trust",
+        "year": 2026,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "The Steel Story",
+        "url": "https://worldsteel.org/about-steel/steel-story/",
+        "publisher": "World Steel Association",
         "year": 2026,
         "source_type": "review",
         "supports": [
@@ -3591,50 +3612,70 @@
         ]
       }
     ],
-    "firstKnownDate": 1760,
-    "datePrecision": "exact",
-    "region": "Europe, North America, and industrializing regions",
+    "firstKnownDate": 1740,
+    "datePrecision": "decade",
+    "region": "Sheffield, England; later Britain, Europe, North America, and global steelmaking regions",
     "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "iron_working",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Iron Working provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "steam_engine",
-        "type": "commercial_or_scaling_dependency",
-        "confidence": 0.72,
-        "evidence_level": "expert_inference",
-        "note": "Steam Engine supports manufacturing, deployment, commercialization, or operational scaling.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "advanced_chemistry",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Chemistry provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "required",
+        "confidence": 0.86,
+        "evidence_level": "textbook",
+        "note": "Steel production requires prior ironworking because steel is an iron-carbon alloy made from iron feedstocks.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Steel",
+            "url": "https://www.britannica.com/technology/steel",
+            "publisher": "Encyclopaedia Britannica",
+            "year": 2026,
+            "source_type": "textbook",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "advanced_metallurgy_medieval",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Metallurgy (Medieval) provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "historical_predecessor",
+        "confidence": 0.78,
+        "evidence_level": "review",
+        "note": "Crucible steel followed earlier iron and steelmaking craft, including cementation and medieval blast-furnace metallurgy.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "The Steel Story",
+            "url": "https://worldsteel.org/about-steel/steel-story/",
+            "publisher": "World Steel Association",
+            "year": 2026,
+            "source_type": "review",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "blast_furnace",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Blast Furnace provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "commercial_or_scaling_dependency",
+        "confidence": 0.76,
+        "evidence_level": "review",
+        "note": "Blast furnaces supplied pig iron for subsequent steel processing and became major scaling infrastructure, but they are not the defining invention of Huntsman's crucible steel.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Steel Production",
+            "url": "https://www.steel.org/steel-technology/steel-production/",
+            "publisher": "American Iron and Steel Institute",
+            "year": 2026,
+            "source_type": "review",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T15:18:33.497Z",
+  "generatedAt": "2026-06-12T15:29:13.367Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,10 +25,10 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1918,
-      "denominator": 5507,
-      "formatted": "1,918 / 5,507",
-      "note": "34.8%"
+      "value": 1921,
+      "denominator": 5505,
+      "formatted": "1,921 / 5,505",
+      "note": "34.9%"
     },
     {
       "label": "Era-default placeholder dates",
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 533,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5507,
-    "edgesWithSources": 1918
+    "totalEdges": 5505,
+    "edgesWithSources": 1921
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T15:18:33.497Z
+Generated: 2026-06-12T15:29:13.367Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 644 / 1,660 (38.8%) |
 | Nodes with node-level sources | 678 / 1,660 (40.8%) |
-| Dependency edges with edge-level sources | 1,918 / 5,507 (34.8%) |
+| Dependency edges with edge-level sources | 1,921 / 5,505 (34.9%) |
 | Era-default placeholder dates | 533 / 1,660 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-12-steel-production-advanced-chemistry-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-steel-production-advanced-chemistry-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-12-steel-production-advanced-chemistry-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "steel_production",
+    "prerequisite": "advanced_chemistry"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Chemistry provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because the scoped 1740s crucible/cast-steel process was craft metallurgy before modern chemistry explained steel composition; chemistry is important to later metallurgical science but not a direct prerequisite here.",
+  "source_supports_edge": "no",
+  "source_url": "https://worldsteel.org/about-steel/steel-story/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "World Steel Association notes Iron Age and early steelmakers did not understand steel chemistry and later explains Huntsman's 1740 crucible technique through cementation bars, crucibles, heat, and casting.",
+    "source_claim_summary": "Early and crucible steelmaking existed as craft metallurgy before modern scientific understanding of steel chemistry.",
+    "source_support_rationale": "The source supports removing advanced chemistry as a direct prerequisite for this early industrial steel-production scope."
+  },
+  "ontology_before": "The graph made steel production depend directly on advanced chemistry by broad inference.",
+  "ontology_after": "The graph removes the broad chemistry prerequisite and leaves steel production anchored in ironworking, metallurgy lineage, and blast-furnace scaling.",
+  "invariant_preserved_or_changed": "Changed: direct steel_production -> advanced_chemistry edge removed.",
+  "would_reject_if": [
+    "The node were rescoped to modern alloy design or physical metallurgy rather than steel production.",
+    "A stronger source showed Huntsman's crucible production required advanced chemistry as a direct capability."
+  ],
+  "short_reason": "Advanced chemistry is later explanatory science, not a direct prerequisite for 1740s crucible steel.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/steel_production.before.json /tmp/steel_production.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-steel-production-blast-furnace-scaling.json
+++ b/docs/edge-change-receipts/2026-06-12-steel-production-blast-furnace-scaling.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-12-steel-production-blast-furnace-scaling",
+  "decision_date": "2026-06-12",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "steel_production",
+    "prerequisite": "blast_furnace"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Blast Furnace provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "commercial_or_scaling_dependency",
+    "confidence": 0.76,
+    "evidence_level": "review",
+    "note": "Blast furnaces supplied pig iron for subsequent steel processing and became major scaling infrastructure, but they are not the defining invention of Huntsman's crucible steel."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.steel.org/steel-technology/steel-production/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "American Iron and Steel Institute 'How Steel Is Made' states steel is primarily produced by blast furnace or electric arc furnace routes and that the blast furnace produces pig iron from iron oxides.",
+    "source_claim_summary": "Blast furnaces are a major ironmaking step for steel production, while electric-arc routes also exist.",
+    "source_support_rationale": "The source supports blast furnaces as commercial/scaling infrastructure for steel production rather than as the defining prerequisite for Huntsman's crucible process."
+  },
+  "ontology_before": "The graph treated blast furnaces as a generic enabling prerequisite.",
+  "ontology_after": "The graph treats blast furnaces as major scaling infrastructure and feedstock production for steelmaking.",
+  "invariant_preserved_or_changed": "Changed: steel_production -> blast_furnace is commercial_or_scaling_dependency.",
+  "would_reject_if": [
+    "The node were narrowed only to modern electric-arc furnace steelmaking from scrap.",
+    "The graph later splits early crucible steel from bulk integrated steelmaking and moves this edge to the bulk steel node."
+  ],
+  "short_reason": "Blast furnaces scale steel feedstock rather than define early crucible steel.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/steel_production.before.json /tmp/steel_production.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-steel-production-iron-working-required.json
+++ b/docs/edge-change-receipts/2026-06-12-steel-production-iron-working-required.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-12-steel-production-iron-working-required",
+  "decision_date": "2026-06-12",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "steel_production",
+    "prerequisite": "iron_working"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Iron Working provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.86,
+    "evidence_level": "textbook",
+    "note": "Steel production requires prior ironworking because steel is an iron-carbon alloy made from iron feedstocks."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/technology/steel",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Britannica steel article introduction and 'How iron is turned into steel' media text define steel as an iron-carbon alloy and describe iron ore as a primary input for steel production.",
+    "source_claim_summary": "Steel is an alloy of iron and carbon; iron is a base input for steel production.",
+    "source_support_rationale": "The source supports ironworking as a direct material prerequisite for steel production, rather than merely contextual enabling background."
+  },
+  "ontology_before": "The graph treated iron working as a generic enabling background for steel production.",
+  "ontology_after": "The graph treats iron working as a required material prerequisite because steel production operates on iron feedstocks.",
+  "invariant_preserved_or_changed": "Changed: steel_production -> iron_working is required and source-backed.",
+  "would_reject_if": [
+    "The node were rescoped to steel trade, recycling-only scrap sorting, or a non-production use of steel.",
+    "A stronger ontology split represented raw iron feedstock separately from iron_working."
+  ],
+  "short_reason": "Steel production requires iron feedstocks.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/steel_production.before.json /tmp/steel_production.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-steel-production-metallurgy-lineage.json
+++ b/docs/edge-change-receipts/2026-06-12-steel-production-metallurgy-lineage.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-12-steel-production-metallurgy-lineage",
+  "decision_date": "2026-06-12",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "steel_production",
+    "prerequisite": "advanced_metallurgy_medieval"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Metallurgy (Medieval) provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.78,
+    "evidence_level": "review",
+    "note": "Crucible steel followed earlier iron and steelmaking craft, including cementation and medieval blast-furnace metallurgy."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://worldsteel.org/about-steel/steel-story/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "establishes_historical_lineage",
+    "source_locator": "World Steel Association sections 'The rise of crucible steel' and 'Production speed heats up' describe earlier cementation, European blast furnaces, and Huntsman's 1740 crucible technique.",
+    "source_claim_summary": "Huntsman's crucible steel sits in a lineage after earlier iron/steel craft, cementation, and blast-furnace metallurgy.",
+    "source_support_rationale": "The source supports a historical lineage from earlier metallurgy to crucible steel, not a strict engineering requirement for every steelmaking method."
+  },
+  "ontology_before": "The graph modeled advanced medieval metallurgy as a generic enabling prerequisite.",
+  "ontology_after": "The graph models advanced medieval metallurgy as the historical predecessor lineage for industrial crucible steel.",
+  "invariant_preserved_or_changed": "Changed: steel_production -> advanced_metallurgy_medieval is historical_predecessor.",
+  "would_reject_if": [
+    "The node were narrowed to a purely modern basic-oxygen furnace process.",
+    "A stronger source showed this specific medieval metallurgy node has a narrower unrelated scope."
+  ],
+  "short_reason": "Earlier metallurgy is lineage, not a hard prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/steel_production.before.json /tmp/steel_production.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-steel-production-steam-engine-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-steel-production-steam-engine-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-12-steel-production-steam-engine-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "steel_production",
+    "prerequisite": "steam_engine"
+  },
+  "old_claim": {
+    "type": "commercial_or_scaling_dependency",
+    "confidence": 0.72,
+    "evidence_level": "expert_inference",
+    "note": "Steam Engine supports manufacturing, deployment, commercialization, or operational scaling."
+  },
+  "new_claim_absent": "No direct dependency remains because Huntsman's 1740s crucible/cast-steel process predates steam-powered steel scaling and the inspected sources describe steam as later industrial context rather than a direct prerequisite for steel production.",
+  "source_supports_edge": "no",
+  "source_url": "https://worldsteel.org/about-steel/steel-story/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "World Steel Association describes Huntsman's 1740 crucible technique separately from later 'From trees to steam' and mass-production developments.",
+    "source_claim_summary": "Crucible steel was established before steam is presented as industrial scaling context.",
+    "source_support_rationale": "The source anchors steel production in a 1740 crucible process, making steam power unsupported as a direct prerequisite for this scoped node."
+  },
+  "ontology_before": "The graph made steel production depend directly on steam-engine scaling by generic inference.",
+  "ontology_after": "The graph removes steam_engine as a direct prerequisite for the scoped early industrial steel-production capability.",
+  "invariant_preserved_or_changed": "Changed: direct steel_production -> steam_engine edge removed.",
+  "would_reject_if": [
+    "The node were rescoped to steam-powered integrated steelworks rather than established steel production.",
+    "A stronger source showed Huntsman's crucible production directly required steam engines."
+  ],
+  "short_reason": "Steam is later scaling context, not a direct steel-production prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/steel_production.before.json /tmp/steel_production.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-steel-production-huntsman-scope.json
+++ b/docs/graph-invariants/2026-06-12-steel-production-huntsman-scope.json
@@ -1,0 +1,46 @@
+{
+  "id": "2026-06-12-steel-production-huntsman-scope",
+  "description": "Lock steel_production to established crucible/cast-steel production beginning in the 1740s, not low-cost bulk structural steel or generic metallurgy.",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "steel_production",
+      "operator": "eq",
+      "value": 1740,
+      "reason": "The node is anchored to Huntsman's 1740s crucible/cast-steel process, with Bessemer/open-hearth bulk steel represented downstream."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "steel_production",
+      "prerequisite": "iron_working",
+      "expected": "required",
+      "reason": "Steel production requires iron feedstocks because steel is an iron-carbon alloy."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "steel_production",
+      "prerequisite": "advanced_metallurgy_medieval",
+      "expected": "historical_predecessor",
+      "reason": "Earlier iron and steelmaking craft is the historical lineage for industrial crucible steel, not a hard universal component."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "steel_production",
+      "prerequisite": "blast_furnace",
+      "expected": "commercial_or_scaling_dependency",
+      "reason": "Blast furnaces supply pig iron and scaling infrastructure but are not the defining invention of Huntsman's crucible steel."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "steel_production",
+      "prerequisite": "steam_engine",
+      "reason": "Steam power is later scaling context and is not sourced as a direct prerequisite for 1740s crucible/cast-steel production."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "steel_production",
+      "prerequisite": "advanced_chemistry",
+      "reason": "Modern chemistry explains later metallurgy but is not a direct prerequisite for the scoped early industrial steel-production capability."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Rescopes `steel_production` from a generic 1760 large-scale-steel claim to established crucible/cast-steel production beginning in the 1740s.
- Replaces the Wikipedia-as-review node source with Britannica, Sheffield Museums Trust, and World Steel Association sources.
- Tightens direct dependency edges: `iron_working` is required; `advanced_metallurgy_medieval` is historical lineage; `blast_furnace` is commercial/scaling infrastructure.
- Removes unsupported direct `steam_engine` and `advanced_chemistry` prerequisites.
- Adds five edge-change receipts and a graph invariant for the Huntsman/crucible-steel scope.
- Regenerates the quality snapshot because edge-source totals changed from 1,918/5,507 to 1,921/5,505.

## Old Claim vs New Claim

Old claim: `steel_production` was a broad large-quantity steel-production capability dated exactly to 1760, backed only by Wikipedia typed as `review`, with generic inferred prerequisites including `steam_engine` and `advanced_chemistry`.

New claim: `steel_production` is scoped to controlled industrially important crucible/cast-steel production anchored to Huntsman's 1740s Sheffield process. Cheap high-volume structural steel remains represented downstream by Bessemer/open-hearth style nodes.

## Sources Used

- Encyclopaedia Britannica, `Benjamin Huntsman`: identifies Huntsman as inventor of crucible/cast steel and says he opened a Sheffield plant circa 1740.
- Sheffield Museums Trust, `Benjamin Huntsman Clock`: states the clock made in the 1740s is the first object to contain Huntsman's crucible cast steel and that the invention became the foundation of Sheffield's steel industry.
- World Steel Association, `The Steel Story`: describes earlier iron/steel craft, cementation, Huntsman's 1740 crucible technique, and explicitly separates it from later low-cost high-volume mass steel.
- Encyclopaedia Britannica, `Steel`: supports steel as an iron-carbon alloy made from iron feedstocks.
- American Iron and Steel Institute, `Steel Production`: supports blast furnace as a major steelmaking route and pig-iron feedstock/scaling infrastructure, not the defining Huntsman invention.

## Adversarial Note

The strongest reason this correction could be wrong is that `steel_production` might be intended to mean cheap bulk industrial steel rather than established crucible/cast-steel capability. If so, the right follow-up is to split this into `crucible_cast_steel` and `bulk_steel_production` rather than keeping one overloaded node. This PR avoids the larger split to stay reviewable while making the current broad node less misleading.

## Validation

Passed:

- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run invariant-coverage`
- `npm run node-snapshot-diff -- /tmp/steel_production.before.json /tmp/steel_production.after.json --require-behavior-change`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`
- `npm run agent:check -- --run`

Note: an earlier node-focused `source-urls` retry hit unrelated transient timeouts on existing non-steel sources, but the final full `npm run agent:check -- --run` source URL audit passed for 791 unique URLs.