### PR TITLE
Source-check carbon fiber composites

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,660 |
 | Source-checked nodes | 644 / 1,660 (38.8%) |
 | Nodes with node-level sources | 678 / 1,660 (40.8%) |
-| Dependency edges with edge-level sources | 1,919 / 5,503 (34.9%) |
+| Dependency edges with edge-level sources | 1,920 / 5,501 (34.9%) |
 | Era-default placeholder dates | 533 / 1,660 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/modern.json
+++ b/data/modern.json
@@ -954,11 +954,9 @@
     "id": "composite_materials_carbon_fiber",
     "name": "Composite Materials (Carbon Fiber)",
     "era": "Modern",
-    "description": "Materials made from two or more constituent materials with significantly different properties, such as carbon fiber-reinforced polymers, offering high strength-to-weight ratios.",
+    "description": "High-performance carbon fibers and carbon-fiber reinforced polymer composites that combine carbon-fiber reinforcement with polymer matrices for high strength-to-weight structural applications.",
     "prerequisites": [
-      "polymer_chemistry",
-      "synthetic_materials_advanced",
-      "construction"
+      "polymer_chemistry"
     ],
     "fields": [
       "Materials Science & Manufacturing"
@@ -967,57 +965,66 @@
       "Materials Science & Manufacturing": "Composites"
     },
     "maturity": "established",
