### PR TITLE
Source-check financial derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,920 / 5,487 (35.0%) |
+| Dependency edges with edge-level sources | 1,920 / 5,486 (35.0%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/modern.json
+++ b/data/modern.json
@@ -16828,7 +16828,6 @@
     "description": "Standardized exchange-traded options and related derivative contracts supported by formal pricing, clearing, and market-risk practices.",
     "prerequisites": [
       "stock_exchange_modern",
-      "banking",
       "probability_statistics_inference",
       "computers_early"
     ],
@@ -16845,7 +16844,29 @@
         "url": "https://www.cboe.com/insights/posts/the-creation-of-listed-options-at-cboe/",
         "publisher": "Cboe",
         "year": 2024,
-        "source_type": "generic_overview",
+        "source_type": "review",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "SEC News Digest, February 2, 1973",
+        "url": "https://www.sec.gov/news/digest/1973/dig020273.pdf",
+        "publisher": "U.S. Securities and Exchange Commission",
+        "year": 1973,
+        "source_type": "official_agency",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "The Pricing of Options and Corporate Liabilities",
+        "url": "https://www.cs.princeton.edu/courses/archive/fall09/cos323/papers/black_scholes73.pdf",
+        "publisher": "Journal of Political Economy",
+        "year": 1973,
+        "source_type": "primary_paper",
         "supports": [
           "node",
           "maturity"
@@ -16870,7 +16891,7 @@
             "url": "https://www.cboe.com/insights/posts/the-creation-of-listed-options-at-cboe/",
             "publisher": "Cboe",
             "year": 2024,
-            "source_type": "generic_overview",
+            "source_type": "review",
             "supports": [
               "node",
               "maturity",
@@ -16880,30 +16901,20 @@
         ]
       },
       {
-        "prerequisite": "banking",
-        "type": "common_dependency",
-        "confidence": 0.72,
-        "evidence_level": "expert_inference",
-        "note": "Banks and brokers supplied capital, settlement, and counterparty services for modern derivatives markets.",
-        "reviewStatus": "source_checked"
-      },
-      {
         "prerequisite": "probability_statistics_inference",
         "type": "enabling",
         "confidence": 0.84,
         "evidence_level": "primary_source",
-        "note": "Cboe links the 1973 exchange to the Black-Scholes-Merton pricing model, which made probabilistic valuation central to listed options.",
+        "note": "Black and Scholes published their option-pricing model in 1973, making probabilistic valuation central to standardized listed options.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "The Creation of Listed Options at Cboe",
-            "url": "https://www.cboe.com/insights/posts/the-creation-of-listed-options-at-cboe/",
-            "publisher": "Cboe",
-            "year": 2024,
-            "source_type": "generic_overview",
+            "title": "The Pricing of Options and Corporate Liabilities",
+            "url": "https://www.cs.princeton.edu/courses/archive/fall09/cos323/papers/black_scholes73.pdf",
+            "publisher": "Journal of Political Economy",
+            "year": 1973,
+            "source_type": "primary_paper",
             "supports": [
-              "node",
-              "maturity",
               "edge"
             ]
           }
@@ -16922,7 +16933,7 @@
             "url": "https://www.cboe.com/insights/posts/the-creation-of-listed-options-at-cboe/",
             "publisher": "Cboe",
             "year": 2024,
-            "source_type": "generic_overview",
+            "source_type": "review",
             "supports": [
               "node",
               "maturity",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T17:20:16.777Z",
+  "generatedAt": "2026-06-12T17:28:54.587Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -26,8 +26,8 @@
     {
       "label": "Dependency edges with edge-level sources",
       "value": 1920,
-      "denominator": 5487,
-      "formatted": "1,920 / 5,487",
+      "denominator": 5486,
+      "formatted": "1,920 / 5,486",
       "note": "35.0%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 533,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5487,
+    "totalEdges": 5486,
     "edgesWithSources": 1920
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T17:20:16.777Z
+Generated: 2026-06-12T17:28:54.587Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,920 / 5,487 (35.0%) |
+| Dependency edges with edge-level sources | 1,920 / 5,486 (35.0%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-12-financial-derivatives-banking-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-financial-derivatives-banking-removal.json
@@ -1,0 +1,41 @@
+{
+  "id": "2026-06-12-financial-derivatives-banking-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "financial_derivatives",
+    "prerequisite": "banking"
+  },
+  "old_claim": {
+    "type": "common_dependency",
+    "confidence": 0.72,
+    "evidence_level": "expert_inference",
+    "note": "Banks and brokers supplied capital, settlement, and counterparty services for modern derivatives markets."
+  },
+  "new_claim_absent": "No direct dependency remains because the node is scoped to standardized exchange-traded options; broad banking is background financial infrastructure, while the direct scope is better captured by organized exchanges, pricing theory, and market technology.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.cboe.com/insights/posts/the-creation-of-listed-options-at-cboe/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Cboe's historical account centers the 1973 listed-options launch on the new options exchange, listed contracts, trading floor, price display, and Black-Scholes context rather than banks as a direct prerequisite.",
+    "source_claim_summary": "The source supports the exchange-traded listed-options scope without making broad banking a direct causal dependency.",
+    "source_support_rationale": "This supports removing the banking edge because banking may provide background financial services, but the graph already captures the scoped listed-options dependency through stock_exchange_modern."
+  },
+  "ontology_before": "The graph carried a broad banking common-dependency edge that was not source-backed and blurred listed-options market structure with general finance.",
+  "ontology_after": "The graph keeps financial_derivatives focused on the 1973 listed-options exchange, pricing, and market-technology stack.",
+  "invariant_preserved_or_changed": "Changed: direct financial_derivatives -> banking edge removed.",
+  "would_reject_if": [
+    "The node were rescoped to over-the-counter swaps or bank-dealer derivatives markets rather than listed options.",
+    "A stronger source showed banks were a direct prerequisite for Cboe's listed-options launch rather than background market participants."
+  ],
+  "short_reason": "Broad banking is background context, not a direct listed-options prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/financial_derivatives.before.json /tmp/financial_derivatives.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-financial-derivatives-scope.json
+++ b/docs/graph-invariants/2026-06-12-financial-derivatives-scope.json
@@ -1,0 +1,33 @@
+{
+  "id": "2026-06-12-financial-derivatives-scope",
+  "description": "Lock financial_derivatives to modern standardized exchange-traded listed options anchored to Cboe's 1973 launch, not generic bank derivatives.",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "financial_derivatives",
+      "operator": "eq",
+      "value": 1973,
+      "reason": "The node is scoped to Cboe's 1973 listed-options launch and same-year Black-Scholes option-pricing paper."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "financial_derivatives",
+      "prerequisite": "stock_exchange_modern",
+      "expected": "required",
+      "reason": "The scoped node is exchange-traded listed options, so organized exchange infrastructure is defining."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "financial_derivatives",
+      "prerequisite": "probability_statistics_inference",
+      "expected": "enabling",
+      "reason": "Formal probability/statistical valuation enabled modern listed-options pricing but was not the exchange itself."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "financial_derivatives",
+      "prerequisite": "banking",
+      "reason": "Broad banking is too generic for the listed-options scope and should not be a direct edge."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Strengthens `financial_derivatives` sources for the 1973 listed-options scope.
- Reclassifies the existing Cboe source from generic overview to review and adds SEC and Black-Scholes sources.
- Removes the broad, unsourced `banking` common-dependency edge.
- Updates the probability/statistics edge source to the 1973 Black-Scholes paper.
- Adds a receipt and invariant so the node stays scoped to listed options rather than generic bank-dealer derivatives.

## Old claim vs new claim
Old claim: modern financial derivatives were source-checked but still flagged by the queue because the node relied on a generic Cboe source and carried an unsourced broad banking edge.

New claim: the node is explicitly scoped to standardized exchange-traded listed options anchored to Cboe's 1973 launch and the same-year Black-Scholes option-pricing paper. Banking remains background financial infrastructure, not a direct prerequisite.

## Sources
- Cboe, `The Creation of Listed Options at Cboe`: https://www.cboe.com/insights/posts/the-creation-of-listed-options-at-cboe/
- SEC News Digest, February 2, 1973: https://www.sec.gov/news/digest/1973/dig020273.pdf
- Black and Scholes, `The Pricing of Options and Corporate Liabilities`: https://www.cs.princeton.edu/courses/archive/fall09/cos323/papers/black_scholes73.pdf

## Why this is better
The previous graph mixed the listed-options scope with broad banking context. This keeps the technology boundary sharper: exchange-traded options depend directly on organized exchange infrastructure and formal pricing methods, while banking is too broad to be a direct edge without a more specific clearing/settlement node.

## Adversarial note
The strongest reason this could be wrong is if this node is later rescoped to over-the-counter swaps or bank-dealer derivatives markets. Under the current listed-options scope, removing the broad banking edge is cleaner.

## Validation
- `npm run node-snapshot-diff -- /tmp/financial_derivatives.before.json /tmp/financial_derivatives.after.json --require-behavior-change` passed
- `npm test` passed
- `npm run quality` passed
- `npm run coverage` passed
- `npm run quality:queue -- --limit=8` no longer lists `financial_derivatives`
- New source URLs were checked directly with `curl -I -L`
- `npm run agent:check -- --run` passed tests, quality, and coverage; its final source URL step hit unrelated external timeouts on old `penelope.uchicago.edu` sources not touched by this PR.