### PR TITLE
[codex] Source-check semiconductor device sources

### DIFF
--- a/data/modern.json
+++ b/data/modern.json
@@ -2652,7 +2652,7 @@
     "sources": [
       {
         "title": "1947: Invention of the Point-Contact Transistor",
-        "url": "https://en.wikipedia.org/wiki/Transistor",
+        "url": "https://www.computerhistory.org/siliconengine/invention-of-the-point-contact-transistor/",
         "publisher": "Computer History Museum",
         "year": 2007,
         "source_type": "museum",
@@ -2677,7 +2677,7 @@
         "sources": [
           {
             "title": "1947: Invention of the Point-Contact Transistor",
-            "url": "https://en.wikipedia.org/wiki/Transistor",
+            "url": "https://www.computerhistory.org/siliconengine/invention-of-the-point-contact-transistor/",
             "publisher": "Computer History Museum",
             "year": 2007,
             "source_type": "museum",
@@ -2753,7 +2753,7 @@
     "id": "semiconductor_devices",
     "name": "Semiconductor Devices",
     "era": "Modern",
-    "description": "Engineered junction and compound semiconductor devices that actively control and switch electrical signals for electronic function.",
+    "description": "Engineered semiconductor junction and active devices that control, amplify, switch, or convert electrical signals for electronic function.",
     "prerequisites": [
       "semiconductors",
       "electronics"
@@ -2767,8 +2767,19 @@
     "maturity": "established",
     "sources": [
       {
+        "title": "1940: Discovery of the p-n Junction",
+        "url": "https://www.computerhistory.org/siliconengine/discovery-of-the-p-n-junction/",
+        "publisher": "Computer History Museum",
+        "year": 2007,
+        "source_type": "museum",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
         "title": "1947: Invention of the Point-Contact Transistor",
-        "url": "https://en.wikipedia.org/wiki/Transistor",
+        "url": "https://www.computerhistory.org/siliconengine/invention-of-the-point-contact-transistor/",
         "publisher": "Computer History Museum",
         "year": 2007,
         "source_type": "museum",
@@ -2814,8 +2825,8 @@
             ]
           },
           {
-            "title": "1947: Invention of the Point-Contact Transistor",
-            "url": "https://en.wikipedia.org/wiki/Transistor",
+            "title": "1940: Discovery of the p-n Junction",
+            "url": "https://www.computerhistory.org/siliconengine/discovery-of-the-p-n-junction/",
             "publisher": "Computer History Museum",
             "year": 2007,
             "source_type": "museum",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T17:36:57.493Z",
+  "generatedAt": "2026-06-12T17:45:47.323Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T17:36:57.493Z
+Generated: 2026-06-12T17:45:47.323Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 


### PR DESCRIPTION
## Summary
- Replaced copied Wikipedia URLs that were incorrectly labeled as Computer History Museum sources on `transistors` and `semiconductor_devices`.
- Added the CHM p-n junction source to anchor the `semiconductor_devices` 1940 date/scope.
- Tightened the `semiconductor_devices` description to junction and active semiconductor devices without changing topology.
- Regenerated the quality snapshot timestamp through `npm run accuracy:risks`.

## Why this matters
The quality queue flagged `semiconductor_devices` and `transistors` for inflated Wikipedia source typing. The previous model pointed to Wikipedia while claiming Computer History Museum provenance, which made the source metadata misleading even though better CHM pages existed.

## Sources used
- Computer History Museum, `1940: Discovery of the p-n Junction`: https://www.computerhistory.org/siliconengine/discovery-of-the-p-n-junction/
- Computer History Museum, `1947: Invention of the Point-Contact Transistor`: https://www.computerhistory.org/siliconengine/invention-of-the-point-contact-transistor/

Both new URLs were checked with `curl -I -L --max-time 20` and returned HTTP 200.

## Validation
- `npm run quality:queue -- --limit=10` no longer lists `semiconductor_devices` or `transistors`.
- `npm test` passed.
- `npm run quality` passed.
- `npm run coverage` passed.
- `npm run accuracy:risks -- --markdown --limit 24` passed and regenerated the snapshot timestamp.
- `npm run agent:check -- --run` passed through `git diff --check`, `npm test`, `npm run quality`, and `npm run coverage`; `npm run source-urls` still fails only on the known unrelated Penelope/Chicago timeout URLs.

## Adversarial note
The broad `semiconductor_devices` node still spans multiple device classes. This PR does not split it; it only corrects source provenance and adds a 1940 p-n junction source that supports the existing date/scope boundary.