### PR TITLE
[codex] Source-check Roman architecture revival

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,921 / 5,484 (35.0%) |
+| Dependency edges with edge-level sources | 1,923 / 5,482 (35.1%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T17:58:40.706Z",
+  "generatedAt": "2026-06-12T18:09:50.219Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,10 +25,10 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1921,
-      "denominator": 5484,
-      "formatted": "1,921 / 5,484",
-      "note": "35.0%"
+      "value": 1923,
+      "denominator": 5482,
+      "formatted": "1,923 / 5,482",
+      "note": "35.1%"
     },
     {
       "label": "Era-default placeholder dates",
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 533,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5484,
-    "edgesWithSources": 1921
+    "totalEdges": 5482,
+    "edgesWithSources": 1923
   }
 }

--- a/data/renaissance.json
+++ b/data/renaissance.json
@@ -4138,12 +4138,10 @@
     "id": "roman_architecture_revival",
     "name": "Roman Architecture Revival",
     "era": "Renaissance",
-    "description": "Renewed study and adaptation of classical Roman proportion, arches, domes, concrete traditions, and civic building forms.",
+    "description": "Early Renaissance recovery and adaptation of classical Roman and ancient architectural vocabulary, proportion, columns, arches, vaults, and civic building forms.",
     "prerequisites": [
       "humanism",
-      "roman_concrete_opus_caementicium",
-      "arches_domes",
-      "perspective_in_art"
+      "arches_domes"
     ],
     "fields": [
       "Civil Engineering & Built Environment"
@@ -4152,52 +4150,62 @@
       "Civil Engineering & Built Environment": "Structural Systems"
     },
     "firstKnownDate": 1400,
-    "datePrecision": "exact",
-    "region": "Europe and connected early modern exchange networks",
+    "datePrecision": "century",
+    "region": "Florence, Italy; later Italian and European Renaissance architecture",
     "reviewStatus": "source_checked",
