### PR TITLE
Source-check limited liability corporation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 644 / 1,660 (38.8%) |
 | Nodes with node-level sources | 678 / 1,660 (40.8%) |
-| Dependency edges with edge-level sources | 1,921 / 5,505 (34.9%) |
+| Dependency edges with edge-level sources | 1,919 / 5,503 (34.9%) |
 | Era-default placeholder dates | 533 / 1,660 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/industrial.json
+++ b/data/industrial.json
@@ -62,12 +62,10 @@
     "id": "corporation_limited_liability",
     "name": "Limited Liability Corporation",
     "era": "Industrial",
-    "description": "A legal structure for business where corporate debts are separate from the personal assets of its owners, encouraging large-scale investment.",
+    "description": "A registered company/corporate form in which shareholders' exposure to company debts is legally limited, anchored here to the mid-1850s British limited-liability and joint-stock company statutes.",
     "prerequisites": [
       "codified_law",
-      "joint_stock_companies",
-      "banking",
-      "patent_systems"
+      "joint_stock_companies"
     ],
     "fields": [
       "Finance & Markets"
@@ -75,102 +73,96 @@
     "fieldLanes": {
       "Finance & Markets": "Institutions & Law"
     },
-    "firstKnownDate": 1860,
+    "maturity": "established",
+    "scopeNote": "Covers general statutory limited-liability company incorporation as normalized by the UK Limited Liability Act 1855 and Joint Stock Companies Act 1856. It does not represent modern U.S. LLC statutes, all earlier chartered corporations, or a claim that full modern owner shielding was universally adopted by 1855.",
+    "firstKnownDate": 1855,
     "datePrecision": "exact",
-    "region": "Europe, North America, and industrializing regions",
+    "region": "United Kingdom; later Europe, North America, and other industrializing legal systems",
     "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "codified_law",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Codified Law provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated",
+        "type": "common_dependency",
+        "confidence": 0.74,
+        "evidence_level": "textbook",
+        "note": "Limited-liability companies depend on statutory company law and registration rules, but ancient written law codes are a broad legal-system dependency rather than the direct historical invention.",
+        "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Limited liability company",
-            "url": "https://en.wikipedia.org/wiki/Limited_liability_company",
-            "source_type": "weak_web",
+            "title": "Business organization - Limited liability, companies, corporations",
+            "url": "https://www.britannica.com/money/business-organization/Limited-liability",
+            "publisher": "Encyclopaedia Britannica",
+            "year": 2026,
+            "source_type": "textbook",
             "supports": [
               "edge"
-            ],
-            "publisher": "Wikipedia",
-            "year": 2026
+            ]
           }
         ]
       },
       {
         "prerequisite": "joint_stock_companies",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Joint-Stock Companies provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated",
+        "type": "historical_predecessor",
+        "confidence": 0.86,
+        "evidence_level": "primary_source",
+        "note": "The 1855 and 1856 UK statutes applied limited liability through the joint-stock company registration framework.",
+        "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Joint-stock company",
-            "url": "https://en.wikipedia.org/wiki/Joint-stock_company",
-            "source_type": "weak_web",
+            "title": "Joint Stock Companies Act 1856",
+            "url": "https://www.irishstatutebook.ie/eli/1856/act/47/enacted/en/print.html",
+            "publisher": "Irish Statute Book / Office of the Attorney General",
+            "year": 1856,
+            "source_type": "official_agency",
             "supports": [
               "edge"
-            ],
-            "publisher": "Wikipedia",
-            "year": 2026
-          }
-        ]
-      },
-      {
-        "prerequisite": "banking",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Banking provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated",
-        "sources": [
-          {
-            "title": "Bank",
-            "url": "https://en.wikipedia.org/wiki/Bank",
-            "source_type": "weak_web",
-            "supports": [
-              "edge"
-            ],
-            "publisher": "Wikipedia",
-            "year": 2026
-          }
-        ]
-      },
-      {
-        "prerequisite": "patent_systems",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Patent Systems provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated",
-        "sources": [
-          {
-            "title": "Patent",
-            "url": "https://en.wikipedia.org/wiki/Patent",
-            "source_type": "weak_web",
-            "supports": [
-              "edge"
-            ],
-            "publisher": "Wikipedia",
-            "year": 2026
+            ]
           }
         ]
       }
     ],
     "sources": [
       {
-        "title": "Limited liability company",
-        "url": "https://en.wikipedia.org/wiki/Limited_liability_company",
-        "publisher": "Wikipedia",
-        "year": 2026,
-        "source_type": "review",
+        "title": "The Limited Liability Act 1855",
+        "url": "https://www.legislation.gov.uk/ukpga/1855/133/pdfs/ukpga_18550133_en.pdf",
+        "publisher": "legislation.gov.uk",
+        "year": 1855,
+        "source_type": "official_agency",
         "supports": [
           "node",
           "maturity"
+        ]
+      },
+      {
+        "title": "Joint Stock Companies Act 1856",
+        "url": "https://www.irishstatutebook.ie/eli/1856/act/47/enacted/en/print.html",
+        "publisher": "Irish Statute Book / Office of the Attorney General",
+        "year": 1856,
+        "source_type": "official_agency",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Limited liability",
+        "url": "https://www.britannica.com/money/limited-liability",
+        "publisher": "Encyclopaedia Britannica",
+        "year": 2026,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "A new understanding of the history of limited liability: an invitation for theoretical reframing",
+        "url": "https://www.cambridge.org/core/services/aop-cambridge-core/content/view/B12B69696AC81304A2738ADE4FFF4556/S1744137420000181a.pdf/new_understanding_of_the_history_of_limited_liability_an_invitation_for_theoretical_reframing.pdf",
+        "publisher": "Journal of Institutional Economics / Cambridge University Press",
+        "year": 2020,
+        "source_type": "review",
+        "supports": [
+          "node"
         ]
       }
     ]

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T15:29:13.367Z",
+  "generatedAt": "2026-06-12T15:43:05.440Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,9 +25,9 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1921,
-      "denominator": 5505,
-      "formatted": "1,921 / 5,505",
+      "value": 1919,
+      "denominator": 5503,
+      "formatted": "1,919 / 5,503",
       "note": "34.9%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 533,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5505,
