### PR TITLE
Source-check WMS and ATM data

### DIFF
--- a/data/modern.json
+++ b/data/modern.json
@@ -27131,7 +27131,7 @@
     "id": "automated_teller_machines",
     "name": "Automated Teller Machines",
     "era": "Modern",
-    "description": "Electromechanical cash terminals linked to banking networks for account access outside staffed branches.",
+    "description": "Electromechanical cash dispensers and later online terminals for automated cash withdrawal and account services outside staffed branches.",
     "prerequisites": [
       "computers_early",
       "database_management_systems"
@@ -27144,6 +27144,17 @@
     },
     "maturity": "established",
     "sources": [
+      {
+        "title": "Emergence and Evolution of Proprietary ATM Networks in the UK, 1967-2000",
+        "url": "https://mpra.ub.uni-muenchen.de/3689/",
+        "publisher": "Munich Personal RePEc Archive",
+        "year": 2007,
+        "source_type": "review",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
       {
         "title": "First cash dispenser",
         "url": "https://www.guinnessworldrecords.com/world-records/first-cash-dispenser",
@@ -27163,18 +27174,18 @@
     "dependencyEdges": [
       {
         "prerequisite": "computers_early",
-        "type": "historical_predecessor",
-        "confidence": 0.75,
-        "evidence_level": "expert_inference",
-        "note": "Computers (Mainframe/Early) is an earlier historical predecessor or foundation, not a one-to-one engineering dependency.",
+        "type": "enabling",
+        "confidence": 0.78,
+        "evidence_level": "review",
+        "note": "ATM networks emerged as banks adopted online, real-time computing across branch networks; computing enabled networked ATM operation, while the first cash dispensers were not relational database terminals.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "First cash dispenser",
-            "url": "https://www.guinnessworldrecords.com/world-records/first-cash-dispenser",
-            "publisher": "Guinness World Records",
-            "year": 1967,
-            "source_type": "generic_overview",
+            "title": "Emergence and Evolution of Proprietary ATM Networks in the UK, 1967-2000",
+            "url": "https://mpra.ub.uni-muenchen.de/3689/",
+            "publisher": "Munich Personal RePEc Archive",
+            "year": 2007,
+            "source_type": "review",
             "supports": [
               "node",
               "maturity",
@@ -41117,6 +41128,17 @@
     },
     "maturity": "established",
     "sources": [
+      {
+        "title": "Improving Order-picking Process Through Implementation of Warehouse Management System",
+        "url": "https://www.smjournal.rs/index.php/home/article/view/17",
+        "publisher": "Strategic Management - International Journal of Strategic Management and Decision Support Systems in Strategic Management",
+        "year": 2018,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
       {
         "title": "The Basics of Warehouse Management",
         "url": "https://www.ascm.org/topics/warehouse-management-wms-explained/",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T18:09:50.219Z",
+  "generatedAt": "2026-06-12T18:22:14.202Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T18:09:50.219Z
+Generated: 2026-06-12T18:22:14.202Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 

--- a/docs/edge-change-receipts/2026-06-12-atm-computing-enabling.json
+++ b/docs/edge-change-receipts/2026-06-12-atm-computing-enabling.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-12-atm-computing-enabling",
+  "decision_date": "2026-06-12",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "automated_teller_machines",
+    "prerequisite": "computers_early"
+  },
+  "old_claim": {
+    "type": "historical_predecessor",
+    "confidence": 0.75,
+    "evidence_level": "expert_inference",
+    "note": "Computers (Mainframe/Early) is an earlier historical predecessor or foundation, not a one-to-one engineering dependency."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.78,
+    "evidence_level": "review",
+    "note": "ATM networks emerged as banks adopted online, real-time computing across branch networks; computing enabled networked ATM operation, while the first cash dispensers were not relational database terminals."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://mpra.ub.uni-muenchen.de/3689/",
+  "source_shape": {
+    "source_type": "review",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Abstract: describes cash dispensers preceding ATMs, ATMs becoming a global technology, and ATM evolution illustrating banks' adoption of online, real-time computing for branch networks.",
+    "source_claim_summary": "The source treats early cash dispensers and later ATM networks as a business-history sequence tied to online, real-time bank computing.",
+    "source_support_rationale": "The edge should express computing as an enabler of networked ATM operation, not as a hard prerequisite for the earliest cash dispensers."
+  },
+  "ontology_before": "The old edge named early computers as a vague predecessor, while the node description implied network-linked ATMs.",
+  "ontology_after": "The node now covers early cash dispensers and later online ATMs, with computing modeled as an enabling context for networked ATM operation.",
+  "invariant_preserved_or_changed": "Changed edge type from historical_predecessor to enabling; no prerequisites were added or removed.",
+  "would_reject_if": [
+    "The node were narrowed to the 1967 Barclays cash dispenser only.",
+    "A stronger primary source showed the first installed cash dispenser was already an online computer-network terminal.",
+    "A separate node split early cash dispensers from online ATM networks."
+  ],
+  "short_reason": "Early cash dispensers predate full networked ATMs, but online bank computing enabled the later ATM-network form.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-atm-scope.json
+++ b/docs/graph-invariants/2026-06-12-atm-scope.json
@@ -1,0 +1,27 @@
+{
+  "id": "2026-06-12-atm-scope",
+  "description": "Lock automated_teller_machines to early cash dispensers plus later online ATM terminals, without making bank computing a hard prerequisite for the first 1967 dispenser.",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "automated_teller_machines",
+      "operator": "eq",
+      "value": 1967,
+      "reason": "The node remains anchored to the 1967 Barclays cash-dispenser installation while its description also covers later networked ATMs."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "automated_teller_machines",
+      "prerequisite": "computers_early",
+      "expected": "enabling",
+      "reason": "Online, real-time bank computing enabled networked ATM operation, but the earliest cash dispensers should not be modeled as requiring mainframe computing."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "automated_teller_machines",
+      "prerequisite": "database_management_systems",
+      "expected": "enabling",
+      "reason": "Persistent account and transaction data infrastructure enables ATM operation, while the first cash dispensers predate relational DBMS."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added a topic-matched academic source for `warehouse_management_systems`, replacing the queue risk where the source-checked node only had a generic ASCM overview.
- Added a scholarly ATM-network history source for `automated_teller_machines` and narrowed the description to cover early cash dispensers plus later online terminals.
- Retyped `computers_early -> automated_teller_machines` from vague historical predecessor to `enabling`, with an edge-change receipt and invariant so future audits do not repeat the same scope work.
- Refreshed the generated quality snapshot timestamp.

## Why
The source-quality queue was resurfacing WMS and ATM because they were marked `source_checked` but only had generic node sources. WMS now has a directly matching WMS/order-picking paper. ATM now has a directly matching ATM-network archival history source; I kept the source type conservative as `review` because the MPRA record is non-peer-reviewed/archival rather than a primary technical artifact.

## Validation
- `npm run node-snapshot-diff -- /tmp/automated_teller_machines.before.json /tmp/automated_teller_machines.after.json --require-behavior-change`
- `npm run edge-receipts`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`
- `npm run agent:check -- --run` including `npm run source-urls`
- `npm run quality:queue -- --limit=8` now starts with `cloud_data_warehouses`; WMS and ATM no longer recur.

## Remaining uncertainty
The ATM source is an archival working paper rather than a peer-reviewed journal article. It is still a much better topic match than Guinness for the ATM-network scope, but a future pass could replace or supplement it with a published business-history article if one is URL-checkable.