### PR TITLE
[codex] Source-check powder metallurgy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,919 / 5,485 (35.0%) |
+| Dependency edges with edge-level sources | 1,921 / 5,484 (35.0%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/industrial.json
+++ b/data/industrial.json
@@ -15692,6 +15692,93 @@
     ]
   },
   {
+    "id": "powder_metallurgy",
+    "name": "Powder Metallurgy",
+    "era": "Industrial",
+    "description": "Industrial powder-processing methods that make metal objects by producing metal powders, compacting or shaping them, and sintering or heating them below full melting.",
+    "prerequisites": [
+      "advanced_metallurgy_medieval",
+      "precision_machine_tools"
+    ],
+    "fields": [
+      "Materials Science & Manufacturing"
+    ],
+    "fieldLanes": {
+      "Materials Science & Manufacturing": "Advanced Manufacturing"
+    },
+    "maturity": "established",
+    "sources": [
+      {
+        "title": "Pure Intelligence: The Life of William Hyde Wollaston",
+        "url": "https://www.bibliovault.org/BV.landing.epl?ISBN=9780226245874",
+        "publisher": "University of Chicago Press / BiblioVault",
+        "year": 2015,
+        "source_type": "textbook",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "Advanced Automation for Space Missions",
+        "url": "https://ntrs.nasa.gov/api/citations/19830007077/downloads/19830007077.pdf",
+        "publisher": "NASA",
+        "year": 1982,
+        "source_type": "official_agency",
+        "supports": [
+          "node"
+        ]
+      }
+    ],
+    "firstKnownDate": 1801,
+    "datePrecision": "exact",
+    "region": "United Kingdom and Europe; later global industrial powder metallurgy",
+    "reviewStatus": "source_checked",
+    "scopeNote": "Anchored to William Hyde Wollaston's April 1801 compression of spongy platinum powder into a malleable ingot and subsequent commercial platinum preparation. This node excludes ancient sponge-iron working and treats 20th-century tungsten filaments, cemented carbides, filters, and powder-bed additive manufacturing as later applications or branches.",
+    "dependencyEdges": [
+      {
+        "prerequisite": "advanced_metallurgy_medieval",
+        "type": "enabling",
+        "confidence": 0.72,
+        "evidence_level": "textbook",
+        "note": "Powder metallurgy builds on prior metallurgical knowledge of metal ores, powders, heating, and working, but the scoped 1801 platinum-powder consolidation is a distinct later industrial process.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Pure Intelligence: The Life of William Hyde Wollaston",
+            "url": "https://www.bibliovault.org/BV.landing.epl?ISBN=9780226245874",
+            "publisher": "University of Chicago Press / BiblioVault",
+            "year": 2015,
+            "source_type": "textbook",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
+      },
+      {
+        "prerequisite": "precision_machine_tools",
+        "type": "commercial_or_scaling_dependency",
+        "confidence": 0.58,
+        "evidence_level": "expert_inference",
+        "note": "Precision dies, presses, and tooling matter for reproducible industrial powder-metallurgy parts, but they are not required for Wollaston's first platinum-powder consolidation.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Advanced Automation for Space Missions",
+            "url": "https://ntrs.nasa.gov/api/citations/19830007077/downloads/19830007077.pdf",
+            "publisher": "NASA",
+            "year": 1982,
+            "source_type": "official_agency",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     "id": "semiconductors",
     "name": "Semiconductors",
     "era": "Industrial",

--- a/data/modern.json
+++ b/data/modern.json
@@ -41571,67 +41571,6 @@
     ]
   },
   {
-    "id": "powder_metallurgy",
-    "name": "Powder Metallurgy",
-    "era": "Modern",
-    "description": "Manufacturing methods that compact and sinter metal powders to make precise parts, hard materials, filters, and specialized alloys.",
-    "prerequisites": [
-      "advanced_metallurgy_medieval",
-      "steel_production",
-      "precision_machine_tools"
-    ],
-    "fields": [
-      "Materials Science & Manufacturing"
-    ],
-    "fieldLanes": {
-      "Materials Science & Manufacturing": "Advanced Manufacturing"
-    },
-    "maturity": "established",
-    "sources": [
-      {
-        "title": "Powder metallurgy",
-        "url": "https://en.wikipedia.org/wiki/Powder_metallurgy",
-        "publisher": "Wikipedia",
-        "year": 2026,
-        "source_type": "review",
-        "supports": [
-          "node",
-          "maturity"
-        ]
-      }
-    ],
-    "firstKnownDate": 1889,
-    "datePrecision": "decade",
-    "region": "Global / multiple regions",
-    "reviewStatus": "source_checked",
-    "dependencyEdges": [
-      {
-        "prerequisite": "advanced_metallurgy_medieval",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Advanced Metallurgy (Medieval) provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "steel_production",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Steel Production provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "precision_machine_tools",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Precision Machine Tools provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      }
-    ]
-  },
-  {
     "id": "advanced_ceramics",
     "name": "Advanced Ceramics",
     "era": "Modern",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T17:45:47.323Z",
+  "generatedAt": "2026-06-12T17:58:40.706Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,9 +25,9 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1919,
-      "denominator": 5485,
-      "formatted": "1,919 / 5,485",
+      "value": 1921,
+      "denominator": 5484,
+      "formatted": "1,921 / 5,484",
       "note": "35.0%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 533,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5485,
-    "edgesWithSources": 1919
+    "totalEdges": 5484,
+    "edgesWithSources": 1921
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T17:45:47.323Z
+Generated: 2026-06-12T17:58:40.706Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,919 / 5,485 (35.0%) |
+| Dependency edges with edge-level sources | 1,921 / 5,484 (35.0%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-12-powder-metallurgy-steel-production-removed.json
+++ b/docs/edge-change-receipts/2026-06-12-powder-metallurgy-steel-production-removed.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-12-powder-metallurgy-steel-production-removed",
+  "decision_date": "2026-06-12",
+  "edge": {
+    "dependent": "powder_metallurgy",
+    "prerequisite": "steel_production"
+  },
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "old_claim": {
+    "type": "enabling",
+    "evidence_level": "expert_inference",
+    "confidence": 0.68,
+    "note": "Steel Production provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains from powder_metallurgy to steel_production. The corrected node is scoped to industrial metal-powder compaction and sintering, anchored to platinum-powder consolidation rather than steelmaking.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.bibliovault.org/BV.landing.epl?ISBN=9780226245874",
+  "source_shape": {
+    "source_type": "textbook",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "BiblioVault table of contents for Pure Intelligence, Prologue and Chapter 4 summaries: Wollaston's first successful consolidation of powdered platinum into a malleable solid in April 1801; Chapter 4 notes compression of spongy platinum powder into a malleable ingot.",
+    "source_claim_summary": "The source places the corrected early industrial powder-metallurgy anchor in Wollaston's platinum-powder consolidation, not steelmaking.",
+    "source_support_rationale": "Because the dependent node is broad powder metallurgy, a steel edge would incorrectly narrow the causal model to one later material family and contradict the platinum-based anchor."
+  },
+  "ontology_before": "Powder metallurgy was modeled as a Modern 1889 node with steel production as an enabling prerequisite, despite only a Wikipedia source.",
+  "ontology_after": "Powder metallurgy is scoped to industrial compact/sinter powder processing anchored to Wollaston's 1801 platinum-powder consolidation, with steel production absent because steel is an application material rather than a prerequisite for the field.",
+  "invariant_preserved_or_changed": "Changed: powder_metallurgy is Industrial, firstKnownDate 1801, and has no direct steel_production prerequisite.",
+  "would_reject_if": [
+    "The node were narrowed to iron or steel powder-metallurgy parts only.",
+    "A source showed that the first compact-and-sinter powder metallurgy process required steel production.",
+    "A future node split introduced a separate steel powder-metallurgy manufacturing node with its own specific steel-production dependency."
+  ],
+  "short_reason": "The sourced early powder-metallurgy anchor is platinum powder consolidation, so steel production is not a prerequisite for the broad node.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm run node-snapshot-diff -- /tmp/powder_metallurgy.before.json /tmp/powder_metallurgy.after.json --require-behavior-change",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-powder-metallurgy-scope.json
+++ b/docs/graph-invariants/2026-06-12-powder-metallurgy-scope.json
@@ -1,0 +1,25 @@
+{
+  "id": "2026-06-12-powder-metallurgy-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "powder_metallurgy",
+      "operator": "eq",
+      "value": 1801,
+      "reason": "BiblioVault's Pure Intelligence summary identifies April 1801 as Wollaston's first successful consolidation of powdered platinum into a malleable solid."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "powder_metallurgy",
+      "prerequisite": "steel_production",
+      "reason": "The broad powder-metallurgy node is not scoped to steel powder parts; the early industrial anchor is platinum powder consolidation."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "powder_metallurgy",
+      "prerequisite": "precision_machine_tools",
+      "expected": "commercial_or_scaling_dependency",
+      "reason": "Precision dies, presses, and tooling scale reproducible industrial powder-metallurgy parts but are not required for the first 1801 platinum-powder consolidation."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Rescopes `powder_metallurgy` from a Modern 1889/Wikipedia-backed node to an Industrial 1801 source-checked node.
- Replaces the inflated Wikipedia `review` source with accessible University of Chicago Press/BiblioVault and NASA sources.
- Removes the misleading `steel_production` prerequisite because the sourced early anchor is Wollaston's platinum-powder consolidation, not steelmaking.
- Retypes `precision_machine_tools` to `commercial_or_scaling_dependency` and adds edge-level sources for both remaining direct edges.
- Adds an edge-change receipt and graph invariant so the steel edge and old date do not get reintroduced.
- Regenerates the README and quality snapshot metrics.

## Old claim vs new claim
Old: Powder metallurgy was modeled as Modern, firstKnownDate `1889` with decade precision, backed only by Wikipedia typed as `review`, and included `steel_production` as an enabling prerequisite.

New: Powder metallurgy is scoped to industrial metal-powder compaction/sintering, anchored to Wollaston's April 1801 compression of spongy platinum powder into a malleable ingot. Steel production is removed because it is not a prerequisite for that broad platinum-anchored powder-metallurgy node.

## Sources used
- University of Chicago Press / BiblioVault, `Pure Intelligence: The Life of William Hyde Wollaston`: https://www.bibliovault.org/BV.landing.epl?ISBN=9780226245874
- NASA, `Advanced Automation for Space Missions`: https://ntrs.nasa.gov/api/citations/19830007077/downloads/19830007077.pdf

Both new URLs were checked directly with `curl -I -L --max-time 20` and returned HTTP 200.

## Validation
- `npm run node-packet -- powder_metallurgy --json` confirmed the corrected Industrial 1801 packet.
- `npm run node-snapshot-diff -- /tmp/powder_metallurgy.before.json /tmp/powder_metallurgy.after.json --require-behavior-change` passed and showed the intended removal of `steel_production->powder_metallurgy`.
- `npm test` passed.
- `npm run quality` passed.
- `npm run coverage` passed.
- `npm run accuracy:risks -- --markdown --limit 24` passed and updated the snapshot.
- `npm run quality:queue -- --limit=10` no longer lists `powder_metallurgy`.
- `npm run agent:check -- --run` passed through `git diff --check`, `npm test`, `npm run quality`, and `npm run coverage`; `npm run source-urls` still fails only on the known unrelated Penelope/Chicago timeout URLs.

## Adversarial note
The strongest reason this could be wrong is scope: if the node were intentionally meant only for later iron/steel powder-metallurgy parts, then a later date and steel-related dependency could be appropriate. The corrected scope note explicitly keeps the node broad and platinum-anchored, with 20th-century tungsten filaments, cemented carbides, filters, and powder-bed additive manufacturing treated as later applications or branches.