### PR TITLE
Source-check cloud data warehouses

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,923 / 5,482 (35.1%) |
+| Dependency edges with edge-level sources | 1,924 / 5,481 (35.1%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/modern.json
+++ b/data/modern.json
@@ -26277,9 +26277,9 @@
     "description": "Managed cloud analytical database services that provide elastic, pay-as-you-go data warehousing for integrating, storing, querying, and governing large organizational datasets.",
     "prerequisites": [
       "cloud_computing_distributed_systems",
-      "databases_relational_dbms",
-      "enterprise_resource_planning"
+      "relational_data_warehousing"
     ],
+    "maturity": "established",
     "firstKnownDate": 2012,
     "datePrecision": "exact",
     "region": "United States / AWS Redshift preview, then global cloud platforms",
@@ -26288,42 +26288,71 @@
       {
         "prerequisite": "cloud_computing_distributed_systems",
         "type": "enabling",
-        "confidence": 0.78,
-        "evidence_level": "expert_inference",
-        "note": "Managed cloud warehouses are explicitly scoped to cloud services; cloud infrastructure is the deployment substrate.",
+        "confidence": 0.84,
+        "evidence_level": "primary_source",
+        "note": "Managed cloud warehouses are explicitly cloud services; Redshift and Snowflake papers describe data-warehouse systems operated on cloud infrastructure with elastic managed capacity.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "Announcing Amazon Redshift",
-            "url": "https://aws.amazon.com/about-aws/whats-new/2012/11/28/announcing-amazon-redshift/",
-            "publisher": "AWS",
-            "year": 2012,
-            "source_type": "generic_overview",
+            "title": "Amazon Redshift and the Case for Simpler Data Warehouses",
+            "url": "https://www.cs.cmu.edu/~15721-f24/papers/Redshift.pdf",
+            "publisher": "ACM SIGMOD",
+            "year": 2015,
+            "source_type": "primary_paper",
             "supports": [
               "node",
+              "maturity",
               "edge"
             ]
           }
         ]
       },
       {
-        "prerequisite": "databases_relational_dbms",
-        "type": "commercial_or_scaling_dependency",
-        "confidence": 0.72,
-        "evidence_level": "expert_inference",
-        "note": "Databases (Relational DBMS) supports manufacturing, deployment, commercialization, or operational scaling.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "enterprise_resource_planning",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Enterprise Resource Planning provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "prerequisite": "relational_data_warehousing",
+        "type": "historical_predecessor",
+        "confidence": 0.82,
+        "evidence_level": "primary_source",
+        "note": "Cloud data warehouses inherit the analytical SQL/data-warehouse lineage while changing the deployment model to managed elastic cloud services.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "The Snowflake Elastic Data Warehouse",
+            "url": "https://www.cs.cmu.edu/~15721-f24/papers/Snowflake.pdf",
+            "publisher": "ACM SIGMOD",
+            "year": 2016,
+            "source_type": "primary_paper",
+            "supports": [
+              "node",
+              "maturity",
+              "edge"
+            ]
+          }
+        ]
       }
     ],
     "sources": [
+      {
+        "title": "Amazon Redshift and the Case for Simpler Data Warehouses",
+        "url": "https://www.cs.cmu.edu/~15721-f24/papers/Redshift.pdf",
+        "publisher": "ACM SIGMOD",
+        "year": 2015,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
+      {
+        "title": "The Snowflake Elastic Data Warehouse",
+        "url": "https://www.cs.cmu.edu/~15721-f24/papers/Snowflake.pdf",
+        "publisher": "ACM SIGMOD",
+        "year": 2016,
+        "source_type": "primary_paper",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
       {
         "title": "Announcing Amazon Redshift",
         "url": "https://aws.amazon.com/about-aws/whats-new/2012/11/28/announcing-amazon-redshift/",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T18:22:14.202Z",
+  "generatedAt": "2026-06-12T18:33:52.770Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,9 +25,9 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1923,
-      "denominator": 5482,
-      "formatted": "1,923 / 5,482",
+      "value": 1924,
+      "denominator": 5481,
+      "formatted": "1,924 / 5,481",
       "note": "35.1%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 533,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5482,
-    "edgesWithSources": 1923
+    "totalEdges": 5481,
+    "edgesWithSources": 1924
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T18:22:14.202Z
+Generated: 2026-06-12T18:33:52.770Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,923 / 5,482 (35.1%) |
+| Dependency edges with edge-level sources | 1,924 / 5,481 (35.1%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-12-cloud-warehouses-cloud-computing-evidence.json
+++ b/docs/edge-change-receipts/2026-06-12-cloud-warehouses-cloud-computing-evidence.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-12-cloud-warehouses-cloud-computing-evidence",
+  "decision_date": "2026-06-12",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "cloud_data_warehouses",
+    "prerequisite": "cloud_computing_distributed_systems"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.78,
+    "evidence_level": "expert_inference",
+    "note": "Managed cloud warehouses are explicitly scoped to cloud services; cloud infrastructure is the deployment substrate."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.84,
+    "evidence_level": "primary_source",
+    "note": "Managed cloud warehouses are explicitly cloud services; Redshift and Snowflake papers describe data-warehouse systems operated on cloud infrastructure with elastic managed capacity."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.cs.cmu.edu/~15721-f24/papers/Redshift.pdf",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Amazon Redshift paper title and system-architecture discussion: Redshift is presented as a simpler managed data warehouse operated as an AWS service.",
+    "source_claim_summary": "The source describes Amazon Redshift as a managed cloud data-warehouse system and discusses the service architecture used to operate it.",
+    "source_support_rationale": "This supports cloud computing as an enabling substrate because the scoped node is specifically managed cloud data warehousing, not data warehousing in general."
+  },
+  "invariant_preserved_or_changed": "Preserved: cloud_computing_distributed_systems remains an enabling dependency; changed: evidence is now source-backed by a primary architecture paper.",
+  "would_reject_if": [
+    "The node were broadened to all data warehouses, including on-premises relational warehouses.",
+    "A split created a vendor-specific Redshift node and narrowed this node away from managed cloud services.",
+    "A source showed the scoped cloud data warehouses could be deployed without cloud-service infrastructure."
+  ],
+  "short_reason": "Cloud infrastructure is the deployment substrate for managed cloud data warehouses.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-cloud-warehouses-data-warehouse-lineage.json
+++ b/docs/edge-change-receipts/2026-06-12-cloud-warehouses-data-warehouse-lineage.json
@@ -1,0 +1,50 @@
+{
+  "id": "2026-06-12-cloud-warehouses-data-warehouse-lineage",
+  "decision_date": "2026-06-12",
+  "edge": {
+    "dependent": "cloud_data_warehouses",
+    "prerequisite": "relational_data_warehousing"
+  },
+  "replaced_edge": {
+    "dependent": "cloud_data_warehouses",
+    "prerequisite": "databases_relational_dbms"
+  },
+  "change_class": "topology_change",
+  "old_claim": {
+    "type": "commercial_or_scaling_dependency",
+    "evidence_level": "expert_inference",
+    "confidence": 0.72,
+    "note": "Databases (Relational DBMS) supports manufacturing, deployment, commercialization, or operational scaling."
+  },
+  "new_claim": {
+    "type": "historical_predecessor",
+    "evidence_level": "primary_source",
+    "confidence": 0.82,
+    "note": "Cloud data warehouses inherit the analytical SQL/data-warehouse lineage while changing the deployment model to managed elastic cloud services."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.cs.cmu.edu/~15721-f24/papers/Snowflake.pdf",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Snowflake SIGMOD paper title and abstract/architecture sections describing an elastic cloud data warehouse and its relation to data-warehouse architecture.",
+    "source_claim_summary": "The source presents Snowflake as an elastic cloud data warehouse, tying the cloud service category to the established data-warehouse lineage.",
+    "source_support_rationale": "This supports replacing a generic RDBMS scaling edge with a more specific historical predecessor: cloud warehouses are a cloud deployment evolution of analytical data warehousing."
+  },
+  "ontology_before": "The graph connected cloud data warehouses directly to broad relational DBMS with a generic scaling note.",
+  "ontology_after": "The graph connects cloud data warehouses to relational data warehousing as the direct historical lineage, with cloud computing as the deployment substrate.",
+  "invariant_preserved_or_changed": "Changed: databases_relational_dbms is no longer a direct dependency; relational_data_warehousing is the direct historical predecessor.",
+  "would_reject_if": [
+    "The relational_data_warehousing node were deleted without replacing this lineage edge.",
+    "The cloud_data_warehouses node were narrowed to a non-SQL object-store analytics service rather than data warehousing.",
+    "A stronger source showed cloud data warehouses should depend directly on generic RDBMS rather than on data-warehouse lineage."
+  ],
+  "short_reason": "The direct lineage is data warehousing, not generic RDBMS commercialization.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-12-cloud-warehouses-erp-removal.json
+++ b/docs/edge-change-receipts/2026-06-12-cloud-warehouses-erp-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-12-cloud-warehouses-erp-removal",
+  "decision_date": "2026-06-12",
+  "edge": {
+    "dependent": "cloud_data_warehouses",
+    "prerequisite": "enterprise_resource_planning"
+  },
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "old_claim": {
+    "type": "enabling",
+    "evidence_level": "expert_inference",
+    "confidence": 0.68,
+    "note": "Enterprise Resource Planning provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because ERP systems are common enterprise data sources for warehouses, not a prerequisite for building or operating cloud data-warehouse services.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.cs.cmu.edu/~15721-f24/papers/Redshift.pdf",
+  "source_shape": {
+    "source_type": "primary_paper",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Amazon Redshift architecture paper describes the managed data-warehouse service and system architecture without making ERP systems a prerequisite.",
+    "source_claim_summary": "The source supports cloud data warehouses as managed analytical database services, not as systems that require ERP software to exist.",
+    "source_support_rationale": "ERP can feed business data into a warehouse, but that is application context; it should not be modeled as a direct technology prerequisite."
+  },
+  "ontology_before": "The graph made ERP software look like an enabling prerequisite for cloud data-warehouse services.",
+  "ontology_after": "The graph keeps cloud infrastructure and data-warehouse lineage as direct dependencies; ERP remains a possible upstream data source in user deployments.",
+  "invariant_preserved_or_changed": "Changed: enterprise_resource_planning is absent from direct prerequisites.",
+  "would_reject_if": [
+    "The node were narrowed to ERP-embedded warehouse modules rather than cloud data-warehouse services.",
+    "A source showed early cloud warehouse services originated strictly as ERP components.",
+    "A separate enterprise-analytics workflow node represented ERP-to-warehouse integration."
+  ],
+  "short_reason": "ERP is a common data source, not a prerequisite for cloud warehouse technology.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/graph-invariants/2026-06-12-cloud-data-warehouses-scope.json
+++ b/docs/graph-invariants/2026-06-12-cloud-data-warehouses-scope.json
@@ -1,0 +1,39 @@
+{
+  "id": "2026-06-12-cloud-data-warehouses-scope",
+  "description": "Lock cloud_data_warehouses to managed cloud analytical warehouse services, not generic relational warehouses or ERP reporting modules.",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "cloud_data_warehouses",
+      "operator": "eq",
+      "value": 2012,
+      "reason": "The node remains anchored to Amazon Redshift's 2012 preview announcement as an early managed cloud data warehouse service."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "cloud_data_warehouses",
+      "prerequisite": "cloud_computing_distributed_systems",
+      "expected": "enabling",
+      "reason": "Managed cloud warehouses are deployed as cloud services, so cloud infrastructure is the enabling substrate."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "cloud_data_warehouses",
+      "prerequisite": "relational_data_warehousing",
+      "expected": "historical_predecessor",
+      "reason": "Cloud data warehouses are a cloud-service evolution of analytical data warehousing rather than a replacement for generic relational DBMS."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "cloud_data_warehouses",
+      "prerequisite": "databases_relational_dbms",
+      "reason": "The direct lineage should flow through the more specific relational_data_warehousing node."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "cloud_data_warehouses",
+      "prerequisite": "enterprise_resource_planning",
+      "reason": "ERP systems are common data sources and deployment context, not direct prerequisites for cloud data warehouse services."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added primary architecture-paper sources for `cloud_data_warehouses` using the Redshift and Snowflake SIGMOD papers via URL-checkable PDF mirrors.
- Replaced the direct `databases_relational_dbms` prerequisite with the more specific `relational_data_warehousing` historical lineage.
- Removed `enterprise_resource_planning` as a false direct prerequisite; ERP is a common data source/context, not required technology for cloud warehouse services.
- Upgraded the cloud-computing edge evidence and added receipts plus a graph invariant to avoid repeating this scope work.
- Refreshed generated quality snapshot/README metrics after edge count/source coverage changed.

## Why
The node was marked `source_checked` but only had generic AWS/Amazon overview sources. Its direct prerequisites also mixed technology lineage with enterprise application context. The corrected shape models managed cloud warehouses as `cloud computing + data-warehouse lineage`, anchored to the existing 2012 Redshift scope invariant.

## Validation
- `npm run node-packet -- cloud_data_warehouses --json`
- `npm run node-snapshot-diff -- /tmp/cloud_data_warehouses.before.json /tmp/cloud_data_warehouses.after.json --require-behavior-change`
- `npm run edge-receipts && npm run graph-invariants && npm run invariant-coverage`
- `npm test`
- `npm run quality`
- `npm run coverage`
- `npm run accuracy:risks -- --markdown --limit 24`
- `npm run source-urls` passed: 821 unique URLs returned non-404/non-5xx statuses
- Direct checks for the new Redshift/Snowflake PDF URLs returned HTTP 200
- `npm run quality:queue -- --limit=8` now starts with `smartphone_app_stores`; `cloud_data_warehouses` no longer recurs.

## Remaining uncertainty
The Redshift and Snowflake sources are ACM/SIGMOD papers served from a CMU course mirror to avoid ACM challenge/403 URLs in the source audit. A future source hygiene pass could add canonical DOI metadata if the URL checker gains a stable DOI/ACM path.