### PR TITLE
Source-check smartphone app stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@
 <!-- QUALITY_SNAPSHOT_START -->
 ## Quality Snapshot
 
-Generated 2026-06-12 from the same dataset audit used by `npm run accuracy:risks`. This is a trust snapshot, not proof of global accuracy.
+Generated 2026-06-13 from the same dataset audit used by `npm run accuracy:risks`. This is a trust snapshot, not proof of global accuracy.
 
 | Metric | Current |
 | --- | --- |
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,924 / 5,481 (35.1%) |
+| Dependency edges with edge-level sources | 1,925 / 5,480 (35.1%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/data/modern.json
+++ b/data/modern.json
@@ -26201,9 +26201,9 @@
     "description": "Mass-market smartphone software marketplaces that combine mobile application distribution, developer publishing, payment processing, review, updates, identity, and platform governance.",
     "prerequisites": [
       "smartphones",
-      "digital_payment_gateways",
-      "compiler_toolchains"
+      "digital_payment_gateways"
     ],
+    "maturity": "established",
     "firstKnownDate": 2008,
     "datePrecision": "exact",
     "region": "United States / Apple iPhone App Store, then global smartphone platforms",
@@ -26212,19 +26212,20 @@
       {
         "prerequisite": "smartphones",
         "type": "enabling",
-        "confidence": 0.74,
-        "evidence_level": "expert_inference",
-        "note": "The node is scoped to smartphone platform app stores; smartphone operating systems and installed user devices are the enabling platform.",
+        "confidence": 0.82,
+        "evidence_level": "review",
+        "note": "Smartphone app stores are the primary distribution channel for third-party apps on mobile devices, so smartphone operating systems and installed user devices are the enabling platform.",
         "reviewStatus": "source_checked",
         "sources": [
           {
-            "title": "The App Store turns 10",
-            "url": "https://www.apple.com/newsroom/2018/07/app-store-turns-10/",
-            "publisher": "Apple",
-            "year": 2018,
-            "source_type": "generic_overview",
+            "title": "Competition in the Mobile Application Ecosystem",
+            "url": "https://www.ntia.gov/sites/default/files/publications/mobileappecosystemreport.pdf",
+            "publisher": "National Telecommunications and Information Administration",
+            "year": 2023,
+            "source_type": "official_agency",
             "supports": [
               "node",
+              "maturity",
               "edge"
             ]
           }
@@ -26232,22 +26233,39 @@
       },
       {
         "prerequisite": "digital_payment_gateways",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Digital Payment Gateways provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
-      },
-      {
-        "prerequisite": "compiler_toolchains",
-        "type": "enabling",
-        "confidence": 0.68,
-        "evidence_level": "expert_inference",
-        "note": "Compiler Toolchains provides a capability that enables this technology without being the only possible path.",
-        "reviewStatus": "structurally_validated"
+        "type": "commercial_or_scaling_dependency",
+        "confidence": 0.78,
+        "evidence_level": "review",
+        "note": "Payment systems and in-app purchasing are commercial infrastructure for paid apps and store monetization, not a hard prerequisite for distributing free apps.",
+        "reviewStatus": "source_checked",
+        "sources": [
+          {
+            "title": "Competition in the Mobile Application Ecosystem",
+            "url": "https://www.ntia.gov/sites/default/files/publications/mobileappecosystemreport.pdf",
+            "publisher": "National Telecommunications and Information Administration",
+            "year": 2023,
+            "source_type": "official_agency",
+            "supports": [
+              "node",
+              "maturity",
+              "edge"
+            ]
+          }
+        ]
       }
     ],
     "sources": [
+      {
+        "title": "Competition in the Mobile Application Ecosystem",
+        "url": "https://www.ntia.gov/sites/default/files/publications/mobileappecosystemreport.pdf",
+        "publisher": "National Telecommunications and Information Administration",
+        "year": 2023,
+        "source_type": "official_agency",
+        "supports": [
+          "node",
+          "maturity"
+        ]
+      },
       {
         "title": "The App Store turns 10",
         "url": "https://www.apple.com/newsroom/2018/07/app-store-turns-10/",

--- a/data/quality-snapshot.json
+++ b/data/quality-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T18:33:52.770Z",
+  "generatedAt": "2026-06-13T01:11:19.254Z",
   "description": "Trust snapshot, not proof of global accuracy.",
   "metrics": [
     {
@@ -25,9 +25,9 @@
     },
     {
       "label": "Dependency edges with edge-level sources",
-      "value": 1924,
-      "denominator": 5481,
-      "formatted": "1,924 / 5,481",
+      "value": 1925,
+      "denominator": 5480,
+      "formatted": "1,925 / 5,480",
       "note": "35.1%"
     },
     {
@@ -61,7 +61,7 @@
     "sourceCheckedGenericOld": 0,
     "eraDefaultDates": 533,
     "sourceCheckedEraDefaultDates": 0,
-    "totalEdges": 5481,
-    "edgesWithSources": 1924
+    "totalEdges": 5480,
+    "edgesWithSources": 1925
   }
 }

--- a/docs/QUALITY_SNAPSHOT.md
+++ b/docs/QUALITY_SNAPSHOT.md
@@ -1,6 +1,6 @@
 # Quality Snapshot
 
-Generated: 2026-06-12T18:33:52.770Z
+Generated: 2026-06-13T01:11:19.254Z
 
 This is a trust snapshot generated from the same report object used by `npm run accuracy:risks`; it is not proof of global accuracy.
 
@@ -9,7 +9,7 @@ This is a trust snapshot generated from the same report object used by `npm run 
 | Technologies | 1,659 |
 | Source-checked nodes | 644 / 1,659 (38.8%) |
 | Nodes with node-level sources | 678 / 1,659 (40.9%) |
-| Dependency edges with edge-level sources | 1,924 / 5,481 (35.1%) |
+| Dependency edges with edge-level sources | 1,925 / 5,480 (35.1%) |
 | Era-default placeholder dates | 533 / 1,659 (32.1%) |
 | Manual risk-weighted sample | 40 / 40 (passed after correction) |
 

--- a/docs/edge-change-receipts/2026-06-13-smartphone-app-stores-compiler-toolchains-removal.json
+++ b/docs/edge-change-receipts/2026-06-13-smartphone-app-stores-compiler-toolchains-removal.json
@@ -1,0 +1,42 @@
+{
+  "id": "2026-06-13-smartphone-app-stores-compiler-toolchains-removal",
+  "decision_date": "2026-06-13",
+  "edge": {
+    "dependent": "smartphone_app_stores",
+    "prerequisite": "compiler_toolchains"
+  },
+  "change_class": "topology_change",
+  "removed_edge": true,
+  "old_claim": {
+    "type": "enabling",
+    "evidence_level": "expert_inference",
+    "confidence": 0.68,
+    "note": "Compiler Toolchains provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim_absent": "No direct dependency remains because compiler toolchains support app development generally, but app stores are distribution, review, update, payment, identity, and governance platforms.",
+  "source_supports_edge": "no",
+  "source_url": "https://www.ntia.gov/sites/default/files/publications/mobileappecosystemreport.pdf",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Executive Summary, Mobile App Store Benefits, and review/process sections describe distribution, curation, payments, updates, and platform control rather than compiler toolchains as a store prerequisite.",
+    "source_claim_summary": "The NTIA report characterizes mobile app stores as distribution and governance infrastructure for apps, not as compiler toolchain technology.",
+    "source_support_rationale": "Compiler toolchains are upstream app-development infrastructure; keeping them as a direct edge overstates a contextual dependency for the app-store marketplace itself."
+  },
+  "ontology_before": "The graph made generic compiler toolchains a direct prerequisite of smartphone app stores.",
+  "ontology_after": "The graph keeps smartphones as the platform dependency and payments as commercial infrastructure; compiler toolchains remain app-development context rather than a direct app-store dependency.",
+  "invariant_preserved_or_changed": "Changed: compiler_toolchains is absent from direct prerequisites.",
+  "would_reject_if": [
+    "The node were rescoped to mobile SDKs or app build systems rather than app stores.",
+    "A source showed the first mass-market smartphone app stores required a specific compiler toolchain as store infrastructure.",
+    "A future node represented developer toolchains for smartphone apps."
+  ],
+  "short_reason": "Compiler toolchains are app-development context, not app-store infrastructure.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality",
+    "npm run coverage"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-13-smartphone-app-stores-payments-scaling.json
+++ b/docs/edge-change-receipts/2026-06-13-smartphone-app-stores-payments-scaling.json
@@ -1,0 +1,45 @@
+{
+  "id": "2026-06-13-smartphone-app-stores-payments-scaling",
+  "decision_date": "2026-06-13",
+  "change_class": "semantic_retype",
+  "edge": {
+    "dependent": "smartphone_app_stores",
+    "prerequisite": "digital_payment_gateways"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.68,
+    "evidence_level": "expert_inference",
+    "note": "Digital Payment Gateways provides a capability that enables this technology without being the only possible path."
+  },
+  "new_claim": {
+    "type": "commercial_or_scaling_dependency",
+    "confidence": 0.78,
+    "evidence_level": "review",
+    "note": "Payment systems and in-app purchasing are commercial infrastructure for paid apps and store monetization, not a hard prerequisite for distributing free apps."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.ntia.gov/sites/default/files/publications/mobileappecosystemreport.pdf",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Mobile App Store Benefits and Technical Limitations sections: app stores provide payment systems, reduce payment frictions, and the report separately discusses in-app purchasing.",
+    "source_claim_summary": "The NTIA report treats payments and in-app purchasing as important app-store commercial infrastructure and policy surface.",
+    "source_support_rationale": "This supports a commercial/scaling edge because payment processing is central to monetized app stores but not required for every free-app distribution use case."
+  },
+  "ontology_before": "The graph treated digital payment gateways as a generic enabling capability for smartphone app stores.",
+  "ontology_after": "The graph treats payment processing and in-app purchasing as commercial scaling infrastructure for monetized app-store ecosystems.",
+  "invariant_preserved_or_changed": "Changed: digital_payment_gateways is now commercial_or_scaling_dependency rather than generic enabling.",
+  "would_reject_if": [
+    "The node were narrowed to only paid app stores with no free-app distribution.",
+    "A source showed that app-store payment processing is technically required for all app discovery, review, update, and distribution functions.",
+    "A separate node represented only in-app purchase billing rather than app stores as a whole."
+  ],
+  "short_reason": "Payments scale monetized app stores but are not a hard app-distribution prerequisite.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/edge-change-receipts/2026-06-13-smartphone-app-stores-smartphones-evidence.json
+++ b/docs/edge-change-receipts/2026-06-13-smartphone-app-stores-smartphones-evidence.json
@@ -1,0 +1,43 @@
+{
+  "id": "2026-06-13-smartphone-app-stores-smartphones-evidence",
+  "decision_date": "2026-06-13",
+  "change_class": "evidence_upgrade",
+  "edge": {
+    "dependent": "smartphone_app_stores",
+    "prerequisite": "smartphones"
+  },
+  "old_claim": {
+    "type": "enabling",
+    "confidence": 0.74,
+    "evidence_level": "expert_inference",
+    "note": "The node is scoped to smartphone platform app stores; smartphone operating systems and installed user devices are the enabling platform."
+  },
+  "new_claim": {
+    "type": "enabling",
+    "confidence": 0.82,
+    "evidence_level": "review",
+    "note": "Smartphone app stores are the primary distribution channel for third-party apps on mobile devices, so smartphone operating systems and installed user devices are the enabling platform."
+  },
+  "source_supports_edge": "yes",
+  "source_url": "https://www.ntia.gov/sites/default/files/publications/mobileappecosystemreport.pdf",
+  "source_shape": {
+    "source_type": "official_agency",
+    "support_relationship": "reviews_field_relationship",
+    "source_locator": "Executive Summary and State of Play sections: smartphones are described as the primary vehicles for apps, and third-party apps on mobile devices are primarily made available through Apple and Google mobile app stores.",
+    "source_claim_summary": "The NTIA report ties mobile app stores to smartphone operating systems, mobile devices, and app distribution through Apple App Store and Google Play.",
+    "source_support_rationale": "This supports smartphones as an enabling platform for smartphone app stores without turning any specific device model or vendor store into a hard prerequisite."
+  },
+  "invariant_preserved_or_changed": "Preserved: smartphones remains an enabling dependency; changed: evidence is now source-backed.",
+  "would_reject_if": [
+    "The node were broadened to all software package repositories or desktop app stores.",
+    "The node were narrowed to a single vendor's 2008 launch event rather than the smartphone app-store model.",
+    "A stronger source showed mass-market smartphone app stores could exist independently of smartphone operating systems and installed devices."
+  ],
+  "short_reason": "The scoped technology is a smartphone platform app-store model.",
+  "validation_commands": [
+    "npm run edge-receipts",
+    "npm run graph-invariants",
+    "npm test",
+    "npm run quality"
+  ]
+}

--- a/docs/graph-invariants/2026-06-13-smartphone-app-stores-scope.json
+++ b/docs/graph-invariants/2026-06-13-smartphone-app-stores-scope.json
@@ -1,0 +1,33 @@
+{
+  "id": "2026-06-13-smartphone-app-stores-scope",
+  "description": "Lock smartphone_app_stores to mass-market smartphone app-store platforms, not mobile SDKs or generic software repositories.",
+  "checks": [
+    {
+      "type": "first_known_date",
+      "node": "smartphone_app_stores",
+      "operator": "eq",
+      "value": 2008,
+      "reason": "The node remains anchored to the 2008 iPhone App Store launch as the mass-market smartphone app-store scope."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "smartphone_app_stores",
+      "prerequisite": "smartphones",
+      "expected": "enabling",
+      "reason": "Smartphone operating systems and devices are the enabling platform for smartphone app stores."
+    },
+    {
+      "type": "edge_type",
+      "dependent": "smartphone_app_stores",
+      "prerequisite": "digital_payment_gateways",
+      "expected": "commercial_or_scaling_dependency",
+      "reason": "Payment processing and in-app purchasing are commercial scaling infrastructure, not a hard prerequisite for all app distribution."
+    },
+    {
+      "type": "direct_edge_absent",
+      "dependent": "smartphone_app_stores",
+      "prerequisite": "compiler_toolchains",
+      "reason": "Compiler toolchains are upstream app-development context, not direct app-store distribution infrastructure."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added the NTIA `Competition in the Mobile Application Ecosystem` report as an official-agency source for `smartphone_app_stores`.
- Upgraded the `smartphones -> smartphone_app_stores` edge from expert inference to source-backed review evidence.
- Retyped `digital_payment_gateways -> smartphone_app_stores` to `commercial_or_scaling_dependency` because payments/in-app purchasing are monetization infrastructure, not a hard distribution prerequisite.
- Removed the direct `compiler_toolchains` edge; compiler toolchains are app-development context, not app-store distribution infrastructure.
- Added edge receipts plus a scope invariant so this does not get reintroduced in future passes.
- Refreshed generated quality snapshot/README metrics after edge count/source coverage changed.

## Why
The source-quality queue was resurfacing `smartphone_app_stores` because it was marked `source_checked` but only had Apple overview/press-release sources. The NTIA report directly covers mobile app stores, smartphone distribution, review processes, payment systems, app updates, and platform gatekeeping.

## Validation
- `npm run node-packet -- smartphone_app_stores --json`
- `npm run node-snapshot-diff -- /tmp/smartphone_app_stores.before.json /tmp/smartphone_app_stores.after.json --require-behavior-change`
- `npm run edge-receipts && npm run graph-invariants && npm run invariant-coverage`
- `npm run agent:check -- --run`
- `npm run accuracy:risks -- --markdown --limit 24`
- `npm run source-urls` passed: 822 unique URLs returned non-404/non-5xx statuses
- `npm run quality:queue -- --limit=8` now starts with `symbolic_ai_expert_systems`; `smartphone_app_stores` no longer recurs.

## Remaining uncertainty
The node remains anchored to the 2008 Apple App Store launch for mass-market smartphone app stores. Earlier mobile catalogs and carrier portals exist, but those are outside this scoped node.