### PR TITLE
Source-check Brunelleschi architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,915 / 5,495 (34.8%) |
+| Dependency edges with edge-level sources | 1,918 / 5,492 (34.9%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T16:15:38.632Z",
+  "generatedAt": "2026-06-12T16:28:39.259Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,10 +25,10 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1915,
-      "denominator": 5495,
-      "formatted": "1,915 / 5,495",
-      "note": "34.8%"
+      "value": 1918,
+      "denominator": 5492,
+      "formatted": "1,918 / 5,492",
+      "note": "34.9%"
     },
     {
       "label": "Era-default placeholder dates",
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 533,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5495,
-    "edgesWithSources": 1915
+    "totalEdges": 5492,
+    "edgesWithSources": 1918
   }
 }

--- a/data/renaissance.json
+++ b/data/renaissance.json
@@ -3125,13 +3125,11 @@
     "id": "renaissance_architecture_brunelleschi",
     "name": "Renaissance Architecture (Brunelleschi)",
     "era": "Renaissance",
-    "description": "A revival of classical forms and principles like symmetry, proportion, and geometry. Characterized by works like Brunelleschi's dome for the Florence Cathedral, it emphasized human scale and rational design.",
+    "description": "Early Florentine Renaissance architecture associated with Filippo Brunelleschi, especially the Ospedale degli Innocenti and the dome of Santa Maria del Fiore, combining classical architectural vocabulary, geometric order, and new construction solutions.",
     "prerequisites": [
       "geometry",
       "construction",
-      "humanism",
-      "roman_architecture_revival",
-      "mathematics"
+      "roman_architecture_revival"
     ],
     "fields": [
       "Civil Engineering & Built Environment"
@@ -3139,61 +3137,127 @@
     "fieldLanes": {
       "Civil Engineering & Built Environment": "Structural Systems"
     },
-    "firstKnownDate": 1400,
+    "maturity": "established",
+    "scopeNote": "Covers Brunelleschi's early Florentine architectural work beginning with the 1419 Ospedale degli Innocenti commission and the 1420-1436 Santa Maria del Fiore dome. It does not represent all Renaissance architecture, all humanist thought, or generic mathematical practice.",
+    "firstKnownDate": 1419,
     "datePrecision": "exact",
-    "region": "Europe and connected early modern exchange networks",
+    "region": "Florence, Republic of Florence (modern Italy)",
     "reviewStatus": "source_checked",
     "dependencyEdges": [
       {
         "prerequisite": "geometry",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Geometry provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "confidence": 0.78,
+        "evidence_level": "textbook",
+        "note": "Brunelleschi's dome depended on geometric control of ribs, rings, curvature, and measuring wires, but geometry is an enabling design method rather than the whole architectural technology.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "The Duomo",
+            "url": "https://www.britannica.com/topic/the-Duomo",
+            "publisher": "Encyclopaedia Britannica",
+            "year": 2026,
+            "source_type": "textbook",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "construction",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Construction provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "humanism",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Humanism provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "confidence": 0.78,
+        "evidence_level": "review",
+        "note": "The scoped technology is built architecture: Brunelleschi directed construction at the Ospedale degli Innocenti and the cathedral dome worksite, so prior monumental/civic construction practice is enabling infrastructure.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Architecture",
+            "url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+            "publisher": "Museo degli Innocenti",
+            "year": 2026,
+            "source_type": "museum",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "roman_architecture_revival",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Roman Architecture Revival provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "mathematics",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Mathematics provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "confidence": 0.8,
+        "evidence_level": "review",
+        "note": "Brunelleschi's Florentine architecture recovered classical elements, and his dome solution drew on study of the Pantheon; Roman architectural revival is therefore an enabling lineage, not a hard component prerequisite.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Architecture",
+            "url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+            "publisher": "Museo degli Innocenti",
+            "year": 2026,
+            "source_type": "museum",
+            "supports": [
+              "edge"
+            ]
+          },
+          {
+            "title": "Filippo Brunelleschi, Dome of the Cathedral of Florence",
+            "url": "https://smarthistory.org/brunelleschi-dome-of-the-cathedral-of-florence/",
+            "publisher": "Smarthistory",
+            "year": 2026,
+            "source_type": "review",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       }
     ],
     "sources": [
       {
-        "title": "Filippo Brunelleschi",
-        "url": "https://en.wikipedia.org/wiki/Filippo_Brunelleschi",
-        "publisher": "Wikipedia",
+        "title": "Architecture",
+        "url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+        "publisher": "Museo degli Innocenti",
+        "year": 2026,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "On 30 August 1436 the work on Brunelleschi's Dome was completed",
+        "url": "https://duomo.firenze.it/en/opera-magazine/post/4649/on-30-august-1436-the-work-on-brunelleschi-s-dome-was-completed",
+        "publisher": "Opera di Santa Maria del Fiore",
+        "year": 2022,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "The Duomo",
+        "url": "https://www.britannica.com/topic/the-Duomo",
+        "publisher": "Encyclopaedia Britannica",
+        "year": 2026,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Filippo Brunelleschi, Dome of the Cathedral of Florence",
+        "url": "https://smarthistory.org/brunelleschi-dome-of-the-cathedral-of-florence/",
+        "publisher": "Smarthistory",
         "year": 2026,
         "source_type": "review",
         "supports": [
-          "node"
+          "node",
+          "maturity"
         ]
       }
     ]
@@ -3660,8 +3724,7 @@
     "prerequisites": [
       "cannons",
       "construction",
-      "geometry",
-      "renaissance_architecture_brunelleschi"
+      "geometry"
     ],
     "firstKnownDate": 1400,
     "datePrecision": "century",
@@ -3690,14 +3753,6 @@
         "confidence": 0.68,
         "evidence_level": "expert_inference",
         "note": "Geometry provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "renaissance_architecture_brunelleschi",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Renaissance Architecture (Brunelleschi) provides a capability that enables this technology without being the only possible path.",
         "reviewStatus": "structurally_validated"
       }
     ]

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T16:15:38.632Z
+Generated: 2026-06-12T16:28:39.259Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,915 / 5,495 (34.8%) |
+| Dependency edges with edge-level sources | 1,918 / 5,492 (34.9%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-12-brunelleschi-construction-evidence.json
+++ b/docs/edge-change-receipts/2026-06-12-brunelleschi-construction-evidence.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-12-brunelleschi-construction-evidence",
+  "decision_date": "2026-06-12",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "renaissance_architecture_brunelleschi",
+    "prerequisite": "construction"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Construction provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.78,
+    "evidence_level": "review",
+    "note": "The scoped technology is built architecture: Brunelleschi directed construction at the Ospedale degli Innocenti and the cathedral dome worksite, so prior monumental/civic construction practice is enabling infrastructure."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "documents_application_use",
+    "source_locator": "Museo degli Innocenti states that the Ospedale was built beginning in 1419 and that Brunelleschi directed its construction site from 1419 to 1427.",
+    "source_claim_summary": "Brunelleschi's early Renaissance architecture was realized through directed building construction at the Ospedale degli Innocenti.",
+    "source_support_rationale": "This backs construction as enabling infrastructure for the built works while avoiding a stronger claim that classical monumental construction is the only route to Renaissance architectural design."
+  },
+  "invariant_preserved_or_changed": "Preserved edge type: construction remains enabling but is now source-checked.",
+  "would_reject_if": [
+    "The node is narrowed to unbuilt architectural theory only.",
+    "Construction is promoted to required without distinguishing generic building practice from classical monumental construction."
+  ],
+  "short_reason": "Construction is an enabling infrastructure edge for Brunelleschi's built architectural works.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-brunelleschi-geometry-evidence.json
+++ b/docs/edge-change-receipts/2026-06-12-brunelleschi-geometry-evidence.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-12-brunelleschi-geometry-evidence",
+  "decision_date": "2026-06-12",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "renaissance_architecture_brunelleschi",
+    "prerequisite": "geometry"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Geometry provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.78,
+    "evidence_level": "textbook",
+    "note": "Brunelleschi's dome depended on geometric control of ribs, rings, curvature, and measuring wires, but geometry is an enabling design method rather than the whole architectural technology."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.britannica.com/topic/the-Duomo",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "demonstrates_method_dependency",
+    "source_locator": "Britannica description of Brunelleschi's dome explains the ribs, tie rings, shells, curvature, and measuring wires used to maintain the structure's geometry.",
+    "source_claim_summary": "The dome's construction used explicit geometric control of the ribs, rings, and curvature, making geometry an enabling method.",
+    "source_support_rationale": "This supports an enabling edge because the source ties geometric layout/control to Brunelleschi's dome without claiming geometry alone constitutes Renaissance architecture."
+  },
+  "invariant_preserved_or_changed": "Preserved edge type: geometry remains enabling but is now source-checked.",
+  "would_reject_if": [
+    "The node is rescoped away from Brunelleschi's dome and early Florentine architecture.",
+    "Geometry is modeled as a hard required prerequisite for all Renaissance architecture."
+  ],
+  "short_reason": "Geometry stays as an enabling method, now backed by a source-specific dome description.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-brunelleschi-humanism-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-brunelleschi-humanism-removal.json
@@ -1,0 +1,40 @@
+{
+  "id": "2026-06-12-brunelleschi-humanism-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "renaissance_architecture_brunelleschi",
+    "prerequisite": "humanism"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Humanism provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because humanism is a broad cultural context for Renaissance architecture, not a specific technical prerequisite for Brunelleschi's built architectural works.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Museo degli Innocenti explains the 1419 commission, Brunelleschi's construction role, and recovery of classical architectural elements; it does not identify humanism as a direct construction or design dependency.",
+    "source_claim_summary": "The source supports the Brunelleschi architecture scope through commission, construction, and classical elements rather than through a direct humanism dependency.",
+    "source_support_rationale": "This justifies removing the broad context edge because the technical claim is better represented by construction, geometry, and Roman/classical revival edges."
+  },
+  "ontology_before": "The graph treated a broad intellectual movement as a direct prerequisite for Brunelleschi's architecture.",
+  "ontology_after": "The graph keeps concrete design/construction lineages and leaves humanism as wider cultural context rather than a direct dependency.",
+  "invariant_preserved_or_changed": "Changed: direct renaissance_architecture_brunelleschi -> humanism edge removed.",
+  "would_reject_if": [
+    "A future node specifically models humanist architectural theory rather than Brunelleschi's built works.",
+    "A source directly shows humanist scholarship as a necessary design method for the scoped works."
+  ],
+  "short_reason": "Humanism was too broad and contextual for this direct technology-dependency edge.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-brunelleschi-mathematics-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-brunelleschi-mathematics-removal.json
@@ -1,0 +1,40 @@
+{
+  "id": "2026-06-12-brunelleschi-mathematics-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "renaissance_architecture_brunelleschi",
+    "prerequisite": "mathematics"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Mathematics provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because the more specific geometry edge now carries the source-backed design-method relationship for Brunelleschi's dome and architecture.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.britannica.com/topic/the-Duomo",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Britannica details geometric/structural methods for the dome, including ribs, rings, curvature, and measuring wires, rather than a broad mathematics dependency.",
+    "source_claim_summary": "The source supports a specific geometry/design-method edge but does not require a separate broad mathematics edge.",
+    "source_support_rationale": "Removing the duplicate mathematics edge keeps the graph more compact and precise because geometry already sits under mathematics elsewhere in the graph."
+  },
+  "ontology_before": "The graph had both geometry and broad mathematics as direct prerequisites, duplicating the same causal channel.",
+  "ontology_after": "The graph keeps the specific geometry edge and relies on geometry's own prerequisites for broader mathematical lineage.",
+  "invariant_preserved_or_changed": "Changed: direct renaissance_architecture_brunelleschi -> mathematics edge removed.",
+  "would_reject_if": [
+    "The geometry prerequisite is removed from the scoped node.",
+    "A source demonstrates a distinct non-geometric mathematical dependency for Brunelleschi's architecture."
+  ],
+  "short_reason": "The broad mathematics edge duplicated the more precise geometry dependency.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-brunelleschi-roman-revival-evidence.json
+++ b/docs/edge-change-receipts/2026-06-12-brunelleschi-roman-revival-evidence.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-12-brunelleschi-roman-revival-evidence",
+  "decision_date": "2026-06-12",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "renaissance_architecture_brunelleschi",
+    "prerequisite": "roman_architecture_revival"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Roman Architecture Revival provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.8,
+    "evidence_level": "review",
+    "note": "Brunelleschi's Florentine architecture recovered classical elements, and his dome solution drew on study of the Pantheon; Roman architectural revival is therefore an enabling lineage, not a hard component prerequisite."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Museo degli Innocenti describes Brunelleschi's use of columns, capitals, arches, vaults, and recovery of classical elements as anticipating Florentine Renaissance architecture.",
+    "source_claim_summary": "The Ospedale project connects Brunelleschi's architectural language to recovered classical elements and Florentine Renaissance architecture.",
+    "source_support_rationale": "This supports Roman/classical revival as an enabling lineage while leaving the edge non-required because the source frames a stylistic/historical relationship, not a material component."
+  },
+  "invariant_preserved_or_changed": "Preserved edge type: roman_architecture_revival remains enabling but is now source-checked.",
+  "would_reject_if": [
+    "The node is rescoped to a purely Gothic continuation with no classical-revival content.",
+    "The edge is used to imply Roman concrete or Roman buildings were direct physical prerequisites for Brunelleschi."
+  ],
+  "short_reason": "Roman/classical revival is a sourced lineage for Brunelleschi's architectural language.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-star-fort-brunelleschi-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-star-fort-brunelleschi-removal.json
@@ -1,0 +1,40 @@
+{
+  "id": "2026-06-12-star-fort-brunelleschi-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "star_fort_trace_italienne",
+    "prerequisite": "renaissance_architecture_brunelleschi"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Renaissance Architecture (Brunelleschi) provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because star forts/trace italienne are artillery-response fortifications shaped by cannon, geometry, and fortification construction, not by Brunelleschi's Florentine architectural works.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.nature.com/articles/s40494-025-01632-y",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Heritage Science review describes the mid-fifteenth-century transformation of medieval European city fortifications into bastion fortification systems and emphasizes geometric bastion design principles.",
+    "source_claim_summary": "Bastion fortification developed as a geometric artillery-era fortification system, not as a direct outgrowth of Brunelleschi's architecture node.",
+    "source_support_rationale": "The source supports removing the Brunelleschi edge because the relevant causal channels are artillery pressure and geometric fortification design, already represented by the remaining cannons, construction, and geometry prerequisites."
+  },
+  "ontology_before": "The graph made star forts depend on Brunelleschi architecture, creating a temporal inconsistency once Brunelleschi was correctly dated to 1419.",
+  "ontology_after": "The graph keeps star forts connected to cannon, construction, and geometry while removing the over-specific Brunelleschi dependency.",
+  "invariant_preserved_or_changed": "Changed: direct star_fort_trace_italienne -> renaissance_architecture_brunelleschi edge removed.",
+  "would_reject_if": [
+    "A future source shows a specific Brunelleschian design lineage for the scoped star-fort node.",
+    "The star-fort node is rescoped to Renaissance ideal-city architectural planning rather than artillery fortification."
+  ],
+  "short_reason": "Star forts should not depend directly on Brunelleschi architecture.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-brunelleschi-architecture-scope.json
+++ b/docs/graph-invariants/2026-06-12-brunelleschi-architecture-scope.json
@@ -1,0 +1,46 @@
+{
+  "id": "2026-06-12-brunelleschi-architecture-scope",
+  "description": "Lock renaissance_architecture_brunelleschi to Brunelleschi's early Florentine built architecture, anchored by the 1419 Ospedale degli Innocenti commission and the 1420-1436 cathedral dome.",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "renaissance_architecture_brunelleschi",
+      "operator": "eq",
+      "value": 1419,
+      "reason": "The scoped node begins with Brunelleschi's Ospedale degli Innocenti commission and construction direction from 1419."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "renaissance_architecture_brunelleschi",
+      "prerequisite": "geometry",
+      "expected": "enabling",
+      "reason": "Geometry is a design/control method for the dome and architectural order, not the whole technology."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "renaissance_architecture_brunelleschi",
+      "prerequisite": "construction",
+      "expected": "enabling",
+      "reason": "Construction practice enables Brunelleschi's built architecture without making classical monumental construction a universal hard prerequisite."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "renaissance_architecture_brunelleschi",
+      "prerequisite": "roman_architecture_revival",
+      "expected": "enabling",
+      "reason": "Classical/Roman revival is a historical and stylistic lineage for Brunelleschi, not a physical component."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "renaissance_architecture_brunelleschi",
+      "prerequisite": "humanism",
+      "reason": "Humanism is wider cultural context, not a direct technical prerequisite for this scoped built-architecture node."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "renaissance_architecture_brunelleschi",
+      "prerequisite": "mathematics",
+      "reason": "The broad mathematics relationship is represented through the more specific geometry edge."
+    }
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-star-fort-scope.json
+++ b/docs/graph-invariants/2026-06-12-star-fort-scope.json
@@ -1,0 +1,24 @@
+{
+  "id": "2026-06-12-star-fort-scope",
+  "description": "Prevent star_fort_trace_italienne from depending on Brunelleschi architecture; its direct prerequisites should remain artillery/geometry/construction oriented until the node is separately source-checked.",
+  "checks": [
+    {
+      "type": "direct_edge_absent",
+      "dependent": "star_fort_trace_italienne",
+      "prerequisite": "renaissance_architecture_brunelleschi",
+      "reason": "Trace italienne/star-fort fortification should not depend directly on Brunelleschi's Florentine architecture."
+    },
+    {
+      "type": "direct_edge_present",
+      "dependent": "star_fort_trace_italienne",
+      "prerequisite": "cannons",
+      "reason": "The scoped fortification form is modeled as a response to cannon/artillery pressure."
+    },
+    {
+      "type": "direct_edge_present",
+      "dependent": "star_fort_trace_italienne",
+      "prerequisite": "geometry",
+      "reason": "The scoped fortification form depends on geometric bastion layout."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Source-checks `renaissance_architecture_brunelleschi` and replaces the inflated Wikipedia source with Museo degli Innocenti, Opera di Santa Maria del Fiore, Britannica, and Smarthistory sources.
- Rescopes the node to Brunelleschi's early Florentine built architecture, anchored by the 1419 Ospedale degli Innocenti commission and the 1420-1436 Santa Maria del Fiore dome.
- Corrects `firstKnownDate` from `1400` to `1419`, sets the region to Florence, and adds a scope note.
- Upgrades direct edges for `geometry`, `construction`, and `roman_architecture_revival` with source-backed notes.
- Removes broad/contextual direct edges from `humanism` and broad `mathematics`; geometry now carries the specific mathematical design relationship.
- Removes the exposed over-specific `renaissance_architecture_brunelleschi -> star_fort_trace_italienne` edge; star forts remain connected to cannon, construction, and geometry.
- Adds edge-change receipts and graph invariants so these corrections are reviewable and not repeated.

## Why the old model was misleading

The prior node used a generic year `1400` with only Wikipedia-as-review sourcing. Its dependency list mixed concrete design/building capabilities with broad context (`humanism`) and duplicate abstraction (`mathematics` alongside `geometry`). Once the Brunelleschi node was correctly dated to 1419, it also exposed a bad downstream edge into star forts.

## Sources used

- Museo degli Innocenti, `Architecture`
- Opera di Santa Maria del Fiore, `On 30 August 1436 the work on Brunelleschi's Dome was completed`
- Encyclopaedia Britannica, `The Duomo`
- Smarthistory, `Filippo Brunelleschi, Dome of the Cathedral of Florence`
- Heritage Science / Nature, bastion fortification geometry review for the star-fort edge removal

## Adversarial note

The main uncertainty is whether this node should be split into two nodes: `Ospedale degli Innocenti / early Renaissance architecture` and `Brunelleschi dome construction`. This PR keeps one node but locks the scope tightly enough that a future split can move edges cleanly.

## Validation

- `npm test`
- `npm run edge-receipts`
- `npm run graph-invariants`
- `npm run invariant-coverage`
- `npm run node-snapshot-diff -- /tmp/renaissance_architecture_brunelleschi.before.json /tmp/renaissance_architecture_brunelleschi.after.json --require-behavior-change`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`
- `npm run agent:check -- --run`