-    "edgesWithSources": 1921
+    "totalEdges": 5503,
+    "edgesWithSources": 1919
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T15:29:13.367Z
+Generated: 2026-06-12T15:43:05.440Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 644 / 1,660 (38.8%) |
 | Nodes with node-level sources | 678 / 1,660 (40.8%) |
-| Dependency edges with edge-level sources | 1,921 / 5,505 (34.9%) |
+| Dependency edges with edge-level sources | 1,919 / 5,503 (34.9%) |
 | Era-default placeholder dates | 533 / 1,660 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-12-limited-liability-banking-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-limited-liability-banking-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-12-limited-liability-banking-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "corporation_limited_liability",
+    "prerequisite": "banking"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Banking provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because the scoped technology is a statutory company-law form; the inspected 1856 Act explicitly excluded banking firms from its ordinary registration provisions.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.irishstatutebook.ie/eli/1856/act/47/enacted/en/print.html",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Joint Stock Companies Act 1856 provisions exclude banking and insurance companies from the Act's ordinary application while creating the general company registration framework.",
+    "source_claim_summary": "Banking was not the direct prerequisite for the scoped limited-liability company form and was partly outside the 1856 Act framework.",
+    "source_support_rationale": "The source supports removing banking as a direct technology prerequisite, even though finance and investment are broader economic context."
+  },
+  "ontology_before": "The graph made limited-liability corporations depend directly on banking using a weak Wikipedia edge source.",
+  "ontology_after": "The graph removes banking from the direct prerequisites and keeps the node anchored to company law and joint-stock company lineage.",
+  "invariant_preserved_or_changed": "Changed: direct corporation_limited_liability -> banking edge removed.",
+  "would_reject_if": [
+    "The node were rescoped to banking corporations specifically.",
+    "A stronger source showed banking infrastructure was a direct legal prerequisite for general limited-liability incorporation."
+  ],
+  "short_reason": "Banking is economic context, not a direct company-law prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/corporation_limited_liability.before.json /tmp/corporation_limited_liability.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-limited-liability-codified-law-common.json
+++ b/docs/edge-change-receipts/2026-06-12-limited-liability-codified-law-common.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-12-limited-liability-codified-law-common",
+  "decision_date": "2026-06-12",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "corporation_limited_liability",
+    "prerequisite": "codified_law"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Codified Law provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "common_dependency",
+    "confidence": 0.74,
+    "evidence_level": "textbook",
+    "note": "Limited-liability companies depend on statutory company law and registration rules, but ancient written law codes are a broad legal-system dependency rather than the direct historical invention."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/money/business-organization/Limited-liability",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Britannica Money section 'History of the limited-liability company' distinguishes modern incorporation from general associated activity and describes incorporation, charters, and statutory corporate bodies.",
+    "source_claim_summary": "Limited-liability companies are legal/corporate entities created through incorporation law, not merely private business practice.",
+    "source_support_rationale": "The source supports a legal-system dependency while showing that ancient codified law is too broad to be a direct enabling invention for mid-19th-century limited-liability company statutes."
+  },
+  "ontology_before": "The graph treated ancient codified law as a generic enabling prerequisite for limited-liability corporations.",
+  "ontology_after": "The graph treats codified law as a broad common legal dependency while the node is scoped to specific mid-19th-century company statutes.",
+  "invariant_preserved_or_changed": "Changed: corporation_limited_liability -> codified_law is common_dependency.",
+  "would_reject_if": [
+    "A narrower company_law or incorporation_statute node is added and replaces codified_law.",
+    "The node is rescoped to ancient corporate bodies rather than mid-19th-century statutory company law."
+  ],
+  "short_reason": "Codified law is legal infrastructure, not the direct invention.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/corporation_limited_liability.before.json /tmp/corporation_limited_liability.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-limited-liability-joint-stock-lineage.json
+++ b/docs/edge-change-receipts/2026-06-12-limited-liability-joint-stock-lineage.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-12-limited-liability-joint-stock-lineage",
+  "decision_date": "2026-06-12",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "corporation_limited_liability",
+    "prerequisite": "joint_stock_companies"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Joint-Stock Companies provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.86,
+    "evidence_level": "primary_source",
+    "note": "The 1855 and 1856 UK statutes applied limited liability through the joint-stock company registration framework."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.irishstatutebook.ie/eli/1856/act/47/enacted/en/print.html",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "supports_chronology",
+    "source_locator": "Joint Stock Companies Act 1856 title and preamble describe incorporation and regulation of joint-stock companies and other associations; the Act repeals and consolidates the Limited Liability Act 1855.",
+    "source_claim_summary": "The 1856 statute made limited company registration part of joint-stock company law.",
+    "source_support_rationale": "The source supports joint-stock companies as the direct legal lineage for the limited-liability company form, not just generic business context."
+  },
+  "ontology_before": "The graph treated joint-stock companies as a generic enabling prerequisite.",
+  "ontology_after": "The graph models joint-stock companies as the historical legal predecessor for mid-19th-century limited-liability companies.",
+  "invariant_preserved_or_changed": "Changed: corporation_limited_liability -> joint_stock_companies is historical_predecessor.",
+  "would_reject_if": [
+    "The node were split into a non-shareholder LLC form such as the 1977 Wyoming LLC.",
+    "A future company_law node absorbs the legal lineage and this edge becomes too broad."
+  ],
+  "short_reason": "Limited liability was routed through joint-stock company law.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/corporation_limited_liability.before.json /tmp/corporation_limited_liability.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-limited-liability-patent-systems-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-limited-liability-patent-systems-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-12-limited-liability-patent-systems-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "corporation_limited_liability",
+    "prerequisite": "patent_systems"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Patent Systems provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because the scoped technology is statutory company registration with limited liability, not intellectual-property patents or incorporation by special patent grant.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.irishstatutebook.ie/eli/1856/act/47/enacted/en/print.html",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Joint Stock Companies Act 1856 title, preamble, and memorandum forms describe incorporation by registration and association rather than patent systems.",
+    "source_claim_summary": "The Act provides a registration route for joint-stock companies and does not require the patent system.",
+    "source_support_rationale": "The source supports removing the patent_systems edge as a topic mismatch for general limited-liability company incorporation."
+  },
+  "ontology_before": "The graph made limited-liability corporations depend directly on patent systems using a weak Wikipedia edge source.",
+  "ontology_after": "The graph removes patent systems and leaves the node scoped to statutory company registration and joint-stock company lineage.",
+  "invariant_preserved_or_changed": "Changed: direct corporation_limited_liability -> patent_systems edge removed.",
+  "would_reject_if": [
+    "The graph used patent_systems to mean letters patent or state chartering rather than intellectual-property patent systems.",
+    "The node were rescoped to chartered monopoly corporations instead of general limited-liability company registration."
+  ],
+  "short_reason": "Patent systems are a topic mismatch for general limited-liability incorporation.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/corporation_limited_liability.before.json /tmp/corporation_limited_liability.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-limited-liability-company-law-scope.json
+++ b/docs/graph-invariants/2026-06-12-limited-liability-company-law-scope.json
@@ -1,0 +1,39 @@
+{
+  "id": "2026-06-12-limited-liability-company-law-scope",
+  "description": "Lock corporation_limited_liability to mid-19th-century statutory limited-liability company incorporation, not modern LLCs, generic corporate capitalism, banking, or patent systems.",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "corporation_limited_liability",
+      "operator": "eq",
+      "value": 1855,
+      "reason": "The scoped node is anchored to the UK Limited Liability Act 1855, with the 1856 Joint Stock Companies Act as consolidation and registration framework."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "corporation_limited_liability",
+      "prerequisite": "codified_law",
+      "expected": "common_dependency",
+      "reason": "Limited liability requires statutory company law, but ancient codified law is broad legal infrastructure rather than the direct historical invention."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "corporation_limited_liability",
+      "prerequisite": "joint_stock_companies",
+      "expected": "historical_predecessor",
+      "reason": "The mid-1850s statutes applied limited liability through joint-stock company law and registration."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "corporation_limited_liability",
+      "prerequisite": "banking",
+      "reason": "Banking is broader finance context and was not a direct prerequisite for general limited-liability company incorporation."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "corporation_limited_liability",
+      "prerequisite": "patent_systems",
+      "reason": "Patent systems are not a direct prerequisite for statutory company registration with limited liability."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "agent:check": "node scripts/agent-check-plan.js",
     "accuracy:risks": "node scripts/generate-quality-snapshot.js --silent && node scripts/accuracy-risk-report.js",
     "quality:snapshot": "node scripts/generate-quality-snapshot.js",
+    "quality:queue": "node scripts/source-quality-queue.js",
     "quality:field:crispr": "node scripts/generate-field-quality-snapshot.js",
     "trust:audit": "node scripts/audit-trust-levels.js",
     "audit:crispr": "node scripts/audit-crispr-edge-quality.js",

--- a/scripts/source-quality-queue.js
+++ b/scripts/source-quality-queue.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const ERA_FILES = [
+  'ancient.json',
+  'classical.json',
+  'medieval.json',
+  'renaissance.json',
+  'industrial.json',
+  'modern.json',
+  'future.json'
+];
+
+const limitArg = process.argv.find(arg => arg.startsWith('--limit='));
+const limit = limitArg ? Number(limitArg.split('=')[1]) : 40;
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function sourceText(source) {
+  return `${source.publisher || ''} ${source.title || ''} ${source.url || ''}`;
+}
+
+function sourceLabel(source) {
+  let host = '';
+  try {
+    host = source.url ? new URL(source.url).hostname.replace(/^www\./, '') : '';
+  } catch {
+    host = 'invalid-url';
+  }
+  return `${source.publisher || source.title}:${source.source_type}${host ? `@${host}` : ''}`;
+}
+
+function isWikipedia(source) {
+  return /wikipedia/i.test(sourceText(source));
+}
+
+function isInflatedWikipedia(source) {
+  return isWikipedia(source) && !['weak_web', 'generic_overview'].includes(source.source_type);
+}
+
+function isWeakOrGeneric(source) {
+  return ['weak_web', 'generic_overview'].includes(source.source_type);
+}
+
+function readCoverageText(dir) {
+  if (!fs.existsSync(dir)) return '';
+  return fs.readdirSync(dir)
+    .filter(file => file.endsWith('.json'))
+    .map(file => fs.readFileSync(path.join(dir, file), 'utf8'))
+    .join('\n');
+}
+
+const nodes = [];
+for (const file of ERA_FILES) {
+  for (const node of readJson(path.join('data', file))) {
+    nodes.push({ ...node, file });
+  }
+}
+
+const dependentCounts = new Map(nodes.map(node => [node.id, 0]));
+for (const node of nodes) {
+  for (const prerequisite of node.prerequisites || []) {
+    dependentCounts.set(prerequisite, (dependentCounts.get(prerequisite) || 0) + 1);
+  }
+}
+
+const coverageText = [
+  readCoverageText(path.join('docs', 'edge-change-receipts')),
+  readCoverageText(path.join('docs', 'graph-invariants'))
+].join('\n');
+
+const candidates = [];
+for (const node of nodes) {
+  const sources = node.sources || [];
+  if (node.reviewStatus !== 'source_checked' || sources.length === 0) continue;
+
+  const inflatedWikipedia = sources.some(isInflatedWikipedia);
+  const onlyWeakOrGeneric = sources.every(isWeakOrGeneric);
+  const onlyWikipedia = sources.every(isWikipedia);
+  if (!inflatedWikipedia && !onlyWeakOrGeneric && !onlyWikipedia) continue;
+
+  candidates.push({
+    id: node.id,
+    name: node.name,
+    era: node.era,
+    date: node.firstKnownDate,
+    file: node.file,
+    dependents: dependentCounts.get(node.id) || 0,
+    risk: [
+      inflatedWikipedia ? 'inflated_wikipedia_source_type' : null,
+      onlyWeakOrGeneric ? 'only_weak_or_generic_sources' : null,
+      onlyWikipedia ? 'only_wikipedia_sources' : null
+    ].filter(Boolean).join(','),
+    alreadyCovered: coverageText.includes(`"${node.id}"`),
+    sources: sources.map(sourceLabel).join('; ')
+  });
+}
+
+candidates.sort((a, b) => {
+  if (a.alreadyCovered !== b.alreadyCovered) return a.alreadyCovered ? 1 : -1;
+  return b.dependents - a.dependents || a.id.localeCompare(b.id);
+});
+
+console.log('dependents\tcovered\tid\tname\tera\tdate\trisk\tsources');
+for (const candidate of candidates.slice(0, limit)) {
+  console.log([
+    candidate.dependents,
+    candidate.alreadyCovered ? 'yes' : 'no',
+    candidate.id,
+    candidate.name,
+    candidate.era,
+    candidate.date,
+    candidate.risk,
+    candidate.sources
+  ].join('\t'));
+}


### PR DESCRIPTION
## Summary

- Rescopes `corporation_limited_liability` to statutory limited-liability company incorporation anchored to the UK Limited Liability Act 1855 and Joint Stock Companies Act 1856.
- Replaces the Wikipedia-as-review source with official statute sources, Britannica, and a Cambridge/JIE review article.
- Changes the date from exact 1860 to exact 1855 and narrows the region/scope note.
- Retypes `codified_law` from generic enabling to `common_dependency` and `joint_stock_companies` to `historical_predecessor`.
- Removes unsupported direct `banking` and `patent_systems` prerequisites.
- Adds four edge-change receipts and one graph invariant.
- Adds `npm run quality:queue` to surface unresolved source-quality targets and mark nodes that already have receipt/invariant coverage, reducing repeated work.
- Regenerates the quality snapshot after removing two unsupported edges.

## Old Claim vs New Claim

Old claim: `corporation_limited_liability` was a broad 1860 industrial-era legal structure backed only by Wikipedia typed as `review`, with weak direct edges to banking and patent systems.

New claim: the node is explicitly scoped to general statutory limited-liability company incorporation in the mid-1850s UK company-law framework. It does not claim that modern U.S. LLCs, all chartered corporations, or full modern owner shielding were already universal in 1855.

## Sources Used

- `The Limited Liability Act 1855`, legislation.gov.uk PDF.
- `Joint Stock Companies Act 1856`, Irish Statute Book / Office of the Attorney General.
- Britannica Money, `Limited liability` and `Business organization - Limited liability, companies, corporations`.
- Ron Harris, `A new understanding of the history of limited liability`, Journal of Institutional Economics / Cambridge University Press, 2020.

## Repeat-Avoidance

`npm run quality:queue -- --limit=15` now lists source-quality candidates by downstream impact, whether they already have receipt/invariant coverage, and source host/type. This makes source-title leakage visible, e.g. a museum publisher attached to a Wikipedia URL, and keeps already-covered nodes below fresh unresolved targets.

## Adversarial Note

The strongest reason this correction could be wrong is that the node name could be interpreted as the modern U.S. limited liability company rather than the older limited-liability corporation/company form. The scope note now explicitly rejects the modern LLC interpretation; if the graph later needs U.S. LLCs, that should be a separate node dated to Wyoming's 1977 LLC statute.

## Validation

Passed:

- `node --check scripts/source-quality-queue.js`
- `npm run quality:queue -- --limit=15`
- `npm run node-snapshot-diff -- /tmp/corporation_limited_liability.before.json /tmp/corporation_limited_liability.after.json --require-behavior-change`
- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run invariant-coverage`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`
- `npm run agent:check -- --run` including source URL audit for 794 unique URLs