+    "scopeNote": "Covers the early Florentine Renaissance recovery of classical architectural elements, anchored here by Brunelleschi's 1419 Ospedale degli Innocenti project. It is not the later nineteenth-century Renaissance Revival style, all Renaissance architecture, or a claim that Roman concrete technology itself was reused.",
     "dependencyEdges": [
       {
         "prerequisite": "humanism",
         "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Humanism provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "roman_concrete_opus_caementicium",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Roman Concrete (Opus Caementicium) provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "confidence": 0.7,
+        "evidence_level": "review",
+        "note": "Florentine humanist recovery of classical antiquity supplied cultural and intellectual context for the architectural return to classical elements, without being a physical construction prerequisite.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Architecture",
+            "url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+            "publisher": "Museo degli Innocenti",
+            "year": 2026,
+            "source_type": "museum",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       },
       {
         "prerequisite": "arches_domes",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Arches and Domes provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "perspective_in_art",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Perspective in Art provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "historical_predecessor",
+        "confidence": 0.76,
+        "evidence_level": "review",
+        "note": "Brunelleschi's classicalizing architectural language used columns, capitals, arches, and vaults, so ancient arch-and-vault forms are a historical vocabulary rather than a hard prerequisite.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Architecture",
+            "url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+            "publisher": "Museo degli Innocenti",
+            "year": 2026,
+            "source_type": "museum",
+            "supports": [
+              "edge"
+            ]
+          }
+        ]
       }
     ],
     "sources": [
       {
-        "title": "Renaissance architecture",
-        "url": "https://en.wikipedia.org/wiki/Renaissance_architecture",
-        "publisher": "Wikipedia",
+        "title": "Architecture",
+        "url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+        "publisher": "Museo degli Innocenti",
         "year": 2026,
-        "source_type": "review",
+        "source_type": "museum",
         "supports": [
-          "node"
+          "node",
+          "maturity"
         ]
       }
     ]

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T17:58:40.706Z
+Generated: 2026-06-12T18:09:50.219Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,921 / 5,484 (35.0%) |
+| Dependency edges with edge-level sources | 1,923 / 5,482 (35.1%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-12-roman-architecture-arches-lineage.json
+++ b/docs/edge-change-receipts/2026-06-12-roman-architecture-arches-lineage.json
@@ -1,0 +1,44 @@
+{
+  "id": "2026-06-12-roman-architecture-arches-lineage",
+  "decision_date": "2026-06-12",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "roman_architecture_revival",
+    "prerequisite": "arches_domes"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Arches and Domes provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.76,
+    "evidence_level": "review",
+    "note": "Brunelleschi's classicalizing architectural language used columns, capitals, arches, and vaults, so ancient arch-and-vault forms are a historical vocabulary rather than a hard prerequisite."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "establishes_historical_lineage",
+    "source_locator": "Museo degli Innocenti, Architecture page, Brunelleschian project section: columns, capitals, arches, and vaults are named as part of the recovery of classical elements.",
+    "source_claim_summary": "The source identifies arches and vaults as part of the recovered classical vocabulary in Brunelleschi's early Renaissance architectural language.",
+    "source_support_rationale": "The edge should express historical vocabulary lineage, because the source describes formal recovery rather than a necessary construction component."
+  },
+  "ontology_before": "The old edge treated arches and domes as a generic enabling capability.",
+  "ontology_after": "The corrected edge models arches and vaults as classical forms revived by early Renaissance architecture.",
+  "invariant_preserved_or_changed": "Changed edge type: arches_domes is now historical_predecessor.",
+  "would_reject_if": [
+    "The node were narrowed to physical dome construction rather than classical architectural revival.",
+    "A source showed that the early Florentine classical-revival vocabulary did not use arches, vaults, or related ancient forms."
+  ],
+  "short_reason": "Arches and vaults are revived historical vocabulary, not a generic enabling capability.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-roman-architecture-concrete-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-roman-architecture-concrete-removal.json
@@ -1,0 +1,40 @@
+{
+  "id": "2026-06-12-roman-architecture-concrete-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "roman_architecture_revival",
+    "prerequisite": "roman_concrete_opus_caementicium"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Roman Concrete (Opus Caementicium) provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains from roman_architecture_revival to roman_concrete_opus_caementicium. The corrected node is scoped to recovery of classical architectural vocabulary, not reuse of Roman concrete technology.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Museo degli Innocenti, Architecture page: the Brunelleschian project is described through pietra serena, plaster, columns, capitals, arches, vaults, and recovery of classical elements; Roman concrete is not part of the claim.",
+    "source_claim_summary": "The source supports classical-element recovery but does not support Roman concrete as a direct prerequisite for the scoped Florentine revival node.",
+    "source_support_rationale": "Keeping the edge would confuse study of Roman architectural forms with the separate Roman concrete material technology."
+  },
+  "ontology_before": "The node implied Roman concrete technology enabled the Renaissance revival.",
+  "ontology_after": "The node explicitly excludes direct reuse of Roman concrete; classical forms remain represented through arches_domes.",
+  "invariant_preserved_or_changed": "Changed topology: roman_concrete_opus_caementicium is absent from the node.",
+  "would_reject_if": [
+    "The node were narrowed to reconstruction of Roman concrete recipes.",
+    "A source showed Brunelleschi's early classical revival required opus caementicium as a material process."
+  ],
+  "short_reason": "Roman concrete is too specific and unsupported for this classical-revival node.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-roman-architecture-humanism-evidence.json
+++ b/docs/edge-change-receipts/2026-06-12-roman-architecture-humanism-evidence.json
@@ -1,0 +1,44 @@
+{
+  "id": "2026-06-12-roman-architecture-humanism-evidence",
+  "decision_date": "2026-06-12",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "roman_architecture_revival",
+    "prerequisite": "humanism"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Humanism provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.7,
+    "evidence_level": "review",
+    "note": "Florentine humanist recovery of classical antiquity supplied cultural and intellectual context for the architectural return to classical elements, without being a physical construction prerequisite."
+  },
+  "source_supports_edge": "partial",
+  "source_url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Museo degli Innocenti, Architecture page: the Ospedale project recovered classical elements and later fifteenth-century work in the same complex is described as an expression of Florentine Humanism.",
+    "source_claim_summary": "The source ties the Brunelleschian project to recovered classical elements and places the complex within Florentine Humanist artistic culture.",
+    "source_support_rationale": "This supports humanism as broad enabling context only; it does not justify making humanism a hard material or construction prerequisite."
+  },
+  "ontology_before": "The humanism edge was an unsourced generic enabling edge.",
+  "ontology_after": "Humanism remains a non-required cultural/intellectual enabler for the classical-revival scope and now cites a museum source.",
+  "invariant_preserved_or_changed": "Preserved edge type: humanism remains enabling, with sourced evidence and a narrower note.",
+  "would_reject_if": [
+    "The node were rescoped to purely structural arch or dome construction with no cultural recovery of antiquity.",
+    "A stronger source showed that humanism had no meaningful relationship to Florentine classical architectural revival."
+  ],
+  "short_reason": "Humanism is context for classical revival, not a hard construction dependency.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-roman-architecture-perspective-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-roman-architecture-perspective-removal.json
@@ -1,0 +1,40 @@
+{
+  "id": "2026-06-12-roman-architecture-perspective-removal",
+  "decision_date": "2026-06-12",
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "edge": {
+    "dependent": "roman_architecture_revival",
+    "prerequisite": "perspective_in_art"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Perspective in Art provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains from roman_architecture_revival to perspective_in_art. Perspective is adjacent Renaissance visual culture, but the scoped node is the architectural recovery of classical elements.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/",
+  "source_shape": {
+    "source_type": "museum",
+    "support_relationship": "refutes_dependency",
+    "source_locator": "Museo degli Innocenti, Architecture page: the source anchors the node in Brunelleschi's 1419 building project and recovery of classical elements, not linear perspective as a prerequisite.",
+    "source_claim_summary": "The source supports an architectural-language claim and does not make perspective in art a direct dependency of Roman architectural revival.",
+    "source_support_rationale": "Removing the edge prevents a sibling Renaissance visual method from being modeled as a prerequisite for classical architectural revival."
+  },
+  "ontology_before": "The node implied perspective in art enabled Roman architectural revival.",
+  "ontology_after": "The node is scoped to architectural recovery of classical forms; perspective remains available elsewhere in the graph without a direct edge here.",
+  "invariant_preserved_or_changed": "Changed topology: perspective_in_art is absent from the node.",
+  "would_reject_if": [
+    "The node were narrowed to Brunelleschi's optical perspective experiments rather than architectural revival.",
+    "A stronger source showed perspective was a direct prerequisite for recovering classical Roman architectural vocabulary."
+  ],
+  "short_reason": "Perspective is adjacent Renaissance visual culture, not a direct prerequisite for this node.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-roman-architecture-revival-scope.json
+++ b/docs/graph-invariants/2026-06-12-roman-architecture-revival-scope.json
@@ -1,0 +1,38 @@
+{
+  "id": "2026-06-12-roman-architecture-revival-scope",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "roman_architecture_revival",
+      "operator": "eq",
+      "value": 1400,
+      "reason": "The node is scoped to early fifteenth-century Florentine classical revival, represented with century precision rather than a false exact 1400 event."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "roman_architecture_revival",
+      "prerequisite": "humanism",
+      "expected": "enabling",
+      "reason": "Humanism remains broad cultural context for classical recovery, not a hard material prerequisite."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "roman_architecture_revival",
+      "prerequisite": "arches_domes",
+      "expected": "historical_predecessor",
+      "reason": "Arches and vaults are recovered historical vocabulary for the classical-revival architecture."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "roman_architecture_revival",
+      "prerequisite": "roman_concrete_opus_caementicium",
+      "reason": "The scoped node is not direct reuse of Roman concrete technology."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "roman_architecture_revival",
+      "prerequisite": "perspective_in_art",
+      "reason": "Perspective is adjacent Renaissance visual culture, not a direct prerequisite for classical architectural vocabulary recovery."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Replaces the inflated Wikipedia `review` source on `roman_architecture_revival` with the Museo degli Innocenti architecture source.
- Changes `datePrecision` from false exact `1400` to `century` and narrows the region to Florence/Italy/Europe.
- Adds a scope note distinguishing early Florentine classical architectural recovery from nineteenth-century Renaissance Revival and from direct Roman concrete reuse.
- Removes unsupported direct edges to `roman_concrete_opus_caementicium` and `perspective_in_art`.
- Retypes `arches_domes` to `historical_predecessor` and source-checks the retained `humanism` and `arches_domes` edges.
- Adds receipts and a graph invariant for the scope and edge changes.
- Regenerates quality snapshot metrics.

## Old claim vs new claim
Old: The node claimed exact `1400`, broad Europe-wide scope, Wikipedia typed as `review`, and four unsourced generic enabling prerequisites.

New: The node is scoped to early fifteenth-century Florentine recovery of classical architectural elements, anchored by Brunelleschi's 1419 Ospedale degli Innocenti project. It keeps only `humanism` as an enabling cultural context and `arches_domes` as a historical vocabulary predecessor.

## Source used
- Museo degli Innocenti, `Architecture`: https://www.museodeglinnocenti.it/en/museo/percorsi-espositivi/architettura/

The source URL returned HTTP 200 with `curl -I -L --max-time 20` and `npm run source-urls` passed.

## Validation
- `npm run node-packet -- roman_architecture_revival --json` confirmed the corrected packet.
- `npm run node-snapshot-diff -- /tmp/roman_architecture_revival.before.json /tmp/roman_architecture_revival.after.json --require-behavior-change` passed and showed the intended removal of the concrete and perspective paths.
- `npm test` passed.
- `npm run quality` passed.
- `npm run coverage` passed.
- `npm run accuracy:risks -- --markdown --limit 24` passed and refreshed the quality snapshot.
- `npm run source-urls` passed: 817 unique URLs returned non-404/non-5xx statuses.
- `npm run quality:queue -- --limit=10` no longer lists `roman_architecture_revival`.

## Adversarial note
The strongest reason this could be wrong is source breadth: the Museo page anchors the Florentine/Brunelleschian early-Renaissance case, not all European Renaissance architecture. The scope note intentionally keeps the node narrow enough for that source and leaves broader pan-European Renaissance architecture to other nodes if needed.