+    "scopeNote": "Covers modern high-performance carbon fibers beginning with Roger Bacon's 1958 graphite-whisker work and their use in carbon-fiber reinforced polymer/composite systems. It does not cover all ancient or modern composite materials, generic construction, or every advanced synthetic material.",
     "sources": [
       {
-        "title": "Materials",
-        "url": "https://www.nist.gov/materials",
-        "publisher": "NIST",
-        "year": 2026,
-        "source_type": "generic_overview",
+        "title": "High Performance Carbon Fibers",
+        "url": "https://www.acs.org/education/whatischemistry/landmarks/carbonfibers.html",
+        "publisher": "American Chemical Society",
+        "year": 2003,
+        "source_type": "review",
         "supports": [
           "node",
           "maturity"
         ]
       },
       {
-        "title": "Carbon fiber",
-        "url": "https://en.wikipedia.org/wiki/Carbon_fiber",
-        "publisher": "Wikipedia",
-        "year": 2026,
-        "source_type": "weak_web",
+        "title": "Growth, Structure, and Properties of Graphite Whiskers",
+        "url": "https://pubs.aip.org/aip/jap/article/31/2/283/506241/Growth-Structure-and-Properties-of-Graphite",
+        "publisher": "Journal of Applied Physics",
+        "year": 1960,
+        "source_type": "primary_paper",
         "supports": [
-          "node"
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Recent advances in interface microscopic characterization of carbon fiber-reinforced polymer composites",
+        "url": "https://www.frontiersin.org/journals/materials/articles/10.3389/fmats.2023.1124338/full",
+        "publisher": "Frontiers in Materials",
+        "year": 2023,
+        "source_type": "review",
+        "supports": [
+          "node",
+          "maturity"
         ]
       }
     ],
     "firstKnownDate": 1958,
     "datePrecision": "exact",
-    "region": "Global / multiple regions",
+    "region": "Union Carbide Parma Technical Center, Ohio, United States; later global aerospace and industrial composite manufacturing",
     "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "polymer_chemistry",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Polymer Chemistry provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "synthetic_materials_advanced",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Synthetic Materials provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "construction",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Construction provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "required",
+        "confidence": 0.84,
+        "evidence_level": "review",
+        "note": "Carbon-fiber reinforced polymer composites require polymer matrix chemistry and carbon-fiber precursor processing, even though carbon fibers themselves can also be used in non-polymer matrices.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Recent advances in interface microscopic characterization of carbon fiber-reinforced polymer composites",
+            "url": "https://www.frontiersin.org/journals/materials/articles/10.3389/fmats.2023.1124338/full",
+            "publisher": "Frontiers in Materials",
+            "year": 2023,
+            "source_type": "review",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T15:43:05.440Z",
+  "generatedAt": "2026-06-12T15:59:09.758Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,9 +25,9 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1919,
-      "denominator": 5503,
-      "formatted": "1,919 / 5,503",
+      "value": 1920,
+      "denominator": 5501,
+      "formatted": "1,920 / 5,501",
       "note": "34.9%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 533,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5503,
-    "edgesWithSources": 1919
+    "totalEdges": 5501,
+    "edgesWithSources": 1920
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T15:43:05.440Z
+Generated: 2026-06-12T15:59:09.758Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,660 |
 | Source-checked nodes | 644 / 1,660 (38.8%) |
 | Nodes with node-level sources | 678 / 1,660 (40.8%) |
-| Dependency edges with edge-level sources | 1,919 / 5,503 (34.9%) |
+| Dependency edges with edge-level sources | 1,920 / 5,501 (34.9%) |
 | Era-default placeholder dates | 533 / 1,660 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-12-carbon-fiber-construction-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-carbon-fiber-construction-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-12-carbon-fiber-construction-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "composite_materials_carbon_fiber",
+    "prerequisite": "construction"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Construction provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because construction is an application domain for some composites, not a source-backed prerequisite for high-performance carbon fibers or carbon-fiber reinforced polymer composites.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.frontiersin.org/journals/materials/articles/10.3389/fmats.2023.1124338/full",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Frontiers review abstract and introduction define CFRP through carbon fiber, polymer matrix, and interface, and list construction as an application area rather than a prerequisite.",
+    "source_claim_summary": "The scoped composite technology is a materials-engineering system; construction is one downstream application domain.",
+    "source_support_rationale": "The source supports removing construction as a direct prerequisite while leaving construction as a possible application domain elsewhere."
+  },
+  "ontology_before": "The graph made carbon-fiber composites depend directly on classical construction by generic inference.",
+  "ontology_after": "The graph removes construction from the direct prerequisites and anchors the node to carbon-fiber and polymer-composite materials science.",
+  "invariant_preserved_or_changed": "Changed: direct composite_materials_carbon_fiber -> construction edge removed.",
+  "would_reject_if": [
+    "The node were rescoped to civil-engineering composite reinforcement specifically.",
+    "A stronger source showed ancient/classical construction was a direct prerequisite for CFRP invention."
+  ],
+  "short_reason": "Construction is an application domain, not a direct CFRP prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/composite_materials_carbon_fiber.before.json /tmp/composite_materials_carbon_fiber.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-carbon-fiber-polymer-chemistry-required.json
+++ b/docs/edge-change-receipts/2026-06-12-carbon-fiber-polymer-chemistry-required.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-12-carbon-fiber-polymer-chemistry-required",
+  "decision_date": "2026-06-12",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "composite_materials_carbon_fiber",
+    "prerequisite": "polymer_chemistry"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Polymer Chemistry provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "required",
+    "confidence": 0.84,
+    "evidence_level": "review",
+    "note": "Carbon-fiber reinforced polymer composites require polymer matrix chemistry and carbon-fiber precursor processing, even though carbon fibers themselves can also be used in non-polymer matrices."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.frontiersin.org/journals/materials/articles/10.3389/fmats.2023.1124338/full",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "describes_component_architecture",
+    "source_locator": "Frontiers review abstract and introduction state that CFRP comprises carbon fiber, polymer matrix, and the interface between them; it also identifies thermosetting and thermoplastic resins as polymer matrices.",
+    "source_claim_summary": "Carbon-fiber reinforced polymer composites combine carbon-fiber reinforcement with a polymer matrix and interface.",
+    "source_support_rationale": "The source supports polymer chemistry as a direct component dependency for the scoped carbon-fiber reinforced polymer/composite node."
+  },
+  "ontology_before": "The graph treated polymer chemistry as a generic enabling context for carbon-fiber composites.",
+  "ontology_after": "The graph treats polymer chemistry as required for the scoped carbon-fiber reinforced polymer composite capability.",
+  "invariant_preserved_or_changed": "Changed: composite_materials_carbon_fiber -> polymer_chemistry is required.",
+  "would_reject_if": [
+    "The node were rescoped to bare carbon fiber production only.",
+    "The graph split carbon fibers from CFRP and moved the polymer edge to the CFRP-specific node."
+  ],
+  "short_reason": "CFRP requires a polymer matrix and precursor processing.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/composite_materials_carbon_fiber.before.json /tmp/composite_materials_carbon_fiber.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-carbon-fiber-synthetic-materials-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-carbon-fiber-synthetic-materials-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-12-carbon-fiber-synthetic-materials-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "composite_materials_carbon_fiber",
+    "prerequisite": "synthetic_materials_advanced"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Advanced Synthetic Materials provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because the inspected sources explain carbon-fiber composites through high-performance carbon fibers, polymer matrices, and precursor processing rather than the broad advanced_synthetic_materials bucket.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.acs.org/education/whatischemistry/landmarks/carbonfibers.html",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "ACS sections 'Discovery of High Performance Carbon Fibers' and 'Early Applications of Carbon Fibers' identify Bacon's graphite whiskers, rayon/PAN precursors, and entry into advanced composites, not a generic advanced-synthetic-materials prerequisite.",
+    "source_claim_summary": "Carbon-fiber composites emerged from specific carbon-fiber and precursor-process developments rather than a broad synthetic-materials category.",
+    "source_support_rationale": "The source supports replacing the broad inferred prerequisite with a narrower source-backed polymer/fiber basis."
+  },
+  "ontology_before": "The graph made carbon-fiber composites depend directly on a broad unsourced advanced synthetic materials node.",
+  "ontology_after": "The graph removes the broad edge and keeps the direct dependency on polymer chemistry.",
+  "invariant_preserved_or_changed": "Changed: direct composite_materials_carbon_fiber -> synthetic_materials_advanced edge removed.",
+  "would_reject_if": [
+    "The node were rescoped to advanced synthetic materials generally.",
+    "A later split adds a sourced precursor_materials node that replaces polymer_chemistry."
+  ],
+  "short_reason": "The broad synthetic-materials edge hid the specific carbon-fiber/polymer dependency.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/composite_materials_carbon_fiber.before.json /tmp/composite_materials_carbon_fiber.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-carbon-fiber-composites-scope.json
+++ b/docs/graph-invariants/2026-06-12-carbon-fiber-composites-scope.json
@@ -1,0 +1,32 @@
+{
+  "id": "2026-06-12-carbon-fiber-composites-scope",
+  "description": "Lock composite_materials_carbon_fiber to modern high-performance carbon fibers and carbon-fiber reinforced polymer/composite systems, not all composite materials or generic construction.",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "composite_materials_carbon_fiber",
+      "operator": "eq",
+      "value": 1958,
+      "reason": "The node is anchored to Roger Bacon's 1958 demonstration of high-performance carbon fibers at Union Carbide's Parma Technical Center."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "composite_materials_carbon_fiber",
+      "prerequisite": "polymer_chemistry",
+      "expected": "required",
+      "reason": "The scoped CFRP/composite capability requires polymer matrix and precursor chemistry."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "composite_materials_carbon_fiber",
+      "prerequisite": "synthetic_materials_advanced",
+      "reason": "The broad advanced-synthetic-materials node is not a source-backed direct prerequisite for high-performance carbon fibers or CFRP."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "composite_materials_carbon_fiber",
+      "prerequisite": "construction",
+      "reason": "Construction is an application domain for some composites, not a direct prerequisite for the scoped materials capability."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Rescopes `composite_materials_carbon_fiber` to modern high-performance carbon fibers and carbon-fiber reinforced polymer composites, instead of generic composite materials.
- Replaces weak/generic node sources with ACS, the Roger Bacon graphite-whisker paper, and a CFRP review.
- Removes broad contextual prerequisites (`synthetic_materials_advanced`, `construction`) and keeps only the direct scoped `polymer_chemistry` required edge with an edge-level source.
- Adds edge-change receipts plus a graph invariant so this correction is not repeated or silently regressed.
- Regenerates the quality snapshot; sourced dependency edges move from `1,919 / 5,503` to `1,920 / 5,501`.

## Why the old model was misleading

The prior node mixed generic composites, carbon fiber, and broad construction context. That made `construction` and `synthetic_materials_advanced` look like causal prerequisites for CFRP, even though the scoped technology is a materials-engineering system centered on carbon-fiber reinforcement and polymer matrix chemistry.

## Sources used

- American Chemical Society, `High Performance Carbon Fibers`
- Roger Bacon, `Growth, Structure, and Properties of Graphite Whiskers`, Journal of Applied Physics, 1960
- Frontiers in Materials, `Recent advances in interface microscopic characterization of carbon fiber-reinforced polymer composites`, 2023

## Adversarial note

The remaining uncertainty is scope granularity: one could split bare high-performance carbon fibers from carbon-fiber reinforced polymer composites. If we do that later, the polymer dependency should move to the CFRP-specific node while the carbon-fiber production node gets a narrower precursor/process edge model.

## Validation

- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run invariant-coverage`
- `npm run node-snapshot-diff -- /tmp/composite_materials_carbon_fiber.before.json /tmp/composite_materials_carbon_fiber.after.json --require-behavior-change`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`
- `npm run agent:check -- --run`